### PR TITLE
NOISSUE - Fix validate list subscriptions request.

### DIFF
--- a/mqtt/api/http/request.go
+++ b/mqtt/api/http/request.go
@@ -6,9 +6,12 @@ package http
 import (
 	"github.com/MainfluxLabs/mainflux/internal/apiutil"
 	"github.com/MainfluxLabs/mainflux/mqtt"
+	"github.com/MainfluxLabs/mainflux/pkg/errors"
 )
 
 const maxLimitSize = 100
+
+var errAuthHeader = errors.New("missing or invalid auth header")
 
 type apiReq interface {
 	validate() error
@@ -26,8 +29,8 @@ func (req listSubscriptionsReq) validate() error {
 		return apiutil.ErrMissingID
 	}
 
-	if req.token == "" {
-		return apiutil.ErrBearerToken
+	if req.token == "" && req.key == "" {
+		return errAuthHeader
 	}
 
 	if req.pageMetadata.Limit > maxLimitSize {


### PR DESCRIPTION
Fixed token missing error when only key is provided. Validation now checking  both,  token and key.  
