### PR TITLE
MF-172 - Move created_at and updated_at setting from DB layer to service layer

### DIFF
--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -127,17 +127,17 @@ func (orm *orgRepositoryMock) RetrieveMemberships(ctx context.Context, memberID 
 	}, nil
 }
 
-func (orm *orgRepositoryMock) AssignMembers(ctx context.Context, mRel ...auth.MemberRelation) error {
+func (orm *orgRepositoryMock) AssignMembers(ctx context.Context, mr ...auth.MemberRelation) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	for _, rel := range mRel {
-		if _, ok := orm.orgs[rel.OrgID]; !ok {
+	for _, m := range mr {
+		if _, ok := orm.orgs[m.OrgID]; !ok {
 			return errors.ErrNotFound
 		}
-		orm.members[rel.MemberID] = auth.Member{
-			ID:   rel.MemberID,
-			Role: rel.Role,
+		orm.members[m.MemberID] = auth.Member{
+			ID:   m.MemberID,
+			Role: m.Role,
 		}
 	}
 
@@ -158,17 +158,17 @@ func (orm *orgRepositoryMock) UnassignMembers(ctx context.Context, orgID string,
 	return nil
 }
 
-func (orm *orgRepositoryMock) UpdateMembers(ctx context.Context, memberRelations ...auth.MemberRelation) error {
+func (orm *orgRepositoryMock) UpdateMembers(ctx context.Context, mr ...auth.MemberRelation) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	for _, rel := range memberRelations {
-		if _, ok := orm.members[rel.MemberID]; !ok || orm.orgs[rel.OrgID].ID != rel.OrgID {
+	for _, m := range mr {
+		if _, ok := orm.members[m.MemberID]; !ok || orm.orgs[m.OrgID].ID != m.OrgID {
 			return errors.ErrNotFound
 		}
-		orm.members[rel.MemberID] = auth.Member{
-			ID:   rel.MemberID,
-			Role: rel.Role,
+		orm.members[m.MemberID] = auth.Member{
+			ID:   m.MemberID,
+			Role: m.Role,
 		}
 	}
 
@@ -211,16 +211,16 @@ func (orm *orgRepositoryMock) RetrieveMembers(ctx context.Context, orgID string,
 	}, nil
 }
 
-func (orm *orgRepositoryMock) AssignGroups(ctx context.Context, gRel ...auth.GroupRelation) error {
+func (orm *orgRepositoryMock) AssignGroups(ctx context.Context, gr ...auth.GroupRelation) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	for _, rel := range gRel {
-		if _, ok := orm.orgs[rel.OrgID]; !ok {
+	for _, g := range gr {
+		if _, ok := orm.orgs[g.OrgID]; !ok {
 			return errors.ErrNotFound
 		}
-		orm.groups[rel.GroupID] = auth.Group{
-			ID: rel.GroupID,
+		orm.groups[g.GroupID] = auth.Group{
+			ID: g.GroupID,
 		}
 	}
 

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -26,11 +26,11 @@ func NewOrgRepository() auth.OrgRepository {
 	}
 }
 
-func (orm *orgRepositoryMock) Save(ctx context.Context, g ...auth.Org) error {
+func (orm *orgRepositoryMock) Save(ctx context.Context, orgs ...auth.Org) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	for _, org := range g {
+	for _, org := range orgs {
 		if _, ok := orm.orgs[org.ID]; ok {
 			return errors.ErrConflict
 		}
@@ -41,15 +41,15 @@ func (orm *orgRepositoryMock) Save(ctx context.Context, g ...auth.Org) error {
 	return nil
 }
 
-func (orm *orgRepositoryMock) Update(ctx context.Context, g auth.Org) error {
+func (orm *orgRepositoryMock) Update(ctx context.Context, org auth.Org) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	if _, ok := orm.orgs[g.ID]; !ok {
+	if _, ok := orm.orgs[org.ID]; !ok {
 		return errors.ErrNotFound
 	}
 
-	orm.orgs[g.ID] = g
+	orm.orgs[org.ID] = org
 
 	return nil
 }
@@ -127,17 +127,17 @@ func (orm *orgRepositoryMock) RetrieveMemberships(ctx context.Context, memberID 
 	}, nil
 }
 
-func (orm *orgRepositoryMock) AssignMembers(ctx context.Context, mr ...auth.MemberRelation) error {
+func (orm *orgRepositoryMock) AssignMembers(ctx context.Context, mrs ...auth.MemberRelation) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	for _, m := range mr {
-		if _, ok := orm.orgs[m.OrgID]; !ok {
+	for _, mr := range mrs {
+		if _, ok := orm.orgs[mr.OrgID]; !ok {
 			return errors.ErrNotFound
 		}
-		orm.members[m.MemberID] = auth.Member{
-			ID:   m.MemberID,
-			Role: m.Role,
+		orm.members[mr.MemberID] = auth.Member{
+			ID:   mr.MemberID,
+			Role: mr.Role,
 		}
 	}
 
@@ -158,17 +158,17 @@ func (orm *orgRepositoryMock) UnassignMembers(ctx context.Context, orgID string,
 	return nil
 }
 
-func (orm *orgRepositoryMock) UpdateMembers(ctx context.Context, mr ...auth.MemberRelation) error {
+func (orm *orgRepositoryMock) UpdateMembers(ctx context.Context, mrs ...auth.MemberRelation) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	for _, m := range mr {
-		if _, ok := orm.members[m.MemberID]; !ok || orm.orgs[m.OrgID].ID != m.OrgID {
+	for _, mr := range mrs {
+		if _, ok := orm.members[mr.MemberID]; !ok || orm.orgs[mr.OrgID].ID != mr.OrgID {
 			return errors.ErrNotFound
 		}
-		orm.members[m.MemberID] = auth.Member{
-			ID:   m.MemberID,
-			Role: m.Role,
+		orm.members[mr.MemberID] = auth.Member{
+			ID:   mr.MemberID,
+			Role: mr.Role,
 		}
 	}
 
@@ -211,16 +211,16 @@ func (orm *orgRepositoryMock) RetrieveMembers(ctx context.Context, orgID string,
 	}, nil
 }
 
-func (orm *orgRepositoryMock) AssignGroups(ctx context.Context, gr ...auth.GroupRelation) error {
+func (orm *orgRepositoryMock) AssignGroups(ctx context.Context, grs ...auth.GroupRelation) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	for _, g := range gr {
-		if _, ok := orm.orgs[g.OrgID]; !ok {
+	for _, gr := range grs {
+		if _, ok := orm.orgs[gr.OrgID]; !ok {
 			return errors.ErrNotFound
 		}
-		orm.groups[g.GroupID] = auth.Group{
-			ID: g.GroupID,
+		orm.groups[gr.GroupID] = auth.Group{
+			ID: gr.GroupID,
 		}
 	}
 
@@ -330,32 +330,32 @@ func (orm *orgRepositoryMock) RetrieveAllMemberRelations(ctx context.Context) ([
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	var memberRelations []auth.MemberRelation
+	var mrs []auth.MemberRelation
 	for _, org := range orm.orgs {
 		for _, member := range orm.members {
-			memberRelations = append(memberRelations, auth.MemberRelation{
+			mrs = append(mrs, auth.MemberRelation{
 				OrgID:    org.ID,
 				MemberID: member.ID,
 			})
 		}
 	}
 
-	return memberRelations, nil
+	return mrs, nil
 }
 
 func (orm *orgRepositoryMock) RetrieveAllGroupRelations(ctx context.Context) ([]auth.GroupRelation, error) {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	var groupRelations []auth.GroupRelation
+	var grs []auth.GroupRelation
 	for _, org := range orm.orgs {
 		for _, group := range orm.groups {
-			groupRelations = append(groupRelations, auth.GroupRelation{
+			grs = append(grs, auth.GroupRelation{
 				OrgID:   org.ID,
 				GroupID: group.ID,
 			})
 		}
 	}
 
-	return groupRelations, nil
+	return grs, nil
 }

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -158,15 +158,18 @@ func (orm *orgRepositoryMock) UnassignMembers(ctx context.Context, orgID string,
 	return nil
 }
 
-func (orm *orgRepositoryMock) UpdateMembers(ctx context.Context, orgID string, members ...auth.Member) error {
+func (orm *orgRepositoryMock) UpdateMembers(ctx context.Context, memberRelations ...auth.MemberRelation) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	for _, member := range members {
-		if _, ok := orm.members[member.ID]; !ok || orm.orgs[orgID].ID != orgID {
+	for _, rel := range memberRelations {
+		if _, ok := orm.members[rel.MemberID]; !ok || orm.orgs[rel.OrgID].ID != rel.OrgID {
 			return errors.ErrNotFound
 		}
-		orm.members[member.ID] = member
+		orm.members[rel.MemberID] = auth.Member{
+			ID:   rel.MemberID,
+			Role: rel.Role,
+		}
 	}
 
 	return nil

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -117,11 +117,11 @@ type Backup struct {
 // OrgService specifies an API that must be fullfiled by the domain service
 // implementation, and all of its decorators (e.g. logging & metrics).
 type OrgService interface {
-	// CreateOrg creates new  org.
-	CreateOrg(ctx context.Context, token string, g Org) (Org, error)
+	// CreateOrg creates new org.
+	CreateOrg(ctx context.Context, token string, org Org) (Org, error)
 
 	// UpdateOrg updates the org identified by the provided ID.
-	UpdateOrg(ctx context.Context, token string, g Org) (Org, error)
+	UpdateOrg(ctx context.Context, token string, org Org) (Org, error)
 
 	// ViewOrg retrieves data about the org identified by ID.
 	ViewOrg(ctx context.Context, token, id string) (Org, error)
@@ -171,11 +171,11 @@ type OrgService interface {
 
 // OrgRepository specifies an org persistence API.
 type OrgRepository interface {
-	// Save org
-	Save(ctx context.Context, g ...Org) error
+	// Save orgs
+	Save(ctx context.Context, orgs ...Org) error
 
 	// Update an org
-	Update(ctx context.Context, g Org) error
+	Update(ctx context.Context, org Org) error
 
 	// Delete an org
 	Delete(ctx context.Context, owner, id string) error
@@ -196,13 +196,13 @@ type OrgRepository interface {
 	RetrieveMemberships(ctx context.Context, memberID string, pm PageMetadata) (OrgsPage, error)
 
 	// AssignMembers adds members to an org.
-	AssignMembers(ctx context.Context, mr ...MemberRelation) error
+	AssignMembers(ctx context.Context, mrs ...MemberRelation) error
 
 	// UnassignMembers removes members from an org
 	UnassignMembers(ctx context.Context, orgID string, memberIDs ...string) error
 
 	// UpdateMembers updates members role in an org.
-	UpdateMembers(ctx context.Context, mr ...MemberRelation) error
+	UpdateMembers(ctx context.Context, mrs ...MemberRelation) error
 
 	// RetrieveRole retrieves role of member identified by memberID in org identified by orgID.
 	RetrieveRole(ctx context.Context, memberID, orgID string) (string, error)
@@ -214,7 +214,7 @@ type OrgRepository interface {
 	RetrieveAllMemberRelations(ctx context.Context) ([]MemberRelation, error)
 
 	// AssignGroups adds groups to an org.
-	AssignGroups(ctx context.Context, gr ...GroupRelation) error
+	AssignGroups(ctx context.Context, grs ...GroupRelation) error
 
 	// UnassignGroups removes groups from an org
 	UnassignGroups(ctx context.Context, orgID string, groupIDs ...string) error

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -199,7 +199,7 @@ type OrgRepository interface {
 	UnassignMembers(ctx context.Context, orgID string, memberIDs ...string) error
 
 	// UpdateMembers updates members role in an org.
-	UpdateMembers(ctx context.Context, orgID string, members ...Member) error
+	UpdateMembers(ctx context.Context, memberRelations ...MemberRelation) error
 
 	// RetrieveRole retrieves role of member identified by memberID in org identified by orgID.
 	RetrieveRole(ctx context.Context, memberID, orgID string) (string, error)

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -193,7 +193,7 @@ type OrgRepository interface {
 	RetrieveMemberships(ctx context.Context, memberID string, pm PageMetadata) (OrgsPage, error)
 
 	// AssignMembers adds members to an org.
-	AssignMembers(ctx context.Context, orgID string, members ...Member) error
+	AssignMembers(ctx context.Context, memberRelations ...MemberRelation) error
 
 	// UnassignMembers removes members from an org
 	UnassignMembers(ctx context.Context, orgID string, memberIDs ...string) error
@@ -211,7 +211,7 @@ type OrgRepository interface {
 	RetrieveAllMemberRelations(ctx context.Context) ([]MemberRelation, error)
 
 	// AssignGroups adds groups to an org.
-	AssignGroups(ctx context.Context, orgID string, groupIDs ...string) error
+	AssignGroups(ctx context.Context, groupRelations ...GroupRelation) error
 
 	// UnassignGroups removes groups from an org
 	UnassignGroups(ctx context.Context, orgID string, groupIDs ...string) error

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -193,13 +193,13 @@ type OrgRepository interface {
 	RetrieveMemberships(ctx context.Context, memberID string, pm PageMetadata) (OrgsPage, error)
 
 	// AssignMembers adds members to an org.
-	AssignMembers(ctx context.Context, memberRelations ...MemberRelation) error
+	AssignMembers(ctx context.Context, mr ...MemberRelation) error
 
 	// UnassignMembers removes members from an org
 	UnassignMembers(ctx context.Context, orgID string, memberIDs ...string) error
 
 	// UpdateMembers updates members role in an org.
-	UpdateMembers(ctx context.Context, memberRelations ...MemberRelation) error
+	UpdateMembers(ctx context.Context, mr ...MemberRelation) error
 
 	// RetrieveRole retrieves role of member identified by memberID in org identified by orgID.
 	RetrieveRole(ctx context.Context, memberID, orgID string) (string, error)
@@ -211,7 +211,7 @@ type OrgRepository interface {
 	RetrieveAllMemberRelations(ctx context.Context) ([]MemberRelation, error)
 
 	// AssignGroups adds groups to an org.
-	AssignGroups(ctx context.Context, groupRelations ...GroupRelation) error
+	AssignGroups(ctx context.Context, gr ...GroupRelation) error
 
 	// UnassignGroups removes groups from an org
 	UnassignGroups(ctx context.Context, orgID string, groupIDs ...string) error

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -491,12 +491,12 @@ func (or orgRepository) UnassignGroups(ctx context.Context, orgID string, groupI
 	qDel := `DELETE from group_relations WHERE org_id = :org_id AND group_id = :group_id`
 
 	for _, id := range groupIDs {
-		gRel := auth.GroupRelation{
+		gr := auth.GroupRelation{
 			OrgID:   orgID,
 			GroupID: id,
 		}
 
-		dbgr, err := toDBGroupRelation(gRel)
+		dbgr, err := toDBGroupRelation(gr)
 		if err != nil {
 			return errors.Wrap(auth.ErrAssignToOrg, err)
 		}

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -40,12 +40,12 @@ func NewOrgRepo(db Database) auth.OrgRepository {
 	}
 }
 
-func (or orgRepository) Save(ctx context.Context, g ...auth.Org) error {
+func (or orgRepository) Save(ctx context.Context, o ...auth.Org) error {
 	// For root org path is initialized with id
 	q := `INSERT INTO orgs (name, description, id, owner_id, metadata, created_at, updated_at)
 		  VALUES (:name, :description, :id, :owner_id, :metadata, :created_at, :updated_at)`
 
-	for _, org := range g {
+	for _, org := range o {
 		dbg, err := toDBOrg(org)
 		if err != nil {
 			return err
@@ -74,11 +74,11 @@ func (or orgRepository) Save(ctx context.Context, g ...auth.Org) error {
 	return nil
 }
 
-func (or orgRepository) Update(ctx context.Context, g auth.Org) error {
+func (or orgRepository) Update(ctx context.Context, o auth.Org) error {
 	q := `UPDATE orgs SET name = :name, description = :description, metadata = :metadata, updated_at = :updated_at WHERE id = :id
 		  RETURNING id, name, owner_id, description, metadata, created_at, updated_at`
 
-	dbu, err := toDBOrg(g)
+	dbu, err := toDBOrg(o)
 	if err != nil {
 		return errors.Wrap(errors.ErrUpdateEntity, err)
 	}

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -367,12 +367,12 @@ func (or orgRepository) UnassignMembers(ctx context.Context, orgID string, ids .
 	qDel := `DELETE from org_relations WHERE org_id = :org_id AND member_id = :member_id`
 
 	for _, id := range ids {
-		mRel := auth.MemberRelation{
+		mr := auth.MemberRelation{
 			OrgID:    orgID,
 			MemberID: id,
 		}
 
-		dbg, err := toDBMemberRelation(mRel)
+		dbg, err := toDBMemberRelation(mr)
 		if err != nil {
 			return errors.Wrap(auth.ErrAssignToOrg, err)
 		}
@@ -821,23 +821,23 @@ type dbMemberRelation struct {
 	UpdatedAt time.Time `db:"updated_at"`
 }
 
-func toDBMemberRelation(mRel auth.MemberRelation) (dbMemberRelation, error) {
+func toDBMemberRelation(mr auth.MemberRelation) (dbMemberRelation, error) {
 	return dbMemberRelation{
-		OrgID:     mRel.OrgID,
-		MemberID:  mRel.MemberID,
-		Role:      mRel.Role,
-		CreatedAt: mRel.CreatedAt,
-		UpdatedAt: mRel.UpdatedAt,
+		OrgID:     mr.OrgID,
+		MemberID:  mr.MemberID,
+		Role:      mr.Role,
+		CreatedAt: mr.CreatedAt,
+		UpdatedAt: mr.UpdatedAt,
 	}, nil
 }
 
-func toMemberRelation(mRel dbMemberRelation) auth.MemberRelation {
+func toMemberRelation(mr dbMemberRelation) auth.MemberRelation {
 	return auth.MemberRelation{
-		OrgID:     mRel.OrgID,
-		MemberID:  mRel.MemberID,
-		Role:      mRel.Role,
-		CreatedAt: mRel.CreatedAt,
-		UpdatedAt: mRel.UpdatedAt,
+		OrgID:     mr.OrgID,
+		MemberID:  mr.MemberID,
+		Role:      mr.Role,
+		CreatedAt: mr.CreatedAt,
+		UpdatedAt: mr.UpdatedAt,
 	}
 }
 
@@ -848,21 +848,21 @@ type dbGroupRelation struct {
 	UpdatedAt time.Time `db:"updated_at"`
 }
 
-func toDBGroupRelation(dRel auth.GroupRelation) (dbGroupRelation, error) {
+func toDBGroupRelation(gr auth.GroupRelation) (dbGroupRelation, error) {
 	return dbGroupRelation{
-		OrgID:     dRel.OrgID,
-		GroupID:   dRel.GroupID,
-		CreatedAt: dRel.CreatedAt,
-		UpdatedAt: dRel.UpdatedAt,
+		OrgID:     gr.OrgID,
+		GroupID:   gr.GroupID,
+		CreatedAt: gr.CreatedAt,
+		UpdatedAt: gr.UpdatedAt,
 	}, nil
 }
 
-func toGroupRelation(grRel dbGroupRelation) auth.GroupRelation {
+func toGroupRelation(gr dbGroupRelation) auth.GroupRelation {
 	return auth.GroupRelation{
-		OrgID:     grRel.OrgID,
-		GroupID:   grRel.GroupID,
-		CreatedAt: grRel.CreatedAt,
-		UpdatedAt: grRel.UpdatedAt,
+		OrgID:     gr.OrgID,
+		GroupID:   gr.GroupID,
+		CreatedAt: gr.CreatedAt,
+		UpdatedAt: gr.UpdatedAt,
 	}
 }
 

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -40,12 +40,12 @@ func NewOrgRepo(db Database) auth.OrgRepository {
 	}
 }
 
-func (or orgRepository) Save(ctx context.Context, o ...auth.Org) error {
+func (or orgRepository) Save(ctx context.Context, orgs ...auth.Org) error {
 	// For root org path is initialized with id
 	q := `INSERT INTO orgs (name, description, id, owner_id, metadata, created_at, updated_at)
 		  VALUES (:name, :description, :id, :owner_id, :metadata, :created_at, :updated_at)`
 
-	for _, org := range o {
+	for _, org := range orgs {
 		dbo, err := toDBOrg(org)
 		if err != nil {
 			return err
@@ -74,11 +74,11 @@ func (or orgRepository) Save(ctx context.Context, o ...auth.Org) error {
 	return nil
 }
 
-func (or orgRepository) Update(ctx context.Context, o auth.Org) error {
+func (or orgRepository) Update(ctx context.Context, org auth.Org) error {
 	q := `UPDATE orgs SET name = :name, description = :description, metadata = :metadata, updated_at = :updated_at WHERE id = :id
 		  RETURNING id, name, owner_id, description, metadata, created_at, updated_at`
 
-	dbo, err := toDBOrg(o)
+	dbo, err := toDBOrg(org)
 	if err != nil {
 		return errors.Wrap(errors.ErrUpdateEntity, err)
 	}

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -892,15 +892,10 @@ func TestUpdateMembers(t *testing.T) {
 	err = repo.Save(context.Background(), org)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	member := auth.Member{
-		ID:   memberID,
-		Role: auth.AdminRole,
-	}
-
 	memberRelation := auth.MemberRelation{
 		OrgID:     org.ID,
 		MemberID:  memberID,
-		Role:      auth.AdminRole,
+		Role:      auth.EditorRole,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	}
@@ -908,52 +903,86 @@ func TestUpdateMembers(t *testing.T) {
 	err = repo.AssignMembers(context.Background(), memberRelation)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
+	updateMrel := auth.MemberRelation{
+		OrgID:    org.ID,
+		MemberID: memberID,
+		Role:     auth.ViewerRole,
+	}
+
+	invalidOrgIDmRel := auth.MemberRelation{
+		OrgID:    invalidID,
+		MemberID: memberID,
+		Role:     auth.ViewerRole,
+	}
+
+	unknownOrgIDmRel := auth.MemberRelation{
+		OrgID:    unknownID,
+		MemberID: memberID,
+		Role:     auth.ViewerRole,
+	}
+
+	emptyOrgIDmRel := auth.MemberRelation{
+		OrgID:    "",
+		MemberID: memberID,
+		Role:     auth.ViewerRole,
+	}
+
+	invalidMemberIDmRel := auth.MemberRelation{
+		OrgID:    org.ID,
+		MemberID: invalidID,
+		Role:     auth.ViewerRole,
+	}
+
+	unknownMemberIDmRel := auth.MemberRelation{
+		OrgID:    org.ID,
+		MemberID: unknownID,
+		Role:     auth.ViewerRole,
+	}
+
+	emptyMemberIDmRel := auth.MemberRelation{
+		OrgID:    org.ID,
+		MemberID: "",
+		Role:     auth.ViewerRole,
+	}
+
 	cases := []struct {
-		desc   string
-		orgID  string
-		member auth.Member
-		err    error
+		desc           string
+		memberRelation auth.MemberRelation
+		err            error
 	}{
 		{
-			desc:   "update member role",
-			orgID:  org.ID,
-			member: member,
-			err:    nil,
+			desc:           "update member role",
+			memberRelation: updateMrel,
+			err:            nil,
 		}, {
-			desc:   "update role with invalid org id",
-			orgID:  invalidID,
-			member: member,
-			err:    errors.ErrMalformedEntity,
+			desc:           "update role with invalid org id",
+			memberRelation: invalidOrgIDmRel,
+			err:            errors.ErrMalformedEntity,
 		}, {
-			desc:   "update role with unknown org id",
-			orgID:  unknownID,
-			member: member,
-			err:    errors.ErrNotFound,
+			desc:           "update role with unknown org id",
+			memberRelation: unknownOrgIDmRel,
+			err:            errors.ErrNotFound,
 		}, {
-			desc:   "update role without org id",
-			orgID:  "",
-			member: member,
-			err:    errors.ErrMalformedEntity,
+			desc:           "update role without org id",
+			memberRelation: emptyOrgIDmRel,
+			err:            errors.ErrMalformedEntity,
 		}, {
-			desc:   "update role with invalid member id",
-			orgID:  org.ID,
-			member: auth.Member{ID: invalidID},
-			err:    errors.ErrMalformedEntity,
+			desc:           "update role with invalid member id",
+			memberRelation: invalidMemberIDmRel,
+			err:            errors.ErrMalformedEntity,
 		}, {
-			desc:   "update role with unknown member id",
-			orgID:  org.ID,
-			member: auth.Member{ID: unknownID},
-			err:    errors.ErrNotFound,
+			desc:           "update role with unknown member id",
+			memberRelation: unknownMemberIDmRel,
+			err:            errors.ErrNotFound,
 		}, {
-			desc:   "update role with empty member",
-			orgID:  org.ID,
-			member: auth.Member{},
-			err:    errors.ErrMalformedEntity,
+			desc:           "update role with empty member",
+			memberRelation: emptyMemberIDmRel,
+			err:            errors.ErrMalformedEntity,
 		},
 	}
 
 	for _, tc := range cases {
-		err := repo.UpdateMembers(context.Background(), tc.orgID, tc.member)
+		err := repo.UpdateMembers(context.Background(), tc.memberRelation)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/auth/postgres"
@@ -467,12 +468,6 @@ func TestRetrieveMemberships(t *testing.T) {
 	unknownID, err := idProvider.ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	member := auth.Member{
-		ID:    memberID,
-		Email: email,
-		Role:  auth.EditorRole,
-	}
-
 	for i := uint64(0); i < n; i++ {
 		orgID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -488,7 +483,15 @@ func TestRetrieveMemberships(t *testing.T) {
 		err = repo.Save(context.Background(), org)
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		err = repo.AssignMembers(context.Background(), orgID, member)
+		memberRelation := auth.MemberRelation{
+			OrgID:     orgID,
+			MemberID:  memberID,
+			Role:      auth.EditorRole,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+
+		err = repo.AssignMembers(context.Background(), memberRelation)
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	}
 
@@ -610,67 +613,85 @@ func TestAssignMembers(t *testing.T) {
 	err = repo.Save(context.Background(), org)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	var members []auth.Member
+	var memeberRelations []auth.MemberRelation
 	for i := uint64(0); i < n; i++ {
 		memberID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		email := fmt.Sprintf("member%d@email.com", i)
-		member := auth.Member{
-			ID:    memberID,
-			Email: email,
-			Role:  auth.EditorRole,
+		memeberRelation := auth.MemberRelation{
+			OrgID:     orgID,
+			MemberID:  memberID,
+			Role:      auth.EditorRole,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
 		}
 
-		members = append(members, member)
+		memeberRelations = append(memeberRelations, memeberRelation)
+	}
+
+	var invalidOrgIDmRel []auth.MemberRelation
+	for _, m := range memeberRelations {
+		m.OrgID = invalidID
+		invalidOrgIDmRel = append(invalidOrgIDmRel, m)
+	}
+
+	var emptyOrgIDmRel []auth.MemberRelation
+	for _, m := range memeberRelations {
+		m.OrgID = ""
+		emptyOrgIDmRel = append(emptyOrgIDmRel, m)
+	}
+
+	var noMemberIDmRel []auth.MemberRelation
+	for _, m := range memeberRelations {
+		m.MemberID = ""
+		noMemberIDmRel = append(noMemberIDmRel, m)
+	}
+
+	var invalidMemberIDmRel []auth.MemberRelation
+	for _, m := range memeberRelations {
+		m.MemberID = invalidID
+		invalidMemberIDmRel = append(invalidMemberIDmRel, m)
 	}
 
 	cases := []struct {
-		desc    string
-		orgID   string
-		members []auth.Member
-		err     error
+		desc            string
+		memberRelations []auth.MemberRelation
+		err             error
 	}{
 		{
-			desc:    "assign members to org",
-			orgID:   orgID,
-			members: members,
-			err:     nil,
+			desc:            "assign members to org",
+			memberRelations: memeberRelations,
+			err:             nil,
 		},
 		{
-			desc:    "assign already assigned members to org",
-			orgID:   orgID,
-			members: members,
-			err:     auth.ErrOrgMemberAlreadyAssigned,
+			desc:            "assign already assigned members to org",
+			memberRelations: memeberRelations,
+			err:             auth.ErrOrgMemberAlreadyAssigned,
 		},
 		{
-			desc:    "assign members to org with invalid org id",
-			orgID:   invalidID,
-			members: members,
-			err:     errors.ErrMalformedEntity,
+			desc:            "assign members to org with invalid org id",
+			memberRelations: invalidOrgIDmRel,
+			err:             errors.ErrMalformedEntity,
 		},
 		{
-			desc:    "assign members to org without org id",
-			orgID:   "",
-			members: members,
-			err:     errors.ErrMalformedEntity,
+			desc:            "assign members to org without org id",
+			memberRelations: emptyOrgIDmRel,
+			err:             errors.ErrMalformedEntity,
 		},
 		{
-			desc:    "assign members to org with empty members",
-			orgID:   orgID,
-			members: []auth.Member{},
-			err:     nil,
+			desc:            "assign members to org with empty member ids",
+			memberRelations: noMemberIDmRel,
+			err:             errors.ErrMalformedEntity,
 		},
 		{
-			desc:    "assign members to org with invalid member id",
-			orgID:   orgID,
-			members: []auth.Member{{ID: invalidID}},
-			err:     errors.ErrMalformedEntity,
+			desc:            "assign members to org with invalid member ids",
+			memberRelations: invalidMemberIDmRel,
+			err:             errors.ErrMalformedEntity,
 		},
 	}
 
 	for _, tc := range cases {
-		err := repo.AssignMembers(context.Background(), tc.orgID, tc.members...)
+		err := repo.AssignMembers(context.Background(), tc.memberRelations...)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }
@@ -695,24 +716,25 @@ func TestUnassignMembers(t *testing.T) {
 	err = repo.Save(context.Background(), org)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	var members []auth.Member
+	var memberRelations []auth.MemberRelation
 	var memberIDs []string
 	for i := uint64(0); i < n; i++ {
 		memberID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		email := fmt.Sprintf("member%d@email.com", i)
-		member := auth.Member{
-			ID:    memberID,
-			Email: email,
-			Role:  auth.ViewerRole,
+		memberRelation := auth.MemberRelation{
+			OrgID:     orgID,
+			MemberID:  memberID,
+			Role:      auth.EditorRole,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
 		}
 
-		members = append(members, member)
+		memberRelations = append(memberRelations, memberRelation)
 		memberIDs = append(memberIDs, memberID)
 	}
 
-	err = repo.AssignMembers(context.Background(), orgID, members...)
+	err = repo.AssignMembers(context.Background(), memberRelations...)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
@@ -786,12 +808,15 @@ func TestRetrieveRole(t *testing.T) {
 	err = repo.Save(context.Background(), org)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	member := auth.Member{
-		ID:   memberID,
-		Role: auth.AdminRole,
+	memberRelation := auth.MemberRelation{
+		OrgID:     org.ID,
+		MemberID:  memberID,
+		Role:      auth.AdminRole,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
 	}
 
-	err = repo.AssignMembers(context.Background(), org.ID, member)
+	err = repo.AssignMembers(context.Background(), memberRelation)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
@@ -872,7 +897,15 @@ func TestUpdateMembers(t *testing.T) {
 		Role: auth.AdminRole,
 	}
 
-	err = repo.AssignMembers(context.Background(), org.ID, member)
+	memberRelation := auth.MemberRelation{
+		OrgID:     org.ID,
+		MemberID:  memberID,
+		Role:      auth.AdminRole,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	err = repo.AssignMembers(context.Background(), memberRelation)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
@@ -947,22 +980,21 @@ func TestRetrieveMembers(t *testing.T) {
 	err = repo.Save(context.Background(), org)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	var members []auth.Member
+	var memberRelations []auth.MemberRelation
 	for i := uint64(0); i < n; i++ {
 		memberID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		email := fmt.Sprintf("member%d@email.com", i)
-		member := auth.Member{
-			ID:    memberID,
-			Email: email,
-			Role:  auth.EditorRole,
+		memberRelation := auth.MemberRelation{
+			OrgID:    orgID,
+			MemberID: memberID,
+			Role:     auth.EditorRole,
 		}
 
-		members = append(members, member)
+		memberRelations = append(memberRelations, memberRelation)
 	}
 
-	err = repo.AssignMembers(context.Background(), orgID, members...)
+	err = repo.AssignMembers(context.Background(), memberRelations...)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
@@ -1049,66 +1081,95 @@ func TestAssignGroups(t *testing.T) {
 	err = repo.Save(context.Background(), org)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	var groupIDs []string
+	var groupRelations []auth.GroupRelation
 	for i := uint64(0); i < n; i++ {
 		groupID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		groupIDs = append(groupIDs, groupID)
+		groupRelation := auth.GroupRelation{
+			OrgID:     orgID,
+			GroupID:   groupID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+
+		groupRelations = append(groupRelations, groupRelation)
+	}
+
+	var invalidOrgIDgRel []auth.GroupRelation
+	for _, g := range groupRelations {
+		g.OrgID = invalidID
+		invalidOrgIDgRel = append(invalidOrgIDgRel, g)
+	}
+
+	var emptyOrgIDgRel []auth.GroupRelation
+	for _, g := range groupRelations {
+		g.OrgID = ""
+		emptyOrgIDgRel = append(emptyOrgIDgRel, g)
+	}
+
+	var unknownOrgIDgRel []auth.GroupRelation
+	for _, g := range groupRelations {
+		g.OrgID = unknownID
+		unknownOrgIDgRel = append(unknownOrgIDgRel, g)
+	}
+
+	var emptyGroupIDgRel []auth.GroupRelation
+	for _, g := range groupRelations {
+		g.GroupID = ""
+		emptyGroupIDgRel = append(emptyGroupIDgRel, g)
+	}
+
+	var invalidGroupIDgRel []auth.GroupRelation
+	for _, g := range groupRelations {
+		g.GroupID = invalidID
+		invalidGroupIDgRel = append(invalidGroupIDgRel, g)
 	}
 
 	cases := []struct {
-		desc     string
-		orgID    string
-		groupIDs []string
-		err      error
+		desc           string
+		groupRelations []auth.GroupRelation
+		err            error
 	}{
 		{
-			desc:     "assign groups to org",
-			orgID:    orgID,
-			groupIDs: groupIDs,
-			err:      nil,
+			desc:           "assign groups to org",
+			groupRelations: groupRelations,
+			err:            nil,
 		},
 		{
-			desc:     "assign already assigned groups to org",
-			orgID:    orgID,
-			groupIDs: groupIDs,
-			err:      auth.ErrOrgMemberAlreadyAssigned,
+			desc:           "assign already assigned groups to org",
+			groupRelations: groupRelations,
+			err:            auth.ErrOrgMemberAlreadyAssigned,
 		},
 		{
-			desc:     "assign groups to org with invalid org id",
-			orgID:    invalidID,
-			groupIDs: groupIDs,
-			err:      errors.ErrMalformedEntity,
+			desc:           "assign groups to org with invalid org id",
+			groupRelations: invalidOrgIDgRel,
+			err:            errors.ErrMalformedEntity,
 		},
 		{
-			desc:     "assign groups to org without org id",
-			orgID:    "",
-			groupIDs: groupIDs,
-			err:      errors.ErrMalformedEntity,
+			desc:           "assign groups to org without org id",
+			groupRelations: emptyOrgIDgRel,
+			err:            errors.ErrMalformedEntity,
 		},
 		{
-			desc:     "assign groups to org with unknown org id",
-			orgID:    unknownID,
-			groupIDs: groupIDs,
-			err:      nil,
+			desc:           "assign groups to org with unknown org id",
+			groupRelations: unknownOrgIDgRel,
+			err:            nil,
 		},
 		{
-			desc:     "assign groups to org without group ids",
-			orgID:    orgID,
-			groupIDs: []string{},
-			err:      nil,
+			desc:           "assign groups to org without group ids",
+			groupRelations: emptyGroupIDgRel,
+			err:            errors.ErrMalformedEntity,
 		},
 		{
-			desc:     "assign groups to org with invalid group id",
-			orgID:    orgID,
-			groupIDs: []string{invalidID},
-			err:      errors.ErrMalformedEntity,
+			desc:           "assign groups to org with invalid group id",
+			groupRelations: invalidGroupIDgRel,
+			err:            errors.ErrMalformedEntity,
 		},
 	}
 
 	for _, tc := range cases {
-		err := repo.AssignGroups(context.Background(), tc.orgID, tc.groupIDs...)
+		err := repo.AssignGroups(context.Background(), tc.groupRelations...)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }
@@ -1135,15 +1196,22 @@ func TestUnassignGroups(t *testing.T) {
 	err = repo.Save(context.Background(), org)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
+	var groupRelations []auth.GroupRelation
 	var groupIDs []string
 	for i := uint64(0); i < n; i++ {
 		groupID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-
+		groupRelation := auth.GroupRelation{
+			OrgID:     orgID,
+			GroupID:   groupID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		groupRelations = append(groupRelations, groupRelation)
 		groupIDs = append(groupIDs, groupID)
 	}
 
-	err = repo.AssignGroups(context.Background(), orgID, groupIDs...)
+	err = repo.AssignGroups(context.Background(), groupRelations...)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
@@ -1225,14 +1293,23 @@ func TestRetrieveGroups(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	var groupIDs []string
+	var groupRelations []auth.GroupRelation
 	for i := uint64(0); i < n; i++ {
 		groupID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
+		groupRelation := auth.GroupRelation{
+			OrgID:     orgID,
+			GroupID:   groupID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+
 		groupIDs = append(groupIDs, groupID)
+		groupRelations = append(groupRelations, groupRelation)
 	}
 
-	err = repo.AssignGroups(context.Background(), orgID, groupIDs...)
+	err = repo.AssignGroups(context.Background(), groupRelations...)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
@@ -1328,7 +1405,13 @@ func TestRetrieveByGroupID(t *testing.T) {
 		err = repo.Save(context.Background(), org)
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		err = repo.AssignGroups(context.Background(), orgID, groupID)
+		groupRelation := auth.GroupRelation{
+			OrgID:     orgID,
+			GroupID:   groupID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		err = repo.AssignGroups(context.Background(), groupRelation)
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	}
 
@@ -1395,18 +1478,22 @@ func TestRetrieveAllMemberRelations(t *testing.T) {
 	err = repo.Save(context.Background(), org)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
+	var memberRelations []auth.MemberRelation
 	for i := uint64(0); i < n; i++ {
 		memberID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		member := auth.Member{
-			ID:   memberID,
-			Role: auth.EditorRole,
+		memberRelation := auth.MemberRelation{
+			OrgID:    org.ID,
+			MemberID: memberID,
+			Role:     auth.EditorRole,
 		}
 
-		err = repo.AssignMembers(context.Background(), org.ID, member)
-		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+		memberRelations = append(memberRelations, memberRelation)
 	}
+
+	err = repo.AssignMembers(context.Background(), memberRelations...)
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
 		desc string
@@ -1451,13 +1538,24 @@ func TestRetrieveAllGroupRelations(t *testing.T) {
 	err = repo.Save(context.Background(), org)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
+	var groupRelations []auth.GroupRelation
 	for i := uint64(0); i < n; i++ {
 		groupID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		err = repo.AssignGroups(context.Background(), org.ID, groupID)
-		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+		groupRelation := auth.GroupRelation{
+			OrgID:     org.ID,
+			GroupID:   groupID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+
+		groupRelations = append(groupRelations, groupRelation)
+
 	}
+
+	err = repo.AssignGroups(context.Background(), groupRelations...)
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
 		desc string

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -613,7 +613,7 @@ func TestAssignMembers(t *testing.T) {
 	err = repo.Save(context.Background(), org)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	var memeberRelations []auth.MemberRelation
+	var memberRelations []auth.MemberRelation
 	for i := uint64(0); i < n; i++ {
 		memberID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -626,29 +626,29 @@ func TestAssignMembers(t *testing.T) {
 			UpdatedAt: time.Now(),
 		}
 
-		memeberRelations = append(memeberRelations, memeberRelation)
+		memberRelations = append(memberRelations, memeberRelation)
 	}
 
 	var invalidOrgIDmRel []auth.MemberRelation
-	for _, m := range memeberRelations {
+	for _, m := range memberRelations {
 		m.OrgID = invalidID
 		invalidOrgIDmRel = append(invalidOrgIDmRel, m)
 	}
 
 	var emptyOrgIDmRel []auth.MemberRelation
-	for _, m := range memeberRelations {
+	for _, m := range memberRelations {
 		m.OrgID = ""
 		emptyOrgIDmRel = append(emptyOrgIDmRel, m)
 	}
 
 	var noMemberIDmRel []auth.MemberRelation
-	for _, m := range memeberRelations {
+	for _, m := range memberRelations {
 		m.MemberID = ""
 		noMemberIDmRel = append(noMemberIDmRel, m)
 	}
 
 	var invalidMemberIDmRel []auth.MemberRelation
-	for _, m := range memeberRelations {
+	for _, m := range memberRelations {
 		m.MemberID = invalidID
 		invalidMemberIDmRel = append(invalidMemberIDmRel, m)
 	}
@@ -660,12 +660,12 @@ func TestAssignMembers(t *testing.T) {
 	}{
 		{
 			desc:            "assign members to org",
-			memberRelations: memeberRelations,
+			memberRelations: memberRelations,
 			err:             nil,
 		},
 		{
 			desc:            "assign already assigned members to org",
-			memberRelations: memeberRelations,
+			memberRelations: memberRelations,
 			err:             auth.ErrOrgMemberAlreadyAssigned,
 		},
 		{

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -618,7 +618,7 @@ func TestAssignMembers(t *testing.T) {
 		memberID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		memeberRelation := auth.MemberRelation{
+		memberRelation := auth.MemberRelation{
 			OrgID:     orgID,
 			MemberID:  memberID,
 			Role:      auth.EditorRole,
@@ -626,7 +626,7 @@ func TestAssignMembers(t *testing.T) {
 			UpdatedAt: time.Now(),
 		}
 
-		memberRelations = append(memberRelations, memeberRelation)
+		memberRelations = append(memberRelations, memberRelation)
 	}
 
 	var invalidOrgIDmRel []auth.MemberRelation

--- a/auth/service.go
+++ b/auth/service.go
@@ -416,6 +416,7 @@ func (svc service) AssignMembers(ctx context.Context, token, orgID string, membe
 	}
 
 	timestamp := getTimestmap()
+	var mrs []MemberRelation
 	for _, m := range mbs {
 		mr := MemberRelation{
 			OrgID:     orgID,
@@ -425,9 +426,11 @@ func (svc service) AssignMembers(ctx context.Context, token, orgID string, membe
 			CreatedAt: timestamp,
 		}
 
-		if err := svc.orgs.AssignMembers(ctx, mr); err != nil {
-			return err
-		}
+		mrs = append(mrs, mr)
+	}
+
+	if err := svc.orgs.AssignMembers(ctx, mrs...); err != nil {
+		return err
 	}
 
 	return nil

--- a/auth/service.go
+++ b/auth/service.go
@@ -495,7 +495,19 @@ func (svc service) UpdateMembers(ctx context.Context, token, orgID string, membe
 
 	}
 
-	if err := svc.orgs.UpdateMembers(ctx, orgID, mbs...); err != nil {
+	var memberRelations []MemberRelation
+	for _, m := range mbs {
+		mRel := MemberRelation{
+			OrgID:     orgID,
+			MemberID:  m.ID,
+			Role:      m.Role,
+			UpdatedAt: getTimestmap(),
+		}
+
+		memberRelations = append(memberRelations, mRel)
+	}
+
+	if err := svc.orgs.UpdateMembers(ctx, memberRelations...); err != nil {
 		return err
 	}
 

--- a/auth/service.go
+++ b/auth/service.go
@@ -259,7 +259,7 @@ func (svc service) CreateOrg(ctx context.Context, token string, org Org) (Org, e
 		return Org{}, err
 	}
 
-	mRel := MemberRelation{
+	mr := MemberRelation{
 		OrgID:     id,
 		MemberID:  user.ID,
 		Role:      OwnerRole,
@@ -267,7 +267,7 @@ func (svc service) CreateOrg(ctx context.Context, token string, org Org) (Org, e
 		UpdatedAt: timestamp,
 	}
 
-	if err := svc.orgs.AssignMembers(ctx, mRel); err != nil {
+	if err := svc.orgs.AssignMembers(ctx, mr); err != nil {
 		return Org{}, err
 	}
 
@@ -413,7 +413,7 @@ func (svc service) AssignMembers(ctx context.Context, token, orgID string, membe
 
 	timestamp := getTimestmap()
 	for _, m := range mbs {
-		mRel := MemberRelation{
+		mr := MemberRelation{
 			OrgID:     orgID,
 			MemberID:  m.ID,
 			Role:      m.Role,
@@ -421,7 +421,7 @@ func (svc service) AssignMembers(ctx context.Context, token, orgID string, membe
 			CreatedAt: timestamp,
 		}
 
-		if err := svc.orgs.AssignMembers(ctx, mRel); err != nil {
+		if err := svc.orgs.AssignMembers(ctx, mr); err != nil {
 			return err
 		}
 	}
@@ -497,14 +497,14 @@ func (svc service) UpdateMembers(ctx context.Context, token, orgID string, membe
 
 	var memberRelations []MemberRelation
 	for _, m := range mbs {
-		mRel := MemberRelation{
+		mr := MemberRelation{
 			OrgID:     orgID,
 			MemberID:  m.ID,
 			Role:      m.Role,
 			UpdatedAt: getTimestmap(),
 		}
 
-		memberRelations = append(memberRelations, mRel)
+		memberRelations = append(memberRelations, mr)
 	}
 
 	if err := svc.orgs.UpdateMembers(ctx, memberRelations...); err != nil {
@@ -585,14 +585,14 @@ func (svc service) AssignGroups(ctx context.Context, token, orgID string, groupI
 
 	timestamp := getTimestmap()
 	for _, groupID := range groupIDs {
-		gRel := GroupRelation{
+		gr := GroupRelation{
 			OrgID:     orgID,
 			GroupID:   groupID,
 			CreatedAt: timestamp,
 			UpdatedAt: timestamp,
 		}
 
-		if err := svc.orgs.AssignGroups(ctx, gRel); err != nil {
+		if err := svc.orgs.AssignGroups(ctx, gr); err != nil {
 			return err
 		}
 

--- a/auth/service.go
+++ b/auth/service.go
@@ -584,18 +584,20 @@ func (svc service) AssignGroups(ctx context.Context, token, orgID string, groupI
 	}
 
 	timestamp := getTimestmap()
+	var gr []GroupRelation
 	for _, groupID := range groupIDs {
-		gr := GroupRelation{
+		g := GroupRelation{
 			OrgID:     orgID,
 			GroupID:   groupID,
 			CreatedAt: timestamp,
 			UpdatedAt: timestamp,
 		}
 
-		if err := svc.orgs.AssignGroups(ctx, gr); err != nil {
-			return err
-		}
+		gr = append(gr, g)
+	}
 
+	if err := svc.orgs.AssignGroups(ctx, gr...); err != nil {
+		return err
 	}
 
 	return nil

--- a/auth/tracing/orgs.go
+++ b/auth/tracing/orgs.go
@@ -102,12 +102,12 @@ func (orm orgRepositoryMiddleware) RetrieveMemberships(ctx context.Context, memb
 	return orm.repo.RetrieveMemberships(ctx, memberID, pm)
 }
 
-func (orm orgRepositoryMiddleware) AssignMembers(ctx context.Context, memeberRelations ...auth.MemberRelation) error {
+func (orm orgRepositoryMiddleware) AssignMembers(ctx context.Context, mr ...auth.MemberRelation) error {
 	span := createSpan(ctx, orm.tracer, assignOrgMembers)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.AssignMembers(ctx, memeberRelations...)
+	return orm.repo.AssignMembers(ctx, mr...)
 }
 
 func (orm orgRepositoryMiddleware) UnassignMembers(ctx context.Context, orgID string, memberIDs ...string) error {
@@ -118,12 +118,12 @@ func (orm orgRepositoryMiddleware) UnassignMembers(ctx context.Context, orgID st
 	return orm.repo.UnassignMembers(ctx, orgID, memberIDs...)
 }
 
-func (orm orgRepositoryMiddleware) UpdateMembers(ctx context.Context, memberRelations ...auth.MemberRelation) error {
+func (orm orgRepositoryMiddleware) UpdateMembers(ctx context.Context, mr ...auth.MemberRelation) error {
 	span := createSpan(ctx, orm.tracer, updateOrgMembers)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.UpdateMembers(ctx, memberRelations...)
+	return orm.repo.UpdateMembers(ctx, mr...)
 }
 
 func (orm orgRepositoryMiddleware) RetrieveRole(ctx context.Context, orgID, memberID string) (string, error) {
@@ -150,12 +150,12 @@ func (orm orgRepositoryMiddleware) RetrieveAllMemberRelations(ctx context.Contex
 	return orm.repo.RetrieveAllMemberRelations(ctx)
 }
 
-func (orm orgRepositoryMiddleware) AssignGroups(ctx context.Context, groupRelations ...auth.GroupRelation) error {
+func (orm orgRepositoryMiddleware) AssignGroups(ctx context.Context, gr ...auth.GroupRelation) error {
 	span := createSpan(ctx, orm.tracer, assignOrgGroups)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.AssignGroups(ctx, groupRelations...)
+	return orm.repo.AssignGroups(ctx, gr...)
 }
 
 func (orm orgRepositoryMiddleware) UnassignGroups(ctx context.Context, orgID string, groupIDs ...string) error {

--- a/auth/tracing/orgs.go
+++ b/auth/tracing/orgs.go
@@ -118,12 +118,12 @@ func (orm orgRepositoryMiddleware) UnassignMembers(ctx context.Context, orgID st
 	return orm.repo.UnassignMembers(ctx, orgID, memberIDs...)
 }
 
-func (orm orgRepositoryMiddleware) UpdateMembers(ctx context.Context, orgID string, members ...auth.Member) error {
+func (orm orgRepositoryMiddleware) UpdateMembers(ctx context.Context, memberRelations ...auth.MemberRelation) error {
 	span := createSpan(ctx, orm.tracer, updateOrgMembers)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.UpdateMembers(ctx, orgID, members...)
+	return orm.repo.UpdateMembers(ctx, memberRelations...)
 }
 
 func (orm orgRepositoryMiddleware) RetrieveRole(ctx context.Context, orgID, memberID string) (string, error) {

--- a/auth/tracing/orgs.go
+++ b/auth/tracing/orgs.go
@@ -102,12 +102,12 @@ func (orm orgRepositoryMiddleware) RetrieveMemberships(ctx context.Context, memb
 	return orm.repo.RetrieveMemberships(ctx, memberID, pm)
 }
 
-func (orm orgRepositoryMiddleware) AssignMembers(ctx context.Context, orgID string, members ...auth.Member) error {
+func (orm orgRepositoryMiddleware) AssignMembers(ctx context.Context, memeberRelations ...auth.MemberRelation) error {
 	span := createSpan(ctx, orm.tracer, assignOrgMembers)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.AssignMembers(ctx, orgID, members...)
+	return orm.repo.AssignMembers(ctx, memeberRelations...)
 }
 
 func (orm orgRepositoryMiddleware) UnassignMembers(ctx context.Context, orgID string, memberIDs ...string) error {
@@ -150,12 +150,12 @@ func (orm orgRepositoryMiddleware) RetrieveAllMemberRelations(ctx context.Contex
 	return orm.repo.RetrieveAllMemberRelations(ctx)
 }
 
-func (orm orgRepositoryMiddleware) AssignGroups(ctx context.Context, orgID string, groupIDs ...string) error {
+func (orm orgRepositoryMiddleware) AssignGroups(ctx context.Context, groupRelations ...auth.GroupRelation) error {
 	span := createSpan(ctx, orm.tracer, assignOrgGroups)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.AssignGroups(ctx, orgID, groupIDs...)
+	return orm.repo.AssignGroups(ctx, groupRelations...)
 }
 
 func (orm orgRepositoryMiddleware) UnassignGroups(ctx context.Context, orgID string, groupIDs ...string) error {

--- a/auth/tracing/orgs.go
+++ b/auth/tracing/orgs.go
@@ -46,20 +46,20 @@ func OrgRepositoryMiddleware(tracer opentracing.Tracer, gr auth.OrgRepository) a
 	}
 }
 
-func (orm orgRepositoryMiddleware) Save(ctx context.Context, g ...auth.Org) error {
+func (orm orgRepositoryMiddleware) Save(ctx context.Context, orgs ...auth.Org) error {
 	span := createSpan(ctx, orm.tracer, saveOrg)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.Save(ctx, g...)
+	return orm.repo.Save(ctx, orgs...)
 }
 
-func (orm orgRepositoryMiddleware) Update(ctx context.Context, g auth.Org) error {
+func (orm orgRepositoryMiddleware) Update(ctx context.Context, org auth.Org) error {
 	span := createSpan(ctx, orm.tracer, updateOrg)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.Update(ctx, g)
+	return orm.repo.Update(ctx, org)
 }
 
 func (orm orgRepositoryMiddleware) Delete(ctx context.Context, owner, orgID string) error {
@@ -110,12 +110,12 @@ func (orm orgRepositoryMiddleware) RetrieveMemberships(ctx context.Context, memb
 	return orm.repo.RetrieveMemberships(ctx, memberID, pm)
 }
 
-func (orm orgRepositoryMiddleware) AssignMembers(ctx context.Context, mr ...auth.MemberRelation) error {
+func (orm orgRepositoryMiddleware) AssignMembers(ctx context.Context, mrs ...auth.MemberRelation) error {
 	span := createSpan(ctx, orm.tracer, assignOrgMembers)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.AssignMembers(ctx, mr...)
+	return orm.repo.AssignMembers(ctx, mrs...)
 }
 
 func (orm orgRepositoryMiddleware) UnassignMembers(ctx context.Context, orgID string, memberIDs ...string) error {
@@ -126,12 +126,12 @@ func (orm orgRepositoryMiddleware) UnassignMembers(ctx context.Context, orgID st
 	return orm.repo.UnassignMembers(ctx, orgID, memberIDs...)
 }
 
-func (orm orgRepositoryMiddleware) UpdateMembers(ctx context.Context, mr ...auth.MemberRelation) error {
+func (orm orgRepositoryMiddleware) UpdateMembers(ctx context.Context, mrs ...auth.MemberRelation) error {
 	span := createSpan(ctx, orm.tracer, updateOrgMembers)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.UpdateMembers(ctx, mr...)
+	return orm.repo.UpdateMembers(ctx, mrs...)
 }
 
 func (orm orgRepositoryMiddleware) RetrieveRole(ctx context.Context, orgID, memberID string) (string, error) {
@@ -158,12 +158,12 @@ func (orm orgRepositoryMiddleware) RetrieveAllMemberRelations(ctx context.Contex
 	return orm.repo.RetrieveAllMemberRelations(ctx)
 }
 
-func (orm orgRepositoryMiddleware) AssignGroups(ctx context.Context, gr ...auth.GroupRelation) error {
+func (orm orgRepositoryMiddleware) AssignGroups(ctx context.Context, grs ...auth.GroupRelation) error {
 	span := createSpan(ctx, orm.tracer, assignOrgGroups)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.AssignGroups(ctx, gr...)
+	return orm.repo.AssignGroups(ctx, grs...)
 }
 
 func (orm orgRepositoryMiddleware) UnassignGroups(ctx context.Context, orgID string, groupIDs ...string) error {


### PR DESCRIPTION
Moved `created_at` and `updated_at` setting in `assignMembers` and `assignGroups`  from DB layer to service layer

resolves #172 
