### PR TITLE
MF-126 - Move ErrMalformedEntity to apiutil package

### DIFF
--- a/auth/api/grpc/server.go
+++ b/auth/api/grpc/server.go
@@ -183,7 +183,7 @@ func encodeError(err error) error {
 	switch {
 	case errors.Contains(err, nil):
 		return nil
-	case errors.Contains(err, errors.ErrMalformedEntity),
+	case errors.Contains(err, apiutil.ErrMalformedEntity),
 		err == apiutil.ErrInvalidAuthKey,
 		err == apiutil.ErrMissingID,
 		err == apiutil.ErrMissingMemberType:

--- a/auth/api/http/keys/transport.go
+++ b/auth/api/http/keys/transport.go
@@ -58,7 +58,7 @@ func decodeIssue(_ context.Context, r *http.Request) (interface{}, error) {
 
 	req := issueKeyReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -92,7 +92,7 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case errors.Contains(err, errors.ErrMalformedEntity),
+	case errors.Contains(err, apiutil.ErrMalformedEntity),
 		err == apiutil.ErrMissingID,
 		err == apiutil.ErrInvalidAPIKey:
 		w.WriteHeader(http.StatusBadRequest)

--- a/auth/api/http/orgs/transport.go
+++ b/auth/api/http/orgs/transport.go
@@ -228,7 +228,7 @@ func decodeOrgCreate(_ context.Context, r *http.Request) (interface{}, error) {
 
 	req := createOrgReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -244,7 +244,7 @@ func decodeOrgUpdate(_ context.Context, r *http.Request) (interface{}, error) {
 		token: apiutil.ExtractBearerToken(r),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -266,16 +266,16 @@ func decodeMembersRequest(_ context.Context, r *http.Request) (interface{}, erro
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	for i := range req.Members {
 		if req.Members[i].Role == "" {
 			req.Members[i].Role = auth.ViewerRole
 		}
-		
+
 		if req.Members[i].Role == auth.OwnerRole {
-			return nil, errors.ErrMalformedEntity
+			return nil, apiutil.ErrMalformedEntity
 		}
 	}
 
@@ -289,7 +289,7 @@ func decodeUnassignMembersRequest(_ context.Context, r *http.Request) (interface
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -302,7 +302,7 @@ func decodeGroupsRequest(_ context.Context, r *http.Request) (interface{}, error
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -328,7 +328,7 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case errors.Contains(err, errors.ErrMalformedEntity),
+	case errors.Contains(err, apiutil.ErrMalformedEntity),
 		err == apiutil.ErrMissingID,
 		err == apiutil.ErrEmptyList,
 		err == apiutil.ErrMissingMemberType,

--- a/bootstrap/api/endpoint_test.go
+++ b/bootstrap/api/endpoint_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/bootstrap/mocks"
 	"github.com/MainfluxLabs/mainflux/internal/apiutil"
 	"github.com/MainfluxLabs/mainflux/logger"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	mfsdk "github.com/MainfluxLabs/mainflux/pkg/sdk/go"
 	"github.com/MainfluxLabs/mainflux/things"
 	thingsapi "github.com/MainfluxLabs/mainflux/things/api/things/http"
@@ -155,7 +154,7 @@ func dec(in []byte) ([]byte, error) {
 		return nil, err
 	}
 	if len(in) < aes.BlockSize {
-		return nil, errors.ErrMalformedEntity
+		return nil, apiutil.ErrMalformedEntity
 	}
 	iv := in[:aes.BlockSize]
 	in = in[aes.BlockSize:]

--- a/bootstrap/api/transport.go
+++ b/bootstrap/api/transport.go
@@ -113,7 +113,7 @@ func decodeAddRequest(_ context.Context, r *http.Request) (interface{}, error) {
 
 	req := addReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -129,7 +129,7 @@ func decodeUpdateRequest(_ context.Context, r *http.Request) (interface{}, error
 		id:    bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -145,7 +145,7 @@ func decodeUpdateCertRequest(_ context.Context, r *http.Request) (interface{}, e
 		thingID: bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -161,7 +161,7 @@ func decodeUpdateConnRequest(_ context.Context, r *http.Request) (interface{}, e
 		id:    bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -212,7 +212,7 @@ func decodeStateRequest(_ context.Context, r *http.Request) (interface{}, error)
 		id:    bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -264,7 +264,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
 		w.WriteHeader(http.StatusUnsupportedMediaType)
 	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, errors.ErrMalformedEntity),
+		errors.Contains(err, apiutil.ErrMalformedEntity),
 		err == apiutil.ErrMissingID,
 		err == apiutil.ErrBootstrapState,
 		err == apiutil.ErrLimitSize:

--- a/certs/api/transport.go
+++ b/certs/api/transport.go
@@ -143,7 +143,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusUnauthorized)
 	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
 		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, errors.ErrMalformedEntity),
+	case errors.Contains(err, apiutil.ErrMalformedEntity),
 		err == apiutil.ErrMissingID,
 		err == apiutil.ErrMissingCertData,
 		err == apiutil.ErrLimitSize:

--- a/consumers/notifiers/api/transport.go
+++ b/consumers/notifiers/api/transport.go
@@ -80,7 +80,7 @@ func decodeCreate(_ context.Context, r *http.Request) (interface{}, error) {
 
 	req := createSubReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -140,7 +140,7 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case errors.Contains(err, errors.ErrMalformedEntity),
+	case errors.Contains(err, apiutil.ErrMalformedEntity),
 		err == apiutil.ErrInvalidContact,
 		err == apiutil.ErrInvalidTopic,
 		err == apiutil.ErrMissingID,

--- a/http/api/transport.go
+++ b/http/api/transport.go
@@ -105,7 +105,7 @@ func decodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 
 	channelParts := channelPartRegExp.FindStringSubmatch(r.RequestURI)
 	if len(channelParts) < 2 {
-		return nil, errors.ErrMalformedEntity
+		return nil, apiutil.ErrMalformedEntity
 	}
 
 	subtopic, err := parseSubtopic(channelParts[2])
@@ -124,7 +124,7 @@ func decodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 
 	payload, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return nil, errors.ErrMalformedEntity
+		return nil, apiutil.ErrMalformedEntity
 	}
 	defer r.Body.Close()
 
@@ -157,7 +157,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
 		w.WriteHeader(http.StatusUnsupportedMediaType)
 	case errors.Contains(err, errMalformedSubtopic),
-		errors.Contains(err, errors.ErrMalformedEntity):
+		errors.Contains(err, apiutil.ErrMalformedEntity):
 		w.WriteHeader(http.StatusBadRequest)
 
 	default:

--- a/internal/apiutil/errors.go
+++ b/internal/apiutil/errors.go
@@ -98,4 +98,7 @@ var (
 
 	// ErrInvalidMemberRole indicates an invalid member role.
 	ErrInvalidMemberRole = errors.New("invalid member role")
+
+	// ErrMalformedEntity indicates a malformed entity specification.
+	ErrMalformedEntity = errors.New("malformed entity specification")
 )

--- a/internal/apiutil/transport.go
+++ b/internal/apiutil/transport.go
@@ -44,6 +44,7 @@ func LoggingErrorEncoder(logger logger.Logger, enc kithttp.ErrorEncoder) kithttp
 			ErrMaxLevelExceeded,
 			ErrBootstrapState,
 			ErrUnsupportedContentType,
+			ErrMalformedEntity,
 			ErrInvalidQueryParams:
 			logger.Error(err.Error())
 		}

--- a/mqtt/api/http/transport.go
+++ b/mqtt/api/http/transport.go
@@ -91,7 +91,7 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case errors.Contains(err, errors.ErrMalformedEntity),
+	case errors.Contains(err, apiutil.ErrMalformedEntity),
 		errors.Contains(err, apiutil.ErrInvalidQueryParams):
 		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, errors.ErrAuthentication),

--- a/provision/api/transport.go
+++ b/provision/api/transport.go
@@ -96,7 +96,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusUnauthorized)
 	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
 		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, errors.ErrMalformedEntity),
+	case errors.Contains(err, apiutil.ErrMalformedEntity),
 		err == apiutil.ErrMissingID,
 		err == apiutil.ErrBearerKey:
 		w.WriteHeader(http.StatusBadRequest)

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -294,7 +294,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
 	case errors.Contains(err, nil):
 	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, errors.ErrMalformedEntity),
+		errors.Contains(err, apiutil.ErrMalformedEntity),
 		err == apiutil.ErrMissingID,
 		err == apiutil.ErrLimitSize,
 		err == apiutil.ErrOffsetSize,

--- a/things/api/auth/grpc/server.go
+++ b/things/api/auth/grpc/server.go
@@ -148,7 +148,7 @@ func encodeError(err error) error {
 	switch err {
 	case nil:
 		return nil
-	case errors.ErrMalformedEntity,
+	case apiutil.ErrMalformedEntity,
 		apiutil.ErrMissingID,
 		apiutil.ErrBearerKey:
 		return status.Error(codes.InvalidArgument, err.Error())

--- a/things/api/auth/http/transport.go
+++ b/things/api/auth/http/transport.go
@@ -61,7 +61,7 @@ func decodeIdentify(_ context.Context, r *http.Request) (interface{}, error) {
 
 	req := identifyReq{}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -76,7 +76,7 @@ func decodeCanAccessByKey(_ context.Context, r *http.Request) (interface{}, erro
 		chanID: bone.GetValue(r, "chanId"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -91,7 +91,7 @@ func decodeCanAccessByID(_ context.Context, r *http.Request) (interface{}, error
 		chanID: bone.GetValue(r, "chanId"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -125,7 +125,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusForbidden)
 	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
 		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, errors.ErrMalformedEntity),
+	case errors.Contains(err, apiutil.ErrMalformedEntity),
 		errors.Contains(err, apiutil.ErrMissingID):
 		w.WriteHeader(http.StatusBadRequest)
 	default:

--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -260,7 +260,7 @@ func decodeThingsCreation(_ context.Context, r *http.Request) (interface{}, erro
 
 	req := createThingsReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req.Things); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -276,7 +276,7 @@ func decodeThingUpdate(_ context.Context, r *http.Request) (interface{}, error) 
 		id:    bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -292,7 +292,7 @@ func decodeKeyUpdate(_ context.Context, r *http.Request) (interface{}, error) {
 		id:    bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -305,7 +305,7 @@ func decodeChannelsCreation(_ context.Context, r *http.Request) (interface{}, er
 
 	req := createChannelsReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req.Channels); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -321,7 +321,7 @@ func decodeChannelUpdate(_ context.Context, r *http.Request) (interface{}, error
 		id:    bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -385,7 +385,7 @@ func decodeList(_ context.Context, r *http.Request) (interface{}, error) {
 func decodeListByMetadata(_ context.Context, r *http.Request) (interface{}, error) {
 	req := listResourcesReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req.pageMetadata); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -449,7 +449,7 @@ func decodeConnectList(_ context.Context, r *http.Request) (interface{}, error) 
 
 	req := connectReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -488,7 +488,7 @@ func decodeGroupCreate(_ context.Context, r *http.Request) (interface{}, error) 
 
 	req := createGroupReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -532,7 +532,7 @@ func decodeGroupUpdate(_ context.Context, r *http.Request) (interface{}, error) 
 		token: apiutil.ExtractBearerToken(r),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -554,7 +554,7 @@ func decodeAssignRequest(_ context.Context, r *http.Request) (interface{}, error
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -569,7 +569,7 @@ func decodeUnassignRequest(_ context.Context, r *http.Request) (interface{}, err
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -615,7 +615,7 @@ func decodeRestore(_ context.Context, r *http.Request) (interface{}, error) {
 
 	req := restoreReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -652,7 +652,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
 		w.WriteHeader(http.StatusUnsupportedMediaType)
 	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, errors.ErrMalformedEntity),
+		errors.Contains(err, apiutil.ErrMalformedEntity),
 		err == apiutil.ErrNameSize,
 		err == apiutil.ErrEmptyList,
 		err == apiutil.ErrMissingID,

--- a/users/api/endpoint_test.go
+++ b/users/api/endpoint_test.go
@@ -46,8 +46,8 @@ var (
 	admin              = users.User{Email: adminEmail, Password: validPass, Status: "enabled"}
 	notFoundRes        = toJSON(apiutil.ErrorRes{Err: errors.ErrNotFound.Error()})
 	unauthRes          = toJSON(apiutil.ErrorRes{Err: errors.ErrAuthentication.Error()})
-	malformedRes       = toJSON(apiutil.ErrorRes{Err: errors.ErrMalformedEntity.Error()})
 	weakPassword       = toJSON(apiutil.ErrorRes{Err: users.ErrPasswordFormat.Error()})
+	malformedRes       = toJSON(apiutil.ErrorRes{Err: apiutil.ErrMalformedEntity.Error()})
 	unsupportedRes     = toJSON(apiutil.ErrorRes{Err: apiutil.ErrUnsupportedContentType.Error()})
 	missingTokRes      = toJSON(apiutil.ErrorRes{Err: apiutil.ErrBearerToken.Error()})
 	missingEmailRes    = toJSON(apiutil.ErrorRes{Err: apiutil.ErrMissingEmail.Error()})

--- a/users/api/grpc/server.go
+++ b/users/api/grpc/server.go
@@ -78,7 +78,7 @@ func encodeError(err error) error {
 	switch err {
 	case nil:
 		return nil
-	case errors.ErrMalformedEntity, apiutil.ErrMissingID:
+	case apiutil.ErrMalformedEntity, apiutil.ErrMissingID:
 		return status.Error(codes.InvalidArgument, err.Error())
 	case errors.ErrAuthentication:
 		return status.Error(codes.Unauthenticated, err.Error())

--- a/users/api/transport.go
+++ b/users/api/transport.go
@@ -199,7 +199,7 @@ func decodeListUsers(_ context.Context, r *http.Request) (interface{}, error) {
 func decodeUpdateUser(_ context.Context, r *http.Request) (interface{}, error) {
 	req := updateUserReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -212,7 +212,7 @@ func decodeCredentials(_ context.Context, r *http.Request) (interface{}, error) 
 
 	var user users.User
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 	user.Email = strings.TrimSpace(user.Email)
 	return userReq{user}, nil
@@ -225,7 +225,7 @@ func decodeCreateUserReq(_ context.Context, r *http.Request) (interface{}, error
 
 	var user users.User
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	user.Email = strings.TrimSpace(user.Email)
@@ -244,7 +244,7 @@ func decodeSelfRegisterUserReq(_ context.Context, r *http.Request) (interface{},
 
 	var user users.User
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return selfRegisterUserReq{user: user}, nil
@@ -258,7 +258,7 @@ func decodePasswordResetRequest(_ context.Context, r *http.Request) (interface{}
 	var req passwResetReq
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	req.Host = r.Header.Get("Referer")
@@ -272,7 +272,7 @@ func decodePasswordReset(_ context.Context, r *http.Request) (interface{}, error
 
 	var req resetTokenReq
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -285,7 +285,7 @@ func decodePasswordChange(_ context.Context, r *http.Request) (interface{}, erro
 
 	req := passwChangeReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -344,7 +344,7 @@ func decodeRestore(_ context.Context, r *http.Request) (interface{}, error) {
 
 	req := restoreReq{token: apiutil.ExtractBearerToken(r)}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 	}
 
 	return req, nil
@@ -369,7 +369,7 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
 	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, errors.ErrMalformedEntity),
+		errors.Contains(err, apiutil.ErrMalformedEntity),
 		errors.Contains(err, users.ErrPasswordFormat),
 		err == apiutil.ErrMissingEmail,
 		err == apiutil.ErrMissingHost,

--- a/ws/api/endpoints.go
+++ b/ws/api/endpoints.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-zoo/bone"
-	"github.com/gorilla/websocket"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/internal/apiutil"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
 	"github.com/MainfluxLabs/mainflux/ws"
+	"github.com/go-zoo/bone"
+	"github.com/gorilla/websocket"
 )
 
 var channelPartRegExp = regexp.MustCompile(`^/channels/([\w\-]+)/messages(/[^?]*)?(\?.*)?$`)
@@ -71,7 +71,7 @@ func decodeRequest(r *http.Request) (connReq, error) {
 	channelParts := channelPartRegExp.FindStringSubmatch(r.RequestURI)
 	if len(channelParts) < 2 {
 		logger.Warn("Empty channel id or malformed url")
-		return connReq{}, errors.ErrMalformedEntity
+		return connReq{}, apiutil.ErrMalformedEntity
 	}
 
 	subtopic, err := parseSubTopic(channelParts[2])
@@ -160,7 +160,7 @@ func encodeError(w http.ResponseWriter, err error) {
 		statusCode = http.StatusBadRequest
 	case errUnauthorizedAccess:
 		statusCode = http.StatusForbidden
-	case errMalformedSubtopic, errors.ErrMalformedEntity:
+	case errMalformedSubtopic, apiutil.ErrMalformedEntity:
 		statusCode = http.StatusBadRequest
 	default:
 		statusCode = http.StatusNotFound


### PR DESCRIPTION
Move `ErrMalformedEntity` from transport layer in `api` package to `apiutil`

Resolves #126 