### PR TITLE
MF-131 - Fix CanAccessGroup org method

### DIFF
--- a/auth/service.go
+++ b/auth/service.go
@@ -604,8 +604,7 @@ func (svc service) CanAccessGroup(ctx context.Context, token, groupID string) er
 	}
 
 	for _, org := range op.Orgs {
-		err := svc.canEditGroups(ctx, org.ID, user.ID)
-		if err == nil {
+		if err := svc.canEditGroups(ctx, org.ID, user.ID); err == nil {
 			return nil
 		}
 	}

--- a/auth/service.go
+++ b/auth/service.go
@@ -603,13 +603,17 @@ func (svc service) CanAccessGroup(ctx context.Context, token, groupID string) er
 		return err
 	}
 
+	if len(op.Orgs) == 0 {
+		return errors.ErrAuthorization
+	}
+
 	for _, org := range op.Orgs {
 		if err := svc.canEditGroups(ctx, org.ID, user.ID); err != nil {
 			return err
 		}
 	}
 
-	return errors.ErrAuthorization
+	return nil
 }
 
 func (svc service) isOwner(ctx context.Context, orgID, userID string) error {

--- a/auth/service.go
+++ b/auth/service.go
@@ -603,17 +603,14 @@ func (svc service) CanAccessGroup(ctx context.Context, token, groupID string) er
 		return err
 	}
 
-	if len(op.Orgs) == 0 {
-		return errors.ErrAuthorization
-	}
-
 	for _, org := range op.Orgs {
-		if err := svc.canEditGroups(ctx, org.ID, user.ID); err != nil {
-			return err
+		err := svc.canEditGroups(ctx, org.ID, user.ID)
+		if err == nil {
+			return nil
 		}
 	}
 
-	return nil
+	return errors.ErrAuthorization
 }
 
 func (svc service) isOwner(ctx context.Context, orgID, userID string) error {


### PR DESCRIPTION
 Fixed `CanAccessGroup` to check if there is `orgs` where group is assigned.

Resolves #131 
