### PR TITLE
NOISSUE - Fix member role not showing correctly

### DIFF
--- a/auth/service.go
+++ b/auth/service.go
@@ -476,7 +476,7 @@ func (svc service) ListOrgMembers(ctx context.Context, token string, orgID strin
 			return MembersPage{}, err
 		}
 
-		emails := make(map[string]interface{})
+		emails := make(map[string]string)
 		for _, user := range page.Users {
 			emails[user.Id] = user.GetEmail()
 		}
@@ -489,7 +489,7 @@ func (svc service) ListOrgMembers(ctx context.Context, token string, orgID strin
 
 			mbr := Member{
 				ID:    m.ID,
-				Email: email.(string),
+				Email: email,
 				Role:  m.Role,
 			}
 			members = append(members, mbr)

--- a/auth/service.go
+++ b/auth/service.go
@@ -476,10 +476,20 @@ func (svc service) ListOrgMembers(ctx context.Context, token string, orgID strin
 			return MembersPage{}, err
 		}
 
-		for i, m := range mp.Members {
+		emails := make(map[string]interface{})
+		for _, user := range page.Users {
+			emails[user.Id] = user.GetEmail()
+		}
+
+		for _, m := range mp.Members {
+			email, ok := emails[m.ID]
+			if !ok {
+				return MembersPage{}, err
+			}
+
 			mbr := Member{
 				ID:    m.ID,
-				Email: page.Users[i].GetEmail(),
+				Email: email.(string),
 				Role:  m.Role,
 			}
 			members = append(members, mbr)


### PR DESCRIPTION
Fixed bug for   `ListOrgMembers` where role is not assigned correctly to members.