### PR TITLE
MF-117 - Remove owner from RetrieveByID methods

### DIFF
--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -790,7 +790,7 @@ func TestConnectThing(t *testing.T) {
 			thingID: thingID,
 			chanID:  chanID2,
 			token:   token,
-			err:     createError(sdk.ErrFailedConnect, http.StatusNotFound),
+			err:     createError(sdk.ErrFailedConnect, http.StatusForbidden),
 		},
 	}
 

--- a/things/api/things/http/endpoint_test.go
+++ b/things/api/things/http/endpoint_test.go
@@ -2034,7 +2034,7 @@ func TestConnect(t *testing.T) {
 			chanID:  ch2.ID,
 			thingID: th1.ID,
 			auth:    token,
-			status:  http.StatusNotFound,
+			status:  http.StatusForbidden,
 		},
 	}
 

--- a/things/api/things/http/endpoint_test.go
+++ b/things/api/things/http/endpoint_test.go
@@ -1992,7 +1992,7 @@ func TestConnect(t *testing.T) {
 			chanID:  strconv.FormatUint(wrongID, 10),
 			thingID: th1.ID,
 			auth:    token,
-			status:  http.StatusForbidden,
+			status:  http.StatusNotFound,
 		},
 		{
 			desc:    "connect non-existing thing to existing channel",
@@ -2006,7 +2006,7 @@ func TestConnect(t *testing.T) {
 			chanID:  "invalid",
 			thingID: th1.ID,
 			auth:    token,
-			status:  http.StatusForbidden,
+			status:  http.StatusNotFound,
 		},
 		{
 			desc:    "connect thing with invalid id to existing channel",

--- a/things/api/things/http/endpoint_test.go
+++ b/things/api/things/http/endpoint_test.go
@@ -1992,7 +1992,7 @@ func TestConnect(t *testing.T) {
 			chanID:  strconv.FormatUint(wrongID, 10),
 			thingID: th1.ID,
 			auth:    token,
-			status:  http.StatusNotFound,
+			status:  http.StatusForbidden,
 		},
 		{
 			desc:    "connect non-existing thing to existing channel",
@@ -2006,7 +2006,7 @@ func TestConnect(t *testing.T) {
 			chanID:  "invalid",
 			thingID: th1.ID,
 			auth:    token,
-			status:  http.StatusNotFound,
+			status:  http.StatusForbidden,
 		},
 		{
 			desc:    "connect thing with invalid id to existing channel",

--- a/things/api/things/http/endpoint_test.go
+++ b/things/api/things/http/endpoint_test.go
@@ -2168,7 +2168,7 @@ func TestCreateConnections(t *testing.T) {
 			thingIDs:    thIDs,
 			auth:        token,
 			contentType: contentType,
-			status:      http.StatusNotFound,
+			status:      http.StatusForbidden,
 		},
 		{
 			desc:        "connect with invalid content type",

--- a/things/channels.go
+++ b/things/channels.go
@@ -44,7 +44,7 @@ type ChannelRepository interface {
 
 	// RetrieveByID retrieves the channel having the provided identifier, that is owned
 	// by the specified user.
-	RetrieveByID(ctx context.Context, owner, id string) (Channel, error)
+	RetrieveByID(ctx context.Context, id string) (Channel, error)
 
 	// RetrieveByOwner retrieves the subset of channels owned by the specified user.
 	RetrieveByOwner(ctx context.Context, owner string, pm PageMetadata) (ChannelsPage, error)

--- a/things/mocks/channels.go
+++ b/things/mocks/channels.go
@@ -201,21 +201,25 @@ func (crm *channelRepositoryMock) Remove(_ context.Context, owner, id string) er
 
 func (crm *channelRepositoryMock) Connect(_ context.Context, owner string, chIDs, thIDs []string) error {
 	for _, chID := range chIDs {
+		ch, err := crm.RetrieveByID(context.Background(), chID)
+		if err != nil {
+			return err
+		}
+
 		for _, thID := range thIDs {
+			th, err := crm.things.RetrieveByID(context.Background(), thID)
+			if err != nil {
+				return err
+			}
 			crm.tconns <- Connection{
 				chanID:    chID,
-				thing:     things.Thing{ID: thID},
+				thing:     th,
 				connected: true,
 			}
 			if _, ok := crm.cconns[thID]; !ok {
 				crm.cconns[thID] = make(map[string]things.Channel)
 			}
-
-			crm.cconns[thID][chID] = things.Channel{
-				ID:    chID,
-				Owner: owner,
-			}
-
+			crm.cconns[thID][chID] = ch
 		}
 	}
 

--- a/things/mocks/channels.go
+++ b/things/mocks/channels.go
@@ -211,11 +211,6 @@ func (crm *channelRepositoryMock) Connect(_ context.Context, owner string, chIDs
 			if err != nil {
 				return err
 			}
-
-			if owner != ch.Owner {
-				return errors.ErrNotFound
-			}
-
 			crm.tconns <- Connection{
 				chanID:    chID,
 				thing:     th,

--- a/things/mocks/channels.go
+++ b/things/mocks/channels.go
@@ -71,9 +71,14 @@ func (crm *channelRepositoryMock) Update(_ context.Context, channel things.Chann
 	return nil
 }
 
-func (crm *channelRepositoryMock) RetrieveByID(_ context.Context, owner, id string) (things.Channel, error) {
-	if c, ok := crm.channels[key(owner, id)]; ok {
-		return c, nil
+func (crm *channelRepositoryMock) RetrieveByID(_ context.Context, id string) (things.Channel, error) {
+	crm.mu.Lock()
+	defer crm.mu.Unlock()
+
+	for _, ch := range crm.channels {
+		if ch.ID == id {
+			return ch, nil
+		}
 	}
 
 	return things.Channel{}, errors.ErrNotFound
@@ -196,15 +201,19 @@ func (crm *channelRepositoryMock) Remove(_ context.Context, owner, id string) er
 
 func (crm *channelRepositoryMock) Connect(_ context.Context, owner string, chIDs, thIDs []string) error {
 	for _, chID := range chIDs {
-		ch, err := crm.RetrieveByID(context.Background(), owner, chID)
+		ch, err := crm.RetrieveByID(context.Background(), chID)
 		if err != nil {
 			return err
 		}
 
 		for _, thID := range thIDs {
-			th, err := crm.things.RetrieveByID(context.Background(), owner, thID)
+			th, err := crm.things.RetrieveByID(context.Background(), thID)
 			if err != nil {
 				return err
+			}
+
+			if owner != ch.Owner {
+				return errors.ErrNotFound
 			}
 
 			crm.tconns <- Connection{

--- a/things/mocks/channels.go
+++ b/things/mocks/channels.go
@@ -201,25 +201,21 @@ func (crm *channelRepositoryMock) Remove(_ context.Context, owner, id string) er
 
 func (crm *channelRepositoryMock) Connect(_ context.Context, owner string, chIDs, thIDs []string) error {
 	for _, chID := range chIDs {
-		ch, err := crm.RetrieveByID(context.Background(), chID)
-		if err != nil {
-			return err
-		}
-
 		for _, thID := range thIDs {
-			th, err := crm.things.RetrieveByID(context.Background(), thID)
-			if err != nil {
-				return err
-			}
 			crm.tconns <- Connection{
 				chanID:    chID,
-				thing:     th,
+				thing:     things.Thing{ID: thID},
 				connected: true,
 			}
 			if _, ok := crm.cconns[thID]; !ok {
 				crm.cconns[thID] = make(map[string]things.Channel)
 			}
-			crm.cconns[thID][chID] = ch
+
+			crm.cconns[thID][chID] = things.Channel{
+				ID:    chID,
+				Owner: owner,
+			}
+
 		}
 	}
 

--- a/things/mocks/things.go
+++ b/things/mocks/things.go
@@ -102,7 +102,7 @@ func (trm *thingRepositoryMock) UpdateKey(_ context.Context, owner, id, val stri
 	return nil
 }
 
-func (trm *thingRepositoryMock) RetrieveByID(_ context.Context, owner, id string) (things.Thing, error) {
+func (trm *thingRepositoryMock) RetrieveByID(_ context.Context, id string) (things.Thing, error) {
 	trm.mu.Lock()
 	defer trm.mu.Unlock()
 

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -107,7 +107,7 @@ func (cr channelRepository) Update(ctx context.Context, channel things.Channel) 
 	return nil
 }
 
-func (cr channelRepository) RetrieveByID(ctx context.Context, owner, id string) (things.Channel, error) {
+func (cr channelRepository) RetrieveByID(ctx context.Context, id string) (things.Channel, error) {
 	q := `SELECT name, metadata, owner FROM channels WHERE id = $1;`
 
 	dbch := dbChannel{

--- a/things/postgres/channels_test.go
+++ b/things/postgres/channels_test.go
@@ -172,29 +172,25 @@ func TestSingleChannelRetrieval(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := map[string]struct {
-		owner string
 		ID    string
 		err   error
 	}{
 		"retrieve channel with existing user": {
-			owner: ch.Owner,
 			ID:    ch.ID,
 			err:   nil,
 		},
 		"retrieve channel with existing user, non-existing channel": {
-			owner: ch.Owner,
 			ID:    nonexistentChanID,
 			err:   errors.ErrNotFound,
 		},
 		"retrieve channel with malformed ID": {
-			owner: ch.Owner,
 			ID:    wrongValue,
 			err:   errors.ErrNotFound,
 		},
 	}
 
 	for desc, tc := range cases {
-		_, err := chanRepo.RetrieveByID(context.Background(), tc.owner, tc.ID)
+		_, err := chanRepo.RetrieveByID(context.Background(), tc.ID)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 	}
 }

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -146,7 +146,7 @@ func (tr thingRepository) UpdateKey(ctx context.Context, owner, id, key string) 
 }
 
 func (tr thingRepository) RetrieveByID(ctx context.Context, id string) (things.Thing, error) {
-	q := `SELECT name, owner, key, metadata FROM things WHERE id = $1 ;`
+	q := `SELECT name, owner, key, metadata FROM things WHERE id = $1;`
 
 	dbth := dbThing{ID: id}
 

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -145,7 +145,7 @@ func (tr thingRepository) UpdateKey(ctx context.Context, owner, id, key string) 
 	return nil
 }
 
-func (tr thingRepository) RetrieveByID(ctx context.Context, owner, id string) (things.Thing, error) {
+func (tr thingRepository) RetrieveByID(ctx context.Context, id string) (things.Thing, error) {
 	q := `SELECT name, owner, key, metadata FROM things WHERE id = $1 ;`
 
 	dbth := dbThing{ID: id}

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -296,29 +296,25 @@ func TestSingleThingRetrieval(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := map[string]struct {
-		owner string
 		ID    string
 		err   error
 	}{
 		"retrieve thing with existing user": {
-			owner: th.Owner,
 			ID:    th.ID,
 			err:   nil,
 		},
 		"retrieve non-existing thing with existing user": {
-			owner: th.Owner,
 			ID:    nonexistentThingID,
 			err:   errors.ErrNotFound,
 		},
 		"retrieve thing with malformed ID": {
-			owner: th.Owner,
 			ID:    wrongValue,
 			err:   errors.ErrNotFound,
 		},
 	}
 
 	for desc, tc := range cases {
-		_, err := thingRepo.RetrieveByID(context.Background(), tc.owner, tc.ID)
+		_, err := thingRepo.RetrieveByID(context.Background(), tc.ID)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 	}
 }

--- a/things/service.go
+++ b/things/service.go
@@ -436,7 +436,7 @@ func (ts *thingsService) Connect(ctx context.Context, token string, chIDs, thIDs
 	for _, chID := range chIDs {
 		err := ts.IsChannelOwner(ctx, res.GetId(), chID)
 		if err != nil {
-			return err
+			return errors.ErrAuthorization
 		}
 	}
 

--- a/things/service.go
+++ b/things/service.go
@@ -252,7 +252,7 @@ func (ts *thingsService) ViewThing(ctx context.Context, token, id string) (Thing
 		return Thing{}, errors.Wrap(errors.ErrAuthentication, err)
 	}
 
-	thing, err := ts.things.RetrieveByID(ctx, "", id)
+	thing, err := ts.things.RetrieveByID(ctx, id)
 	if err != nil {
 		return Thing{}, err
 	}
@@ -314,7 +314,7 @@ func (ts *thingsService) RemoveThing(ctx context.Context, token, id string) erro
 		return errors.Wrap(errors.ErrAuthentication, err)
 	}
 
-	if _, err = ts.things.RetrieveByID(ctx, res.GetId(), id); err != nil {
+	if _, err = ts.things.RetrieveByID(ctx, id); err != nil {
 		return err
 	}
 
@@ -379,7 +379,7 @@ func (ts *thingsService) ViewChannel(ctx context.Context, token, id string) (Cha
 		return Channel{}, errors.Wrap(errors.ErrAuthentication, err)
 	}
 
-	channel, err := ts.channels.RetrieveByID(ctx, res.GetId(), id)
+	channel, err := ts.channels.RetrieveByID(ctx, id)
 	if err != nil {
 		return Channel{}, err
 	}
@@ -416,7 +416,7 @@ func (ts *thingsService) RemoveChannel(ctx context.Context, token, id string) er
 		return errors.Wrap(errors.ErrAuthentication, err)
 	}
 
-	if _, err = ts.channels.RetrieveByID(ctx, res.GetId(), id); err != nil {
+	if _, err = ts.channels.RetrieveByID(ctx, id); err != nil {
 		return err
 	}
 
@@ -489,7 +489,7 @@ func (ts *thingsService) CanAccessByID(ctx context.Context, chanID, thingID stri
 }
 
 func (ts *thingsService) IsChannelOwner(ctx context.Context, owner, chanID string) error {
-	ch, err := ts.channels.RetrieveByID(ctx, owner, chanID)
+	ch, err := ts.channels.RetrieveByID(ctx, chanID)
 	if err != nil {
 		return err
 	}

--- a/things/service.go
+++ b/things/service.go
@@ -433,9 +433,14 @@ func (ts *thingsService) Connect(ctx context.Context, token string, chIDs, thIDs
 		return errors.Wrap(errors.ErrAuthentication, err)
 	}
 
+	for _, thID := range thIDs {
+		if err := ts.isThingOwner(ctx, res.GetId(), thID); err != nil {
+			return err
+		}
+	}
+
 	for _, chID := range chIDs {
-		err := ts.IsChannelOwner(ctx, res.GetId(), chID)
-		if err != nil {
+		if err := ts.IsChannelOwner(ctx, res.GetId(), chID); err != nil {
 			return err
 		}
 	}
@@ -750,6 +755,19 @@ func (ts *thingsService) authorize(ctx context.Context, email string) error {
 	}
 	if !res.GetAuthorized() {
 		return errors.ErrAuthorization
+	}
+
+	return nil
+}
+
+func (ts *thingsService) isThingOwner(ctx context.Context, owner string, thingID string) error {
+	thing, err := ts.things.RetrieveByID(ctx, thingID)
+	if err != nil {
+		return err
+	}
+
+	if thing.Owner != owner {
+		return errors.ErrNotFound
 	}
 
 	return nil

--- a/things/service.go
+++ b/things/service.go
@@ -436,7 +436,7 @@ func (ts *thingsService) Connect(ctx context.Context, token string, chIDs, thIDs
 	for _, chID := range chIDs {
 		err := ts.IsChannelOwner(ctx, res.GetId(), chID)
 		if err != nil {
-			return errors.ErrNotFound
+			return err
 		}
 	}
 

--- a/things/service.go
+++ b/things/service.go
@@ -433,6 +433,13 @@ func (ts *thingsService) Connect(ctx context.Context, token string, chIDs, thIDs
 		return errors.Wrap(errors.ErrAuthentication, err)
 	}
 
+	for _, chID := range chIDs {
+		err := ts.IsChannelOwner(ctx, res.GetId(), chID)
+		if err != nil {
+			return errors.ErrNotFound
+		}
+	}
+
 	return ts.channels.Connect(ctx, res.GetId(), chIDs, thIDs)
 }
 

--- a/things/service.go
+++ b/things/service.go
@@ -436,7 +436,7 @@ func (ts *thingsService) Connect(ctx context.Context, token string, chIDs, thIDs
 	for _, chID := range chIDs {
 		err := ts.IsChannelOwner(ctx, res.GetId(), chID)
 		if err != nil {
-			return errors.ErrAuthorization
+			return err
 		}
 	}
 

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -1279,7 +1279,7 @@ func TestIsChannelOwner(t *testing.T) {
 		},
 		"user does not own channel": {
 			channel: nonOwnedCh.ID,
-			err:     errors.ErrNotFound,
+			err:     errors.ErrAuthorization,
 		},
 		"access to non-existing channel": {
 			channel: wrongID,

--- a/things/things.go
+++ b/things/things.go
@@ -58,7 +58,7 @@ type ThingRepository interface {
 
 	// RetrieveByID retrieves the thing having the provided identifier, that is owned
 	// by the specified user.
-	RetrieveByID(ctx context.Context, owner, id string) (Thing, error)
+	RetrieveByID(ctx context.Context, id string) (Thing, error)
 
 	// RetrieveByKey returns thing ID for given thing key.
 	RetrieveByKey(ctx context.Context, key string) (string, error)

--- a/things/tracing/channels.go
+++ b/things/tracing/channels.go
@@ -60,12 +60,12 @@ func (crm channelRepositoryMiddleware) Update(ctx context.Context, ch things.Cha
 	return crm.repo.Update(ctx, ch)
 }
 
-func (crm channelRepositoryMiddleware) RetrieveByID(ctx context.Context, owner, id string) (things.Channel, error) {
+func (crm channelRepositoryMiddleware) RetrieveByID(ctx context.Context, id string) (things.Channel, error) {
 	span := createSpan(ctx, crm.tracer, retrieveChannelByIDOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return crm.repo.RetrieveByID(ctx, owner, id)
+	return crm.repo.RetrieveByID(ctx, id)
 }
 
 func (crm channelRepositoryMiddleware) RetrieveByOwner(ctx context.Context, owner string, pm things.PageMetadata) (things.ChannelsPage, error) {

--- a/things/tracing/things.go
+++ b/things/tracing/things.go
@@ -69,12 +69,12 @@ func (trm thingRepositoryMiddleware) UpdateKey(ctx context.Context, owner, id, k
 	return trm.repo.UpdateKey(ctx, owner, id, key)
 }
 
-func (trm thingRepositoryMiddleware) RetrieveByID(ctx context.Context, owner, id string) (things.Thing, error) {
+func (trm thingRepositoryMiddleware) RetrieveByID(ctx context.Context, id string) (things.Thing, error) {
 	span := createSpan(ctx, trm.tracer, retrieveThingByIDOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return trm.repo.RetrieveByID(ctx, owner, id)
+	return trm.repo.RetrieveByID(ctx, id)
 }
 
 func (trm thingRepositoryMiddleware) RetrieveByKey(ctx context.Context, key string) (string, error) {


### PR DESCRIPTION
Removed unnecessary `ownerID` input in `RetrieveByID` methods.

Resolves #117 
