### PR TITLE
NOISSUE - Change readers test limit from 1001 to 101

### DIFF
--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -32,7 +32,7 @@ const (
 	thingToken    = "1"
 	email         = "admin@example.com"
 	invalid       = "invalid"
-	numOfMessages = 1001
+	numOfMessages = 101
 	valueFields   = 5
 	subtopic      = "topic"
 	mqttProt      = "mqtt"

--- a/readers/influxdb/messages_test.go
+++ b/readers/influxdb/messages_test.go
@@ -20,7 +20,7 @@ import (
 const (
 	testDB      = "test"
 	subtopic    = "topic"
-	msgsNum     = 1001
+	msgsNum     = 101
 	limit       = 10
 	oneMsgLimit = 1
 	noLimit     = 0

--- a/readers/mongodb/messages_test.go
+++ b/readers/mongodb/messages_test.go
@@ -25,7 +25,7 @@ import (
 const (
 	testDB      = "test"
 	subtopic    = "subtopic"
-	msgsNum     = 1001
+	msgsNum     = 101
 	limit       = 10
 	noLimit     = 0
 	valueFields = 5

--- a/readers/postgres/messages_test.go
+++ b/readers/postgres/messages_test.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	subtopic    = "subtopic"
-	msgsNum     = 1001
+	msgsNum     = 101
 	limit       = 10
 	noLimit     = 0
 	valueFields = 5

--- a/readers/timescale/messages_test.go
+++ b/readers/timescale/messages_test.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	subtopic    = "subtopic"
-	msgsNum     = 1001
+	msgsNum     = 101
 	limit       = 10
 	valueFields = 5
 	zeroOffset  = 0


### PR DESCRIPTION
Readers tests are taking too much time to execute. Reduce the number of samples  from 1001 to 101