### PR TITLE
MF-38 - Rename repo methods

### DIFF
--- a/things/channels.go
+++ b/things/channels.go
@@ -46,8 +46,8 @@ type ChannelRepository interface {
 	// by the specified user.
 	RetrieveByID(ctx context.Context, owner, id string) (Channel, error)
 
-	// RetrieveAll retrieves the subset of channels owned by the specified user.
-	RetrieveAll(ctx context.Context, owner string, pm PageMetadata) (ChannelsPage, error)
+	// RetrieveByOwner retrieves the subset of channels owned by the specified user.
+	RetrieveByOwner(ctx context.Context, owner string, pm PageMetadata) (ChannelsPage, error)
 
 	// RetrieveByThing retrieves the subset of channels owned by the specified
 	// user and have specified thing connected or not connected to them.

--- a/things/channels.go
+++ b/things/channels.go
@@ -77,8 +77,8 @@ type ChannelRepository interface {
 	// RetrieveAll retrieves all channels for all users.
 	RetrieveAll(ctx context.Context) ([]Channel, error)
 
-	// BackupConnections retrieves all connections between channels and things for all users.
-	BackupConnections(ctx context.Context) ([]Connection, error)
+	// RetrieveAllConnections retrieves all connections between channels and things for all users.
+	RetrieveAllConnections(ctx context.Context) ([]Connection, error)
 }
 
 // ChannelCache contains channel-thing connection caching interface.

--- a/things/channels.go
+++ b/things/channels.go
@@ -74,8 +74,8 @@ type ChannelRepository interface {
 	// returned error will be nil.
 	HasThingByID(ctx context.Context, chanID, thingID string) error
 
-	// BackupChannels retrieves all channels for all users.
-	BackupChannels(ctx context.Context) ([]Channel, error)
+	// RetrieveAll retrieves all channels for all users.
+	RetrieveAll(ctx context.Context) ([]Channel, error)
 
 	// BackupConnections retrieves all connections between channels and things for all users.
 	BackupConnections(ctx context.Context) ([]Connection, error)

--- a/things/mocks/channels.go
+++ b/things/mocks/channels.go
@@ -269,7 +269,7 @@ func (crm *channelRepositoryMock) HasThingByID(_ context.Context, chanID, thingI
 	return nil
 }
 
-func (crm *channelRepositoryMock) BackupChannels(ctx context.Context) ([]things.Channel, error) {
+func (crm *channelRepositoryMock) RetrieveAll(ctx context.Context) ([]things.Channel, error) {
 	crm.mu.Lock()
 	defer crm.mu.Unlock()
 	var chs []things.Channel

--- a/things/mocks/channels.go
+++ b/things/mocks/channels.go
@@ -79,7 +79,7 @@ func (crm *channelRepositoryMock) RetrieveByID(_ context.Context, owner, id stri
 	return things.Channel{}, errors.ErrNotFound
 }
 
-func (crm *channelRepositoryMock) RetrieveAll(_ context.Context, owner string, pm things.PageMetadata) (things.ChannelsPage, error) {
+func (crm *channelRepositoryMock) RetrieveByOwner(_ context.Context, owner string, pm things.PageMetadata) (things.ChannelsPage, error) {
 	if pm.Limit < 0 {
 		return things.ChannelsPage{}, nil
 	}

--- a/things/mocks/channels.go
+++ b/things/mocks/channels.go
@@ -281,7 +281,7 @@ func (crm *channelRepositoryMock) RetrieveAll(ctx context.Context) ([]things.Cha
 	return chs, nil
 }
 
-func (crm *channelRepositoryMock) BackupConnections(ctx context.Context) ([]things.Connection, error) {
+func (crm *channelRepositoryMock) RetrieveAllConnections(ctx context.Context) ([]things.Connection, error) {
 	crm.mu.Lock()
 	defer crm.mu.Unlock()
 	var conns []things.Connection

--- a/things/mocks/things.go
+++ b/things/mocks/things.go
@@ -291,7 +291,7 @@ func (trm *thingRepositoryMock) disconnect(conn Connection) {
 	delete(trm.tconns[conn.chanID], conn.thing.ID)
 }
 
-func (trm *thingRepositoryMock) BackupThings(_ context.Context) ([]things.Thing, error) {
+func (trm *thingRepositoryMock) RetrieveAll(_ context.Context) ([]things.Thing, error) {
 	trm.mu.Lock()
 	defer trm.mu.Unlock()
 	var ths []things.Thing

--- a/things/mocks/things.go
+++ b/things/mocks/things.go
@@ -113,7 +113,7 @@ func (trm *thingRepositoryMock) RetrieveByID(_ context.Context, owner, id string
 	return things.Thing{}, errors.ErrNotFound
 }
 
-func (trm *thingRepositoryMock) RetrieveAll(_ context.Context, owner string, pm things.PageMetadata) (things.Page, error) {
+func (trm *thingRepositoryMock) RetrieveByOwner(_ context.Context, owner string, pm things.PageMetadata) (things.Page, error) {
 	trm.mu.Lock()
 	defer trm.mu.Unlock()
 

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -420,7 +420,7 @@ func (cr channelRepository) hasThing(ctx context.Context, chanID, thingID string
 	return nil
 }
 
-func (cr channelRepository) BackupChannels(ctx context.Context) ([]things.Channel, error) {
+func (cr channelRepository) RetrieveAll(ctx context.Context) ([]things.Channel, error) {
 	q := `SELECT id, owner, name, metadata FROM channels;`
 
 	rows, err := cr.db.NamedQueryContext(ctx, q, map[string]interface{}{})

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -126,7 +126,7 @@ func (cr channelRepository) RetrieveByID(ctx context.Context, owner, id string) 
 	return toChannel(dbch), nil
 }
 
-func (cr channelRepository) RetrieveAll(ctx context.Context, owner string, pm things.PageMetadata) (things.ChannelsPage, error) {
+func (cr channelRepository) RetrieveByOwner(ctx context.Context, owner string, pm things.PageMetadata) (things.ChannelsPage, error) {
 	nq, name := getNameQuery(pm.Name)
 	oq := getOrderQuery(pm.Order)
 	dq := getDirQuery(pm.Dir)

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -442,7 +442,7 @@ func (cr channelRepository) RetrieveAll(ctx context.Context) ([]things.Channel, 
 	return channels, nil
 }
 
-func (cr channelRepository) BackupConnections(ctx context.Context) ([]things.Connection, error) {
+func (cr channelRepository) RetrieveAllConnections(ctx context.Context) ([]things.Connection, error) {
 	q := `SELECT channel_id, channel_owner, thing_id, thing_owner FROM connections;`
 
 	rows, err := cr.db.NamedQueryContext(ctx, q, map[string]interface{}{})

--- a/things/postgres/channels_test.go
+++ b/things/postgres/channels_test.go
@@ -997,7 +997,7 @@ func TestBackupConnections(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		connections, err := chanRepo.BackupConnections(context.Background())
+		connections, err := chanRepo.RetrieveAllConnections(context.Background())
 		size := uint64(len(connections))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", desc, tc.size, size))

--- a/things/postgres/channels_test.go
+++ b/things/postgres/channels_test.go
@@ -942,7 +942,7 @@ func TestBackupChannel(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		channels, err := chanRepo.BackupChannels(context.Background())
+		channels, err := chanRepo.RetrieveAll(context.Background())
 		size := uint64(len(channels))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", desc, tc.size, size))

--- a/things/postgres/channels_test.go
+++ b/things/postgres/channels_test.go
@@ -359,7 +359,7 @@ func TestMultiChannelRetrieval(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		page, err := chanRepo.RetrieveAll(context.Background(), tc.owner, tc.pageMetadata)
+		page, err := chanRepo.RetrieveByOwner(context.Background(), tc.owner, tc.pageMetadata)
 		size := uint64(len(page.Channels))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", desc, tc.size, size))
 		assert.Equal(t, tc.pageMetadata.Total, page.Total, fmt.Sprintf("%s: expected total %d got %d\n", desc, tc.pageMetadata.Total, page.Total))

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -243,7 +243,7 @@ func (tr thingRepository) RetrieveByIDs(ctx context.Context, thingIDs []string, 
 	return page, nil
 }
 
-func (tr thingRepository) RetrieveAll(ctx context.Context, owner string, pm things.PageMetadata) (things.Page, error) {
+func (tr thingRepository) RetrieveByOwner(ctx context.Context, owner string, pm things.PageMetadata) (things.Page, error) {
 	nq, name := getNameQuery(pm.Name)
 	oq := getOrderQuery(pm.Order)
 	dq := getDirQuery(pm.Dir)

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -425,7 +425,7 @@ func (tr thingRepository) Remove(ctx context.Context, owner, id string) error {
 	return nil
 }
 
-func (tr thingRepository) BackupThings(ctx context.Context) ([]things.Thing, error) {
+func (tr thingRepository) RetrieveAll(ctx context.Context) ([]things.Thing, error) {
 	q := `SELECT id, owner, name, key, metadata FROM things;`
 	rows, err := tr.db.NamedQueryContext(ctx, q, map[string]interface{}{})
 	if err != nil {

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -613,7 +613,7 @@ func TestBackupThings(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		things, err := thingRepo.BackupThings(context.Background())
+		things, err := thingRepo.RetrieveAll(context.Background())
 		size := uint64(len(things))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", desc, tc.size, size))

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -540,7 +540,7 @@ func TestMultiThingRetrieval(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		page, err := thingRepo.RetrieveAll(context.Background(), tc.owner, tc.pageMetadata)
+		page, err := thingRepo.RetrieveByOwner(context.Background(), tc.owner, tc.pageMetadata)
 		size := uint64(len(page.Things))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", desc, tc.size, size))
 		assert.Equal(t, tc.pageMetadata.Total, page.Total, fmt.Sprintf("%s: expected total %d got %d\n", desc, tc.pageMetadata.Total, page.Total))

--- a/things/service.go
+++ b/things/service.go
@@ -475,12 +475,12 @@ func (ts *thingsService) Backup(ctx context.Context, token string) (Backup, erro
 		return Backup{}, err
 	}
 
-	things, err := ts.things.BackupThings(ctx)
+	things, err := ts.things.RetrieveAll(ctx)
 	if err != nil {
 		return Backup{}, err
 	}
 
-	channels, err := ts.channels.BackupChannels(ctx)
+	channels, err := ts.channels.RetrieveAll(ctx)
 	if err != nil {
 		return Backup{}, err
 	}

--- a/things/service.go
+++ b/things/service.go
@@ -240,7 +240,7 @@ func (ts *thingsService) ListThings(ctx context.Context, token string, pm PageMe
 	}
 
 	// By default, fetch things from Things service.
-	page, err := ts.things.RetrieveAll(ctx, res.GetId(), pm)
+	page, err := ts.things.RetrieveByOwner(ctx, res.GetId(), pm)
 	if err != nil {
 		return Page{}, err
 	}
@@ -334,7 +334,7 @@ func (ts *thingsService) ListChannels(ctx context.Context, token string, pm Page
 	}
 
 	// By default, fetch channels from database based on the owner field.
-	return ts.channels.RetrieveAll(ctx, res.GetId(), pm)
+	return ts.channels.RetrieveByOwner(ctx, res.GetId(), pm)
 }
 
 func (ts *thingsService) ListChannelsByThing(ctx context.Context, token, thID string, pm PageMetadata) (ChannelsPage, error) {

--- a/things/service.go
+++ b/things/service.go
@@ -485,7 +485,7 @@ func (ts *thingsService) Backup(ctx context.Context, token string) (Backup, erro
 		return Backup{}, err
 	}
 
-	connections, err := ts.channels.BackupConnections(ctx)
+	connections, err := ts.channels.RetrieveAllConnections(ctx)
 	if err != nil {
 		return Backup{}, err
 	}

--- a/things/things.go
+++ b/things/things.go
@@ -77,8 +77,8 @@ type ThingRepository interface {
 	// by the specified user.
 	Remove(ctx context.Context, owner, id string) error
 
-	// BackupThings retrieves all things for all users.
-	BackupThings(ctx context.Context) ([]Thing, error)
+	// RetrieveAll retrieves all things for all users.
+	RetrieveAll(ctx context.Context) ([]Thing, error)
 }
 
 // ThingCache contains thing caching interface.

--- a/things/things.go
+++ b/things/things.go
@@ -63,8 +63,8 @@ type ThingRepository interface {
 	// RetrieveByKey returns thing ID for given thing key.
 	RetrieveByKey(ctx context.Context, key string) (string, error)
 
-	// RetrieveAll retrieves the subset of things owned by the specified user
-	RetrieveAll(ctx context.Context, owner string, pm PageMetadata) (Page, error)
+	// RetrieveByOwner retrieves the subset of things owned by the specified user
+	RetrieveByOwner(ctx context.Context, owner string, pm PageMetadata) (Page, error)
 
 	// RetrieveByIDs retrieves the subset of things specified by given thing ids.
 	RetrieveByIDs(ctx context.Context, thingIDs []string, pm PageMetadata) (Page, error)

--- a/things/tracing/channels.go
+++ b/things/tracing/channels.go
@@ -11,18 +11,18 @@ import (
 )
 
 const (
-	saveChannelsOp               = "save_channels"
-	updateChannelOp              = "update_channel"
-	retrieveChannelByIDOp        = "retrieve_channel_by_id"
-	retrieveAllChannelsByOwnerOp = "retrieve_all_channels_by_owner"
-	retrieveChannelsByThingOp    = "retrieve_channels_by_thing"
-	removeChannelOp              = "retrieve_channel"
-	connectOp                    = "connect"
-	disconnectOp                 = "disconnect"
-	hasThingOp                   = "has_thing"
-	hasThingByIDOp               = "has_thing_by_id"
-	retrieveAllChannelsOp        = "retrieve_all_channels"
-	backupConnectionsOp          = "backup_connections"
+	saveChannelsOp            = "save_channels"
+	updateChannelOp           = "update_channel"
+	retrieveChannelByIDOp     = "retrieve_channel_by_id"
+	retrieveChannelsByOwnerOp = "retrieve_channels_by_owner"
+	retrieveChannelsByThingOp = "retrieve_channels_by_thing"
+	removeChannelOp           = "retrieve_channel"
+	connectOp                 = "connect"
+	disconnectOp              = "disconnect"
+	hasThingOp                = "has_thing"
+	hasThingByIDOp            = "has_thing_by_id"
+	retrieveAllChannelsOp     = "retrieve_all_channels"
+	backupConnectionsOp       = "backup_connections"
 )
 
 var (
@@ -69,7 +69,7 @@ func (crm channelRepositoryMiddleware) RetrieveByID(ctx context.Context, owner, 
 }
 
 func (crm channelRepositoryMiddleware) RetrieveByOwner(ctx context.Context, owner string, pm things.PageMetadata) (things.ChannelsPage, error) {
-	span := createSpan(ctx, crm.tracer, retrieveAllChannelsByOwnerOp)
+	span := createSpan(ctx, crm.tracer, retrieveChannelsByThingOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
@@ -132,12 +132,12 @@ func (crm channelRepositoryMiddleware) RetrieveAll(ctx context.Context) ([]thing
 	return crm.repo.RetrieveAll(ctx)
 }
 
-func (crm channelRepositoryMiddleware) BackupConnections(ctx context.Context) ([]things.Connection, error) {
+func (crm channelRepositoryMiddleware) RetrieveAllConnections(ctx context.Context) ([]things.Connection, error) {
 	span := createSpan(ctx, crm.tracer, backupConnectionsOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return crm.repo.BackupConnections(ctx)
+	return crm.repo.RetrieveAllConnections(ctx)
 }
 
 type channelCacheMiddleware struct {

--- a/things/tracing/channels.go
+++ b/things/tracing/channels.go
@@ -11,18 +11,18 @@ import (
 )
 
 const (
-	saveChannelsOp            = "save_channels"
-	updateChannelOp           = "update_channel"
-	retrieveChannelByIDOp     = "retrieve_channel_by_id"
-	retrieveAllChannelsOp     = "retrieve_all_channels"
-	retrieveChannelsByThingOp = "retrieve_channels_by_thing"
-	removeChannelOp           = "retrieve_channel"
-	connectOp                 = "connect"
-	disconnectOp              = "disconnect"
-	hasThingOp                = "has_thing"
-	hasThingByIDOp            = "has_thing_by_id"
-	backupChannelsOp          = "backup_channels"
-	backupConnectionsOp       = "backup_connections"
+	saveChannelsOp               = "save_channels"
+	updateChannelOp              = "update_channel"
+	retrieveChannelByIDOp        = "retrieve_channel_by_id"
+	retrieveAllChannelsByOwnerOp = "retrieve_all_channels_by_owner"
+	retrieveChannelsByThingOp    = "retrieve_channels_by_thing"
+	removeChannelOp              = "retrieve_channel"
+	connectOp                    = "connect"
+	disconnectOp                 = "disconnect"
+	hasThingOp                   = "has_thing"
+	hasThingByIDOp               = "has_thing_by_id"
+	backupChannelsOp             = "backup_channels"
+	backupConnectionsOp          = "backup_connections"
 )
 
 var (
@@ -68,12 +68,12 @@ func (crm channelRepositoryMiddleware) RetrieveByID(ctx context.Context, owner, 
 	return crm.repo.RetrieveByID(ctx, owner, id)
 }
 
-func (crm channelRepositoryMiddleware) RetrieveAll(ctx context.Context, owner string, pm things.PageMetadata) (things.ChannelsPage, error) {
-	span := createSpan(ctx, crm.tracer, retrieveAllChannelsOp)
+func (crm channelRepositoryMiddleware) RetrieveByOwner(ctx context.Context, owner string, pm things.PageMetadata) (things.ChannelsPage, error) {
+	span := createSpan(ctx, crm.tracer, retrieveAllChannelsByOwnerOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return crm.repo.RetrieveAll(ctx, owner, pm)
+	return crm.repo.RetrieveByOwner(ctx, owner, pm)
 }
 
 func (crm channelRepositoryMiddleware) RetrieveByThing(ctx context.Context, owner, thID string, pm things.PageMetadata) (things.ChannelsPage, error) {

--- a/things/tracing/channels.go
+++ b/things/tracing/channels.go
@@ -22,7 +22,7 @@ const (
 	hasThingOp                = "has_thing"
 	hasThingByIDOp            = "has_thing_by_id"
 	retrieveAllChannelsOp     = "retrieve_all_channels"
-	backupConnectionsOp       = "backup_connections"
+	retrieveAllConnectionsOp  = "retrieve_all_connections"
 )
 
 var (
@@ -133,7 +133,7 @@ func (crm channelRepositoryMiddleware) RetrieveAll(ctx context.Context) ([]thing
 }
 
 func (crm channelRepositoryMiddleware) RetrieveAllConnections(ctx context.Context) ([]things.Connection, error) {
-	span := createSpan(ctx, crm.tracer, backupConnectionsOp)
+	span := createSpan(ctx, crm.tracer, retrieveAllConnectionsOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 

--- a/things/tracing/channels.go
+++ b/things/tracing/channels.go
@@ -21,7 +21,7 @@ const (
 	disconnectOp                 = "disconnect"
 	hasThingOp                   = "has_thing"
 	hasThingByIDOp               = "has_thing_by_id"
-	backupChannelsOp             = "backup_channels"
+	retrieveAllChannelsOp        = "retrieve_all_channels"
 	backupConnectionsOp          = "backup_connections"
 )
 
@@ -124,12 +124,12 @@ func (crm channelRepositoryMiddleware) HasThingByID(ctx context.Context, chanID,
 	return crm.repo.HasThingByID(ctx, chanID, thingID)
 }
 
-func (crm channelRepositoryMiddleware) BackupChannels(ctx context.Context) ([]things.Channel, error) {
-	span := createSpan(ctx, crm.tracer, backupChannelsOp)
+func (crm channelRepositoryMiddleware) RetrieveAll(ctx context.Context) ([]things.Channel, error) {
+	span := createSpan(ctx, crm.tracer, retrieveAllChannelsOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return crm.repo.BackupChannels(ctx)
+	return crm.repo.RetrieveAll(ctx)
 }
 
 func (crm channelRepositoryMiddleware) BackupConnections(ctx context.Context) ([]things.Connection, error) {

--- a/things/tracing/things.go
+++ b/things/tracing/things.go
@@ -11,18 +11,19 @@ import (
 )
 
 const (
-	saveThingOp                = "save_thing"
-	saveThingsOp               = "save_things"
-	updateThingOp              = "update_thing"
-	updateThingKeyOp           = "update_thing_by_key"
-	retrieveThingByIDOp        = "retrieve_thing_by_id"
-	retrieveThingByKeyOp       = "retrieve_thing_by_key"
-	retrieveAllThingsByOwnerOp = "retrieve_all_things_by_owner"
-	retrieveThingsByChannelOp  = "retrieve_things_by_chan"
-	removeThingOp              = "remove_thing"
-	retrieveThingIDByKeyOp     = "retrieve_id_by_key"
-	retrieveAllThingsOp        = "retrieve_all_things"
-	restoreThingsOp            = "restore_things"
+	saveThingOp               = "save_thing"
+	saveThingsOp              = "save_things"
+	updateThingOp             = "update_thing"
+	updateThingKeyOp          = "update_thing_by_key"
+	retrieveThingByIDOp       = "retrieve_thing_by_id"
+	retrieveThingsByIDsOp     = "retrieve_things_by_ids"
+	retrieveThingByKeyOp      = "retrieve_thing_by_key"
+	retrieveThingsByOwnerOp   = "retrieve_things_by_owner"
+	retrieveThingsByChannelOp = "retrieve_things_by_chan"
+	removeThingOp             = "remove_thing"
+	retrieveThingIDByKeyOp    = "retrieve_id_by_key"
+	retrieveAllThingsOp       = "retrieve_all_things"
+	restoreThingsOp           = "restore_things"
 )
 
 var (
@@ -85,7 +86,7 @@ func (trm thingRepositoryMiddleware) RetrieveByKey(ctx context.Context, key stri
 }
 
 func (trm thingRepositoryMiddleware) RetrieveByOwner(ctx context.Context, owner string, pm things.PageMetadata) (things.Page, error) {
-	span := createSpan(ctx, trm.tracer, retrieveAllThingsByOwnerOp)
+	span := createSpan(ctx, trm.tracer, retrieveThingsByOwnerOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
@@ -93,7 +94,7 @@ func (trm thingRepositoryMiddleware) RetrieveByOwner(ctx context.Context, owner 
 }
 
 func (trm thingRepositoryMiddleware) RetrieveByIDs(ctx context.Context, thingIDs []string, pm things.PageMetadata) (things.Page, error) {
-	span := createSpan(ctx, trm.tracer, retrieveAllThingsByOwnerOp)
+	span := createSpan(ctx, trm.tracer, retrieveThingsByIDsOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 

--- a/things/tracing/things.go
+++ b/things/tracing/things.go
@@ -21,7 +21,7 @@ const (
 	retrieveThingsByChannelOp  = "retrieve_things_by_chan"
 	removeThingOp              = "remove_thing"
 	retrieveThingIDByKeyOp     = "retrieve_id_by_key"
-	backupThingsOp             = "backup_things"
+	retrieveAllThingsOp        = "retrieve_all_things"
 	restoreThingsOp            = "restore_things"
 )
 
@@ -116,12 +116,12 @@ func (trm thingRepositoryMiddleware) Remove(ctx context.Context, owner, id strin
 	return trm.repo.Remove(ctx, owner, id)
 }
 
-func (trm thingRepositoryMiddleware) BackupThings(ctx context.Context) ([]things.Thing, error) {
-	span := createSpan(ctx, trm.tracer, backupThingsOp)
+func (trm thingRepositoryMiddleware) RetrieveAll(ctx context.Context) ([]things.Thing, error) {
+	span := createSpan(ctx, trm.tracer, retrieveAllThingsOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return trm.repo.BackupThings(ctx)
+	return trm.repo.RetrieveAll(ctx)
 }
 
 type thingCacheMiddleware struct {

--- a/things/tracing/things.go
+++ b/things/tracing/things.go
@@ -11,18 +11,18 @@ import (
 )
 
 const (
-	saveThingOp               = "save_thing"
-	saveThingsOp              = "save_things"
-	updateThingOp             = "update_thing"
-	updateThingKeyOp          = "update_thing_by_key"
-	retrieveThingByIDOp       = "retrieve_thing_by_id"
-	retrieveThingByKeyOp      = "retrieve_thing_by_key"
-	retrieveAllThingsOp       = "retrieve_all_things"
-	retrieveThingsByChannelOp = "retrieve_things_by_chan"
-	removeThingOp             = "remove_thing"
-	retrieveThingIDByKeyOp    = "retrieve_id_by_key"
-	backupThingsOp            = "backup_things"
-	restoreThingsOp           = "restore_things"
+	saveThingOp                = "save_thing"
+	saveThingsOp               = "save_things"
+	updateThingOp              = "update_thing"
+	updateThingKeyOp           = "update_thing_by_key"
+	retrieveThingByIDOp        = "retrieve_thing_by_id"
+	retrieveThingByKeyOp       = "retrieve_thing_by_key"
+	retrieveAllThingsByOwnerOp = "retrieve_all_things_by_owner"
+	retrieveThingsByChannelOp  = "retrieve_things_by_chan"
+	removeThingOp              = "remove_thing"
+	retrieveThingIDByKeyOp     = "retrieve_id_by_key"
+	backupThingsOp             = "backup_things"
+	restoreThingsOp            = "restore_things"
 )
 
 var (
@@ -84,16 +84,16 @@ func (trm thingRepositoryMiddleware) RetrieveByKey(ctx context.Context, key stri
 	return trm.repo.RetrieveByKey(ctx, key)
 }
 
-func (trm thingRepositoryMiddleware) RetrieveAll(ctx context.Context, owner string, pm things.PageMetadata) (things.Page, error) {
-	span := createSpan(ctx, trm.tracer, retrieveAllThingsOp)
+func (trm thingRepositoryMiddleware) RetrieveByOwner(ctx context.Context, owner string, pm things.PageMetadata) (things.Page, error) {
+	span := createSpan(ctx, trm.tracer, retrieveAllThingsByOwnerOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return trm.repo.RetrieveAll(ctx, owner, pm)
+	return trm.repo.RetrieveByOwner(ctx, owner, pm)
 }
 
 func (trm thingRepositoryMiddleware) RetrieveByIDs(ctx context.Context, thingIDs []string, pm things.PageMetadata) (things.Page, error) {
-	span := createSpan(ctx, trm.tracer, retrieveAllThingsOp)
+	span := createSpan(ctx, trm.tracer, retrieveAllThingsByOwnerOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 


### PR DESCRIPTION
Renamed repo  methods for `backup` and `restore`

Resolve: #38 
