### PR TITLE
MF-174 - Return group relations object in page instead of GroupIDs

### DIFF
--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -239,11 +239,11 @@ func (orm *orgRepositoryMock) RetrieveGroups(ctx context.Context, orgID string, 
 	defer orm.mu.Unlock()
 
 	i := uint64(0)
-	groups := []auth.GroupRelation{}
+	gr := []auth.GroupRelation{}
 	for _, group := range orm.groups {
 		if i >= pm.Offset && i < pm.Offset+pm.Limit {
 			if _, ok := orm.orgs[orgID]; ok {
-				groups = append(groups, auth.GroupRelation{
+				gr = append(gr, auth.GroupRelation{
 					OrgID:   orgID,
 					GroupID: group,
 				})
@@ -253,7 +253,7 @@ func (orm *orgRepositoryMock) RetrieveGroups(ctx context.Context, orgID string, 
 	}
 
 	return auth.GroupRelationsPage{
-		GroupRelations: groups,
+		GroupRelations: gr,
 		PageMetadata: auth.PageMetadata{
 			Total:  uint64(len(orm.groups)),
 			Offset: pm.Offset,

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -234,35 +234,32 @@ func (orm *orgRepositoryMock) UnassignGroups(ctx context.Context, orgID string, 
 	return nil
 }
 
-func (orm *orgRepositoryMock) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.OrgGroupsPage, error) {
+func (orm *orgRepositoryMock) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationPage, error) {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
 	i := uint64(0)
-	groups := []auth.Group{}
+	groups := []auth.GroupRelation{}
 	for _, group := range orm.groups {
 		if i >= pm.Offset && i < pm.Offset+pm.Limit {
 			if _, ok := orm.orgs[orgID]; ok {
-				groups = append(groups, auth.Group{ID: group})
+				groups = append(groups, auth.GroupRelation{
+					OrgID:   orgID,
+					GroupID: group,
+				})
 			}
 		}
 		i++
 	}
 
-	var groupIDs []string
-	for _, g := range groups {
-		groupIDs = append(groupIDs, g.ID)
-	}
-
-	return auth.OrgGroupsPage{
-		GroupIDs: groupIDs,
+	return auth.GroupRelationPage{
+		GroupRelations: groups,
 		PageMetadata: auth.PageMetadata{
-			Total:  uint64(len(groups)),
+			Total:  uint64(len(orm.groups)),
 			Offset: pm.Offset,
 			Limit:  pm.Limit,
 		},
 	}, nil
-
 }
 
 func (orm *orgRepositoryMock) RetrieveByGroupID(ctx context.Context, groupID string) (auth.OrgsPage, error) {

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -239,11 +239,11 @@ func (orm *orgRepositoryMock) RetrieveGroups(ctx context.Context, orgID string, 
 	defer orm.mu.Unlock()
 
 	i := uint64(0)
-	gr := []auth.GroupRelation{}
+	grs := []auth.GroupRelation{}
 	for _, group := range orm.groups {
 		if i >= pm.Offset && i < pm.Offset+pm.Limit {
 			if _, ok := orm.orgs[orgID]; ok {
-				gr = append(gr, auth.GroupRelation{
+				grs = append(grs, auth.GroupRelation{
 					OrgID:   orgID,
 					GroupID: group,
 				})
@@ -253,7 +253,7 @@ func (orm *orgRepositoryMock) RetrieveGroups(ctx context.Context, orgID string, 
 	}
 
 	return auth.GroupRelationsPage{
-		GroupRelations: gr,
+		GroupRelations: grs,
 		PageMetadata: auth.PageMetadata{
 			Total:  uint64(len(orm.groups)),
 			Offset: pm.Offset,

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -234,7 +234,7 @@ func (orm *orgRepositoryMock) UnassignGroups(ctx context.Context, orgID string, 
 	return nil
 }
 
-func (orm *orgRepositoryMock) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationPage, error) {
+func (orm *orgRepositoryMock) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationsPage, error) {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
@@ -252,7 +252,7 @@ func (orm *orgRepositoryMock) RetrieveGroups(ctx context.Context, orgID string, 
 		i++
 	}
 
-	return auth.GroupRelationPage{
+	return auth.GroupRelationsPage{
 		GroupRelations: groups,
 		PageMetadata: auth.PageMetadata{
 			Total:  uint64(len(orm.groups)),

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -87,10 +87,10 @@ type GroupsPage struct {
 	Groups []Group
 }
 
-type GroupRelationPage struct {
+type GroupRelationsPage struct {
 	PageMetadata
 	GroupRelations []GroupRelation
- }
+}
 
 type Member struct {
 	ID    string `json:"id"`
@@ -225,7 +225,7 @@ type OrgRepository interface {
 	UnassignGroups(ctx context.Context, orgID string, groupIDs ...string) error
 
 	// RetrieveGroups retrieves groups assigned to an org identified by orgID.
-	RetrieveGroups(ctx context.Context, orgID string, pm PageMetadata) (GroupRelationPage, error)
+	RetrieveGroups(ctx context.Context, orgID string, pm PageMetadata) (GroupRelationsPage, error)
 
 	// RetrieveByGroupID retrieves orgs where group is assigned.
 	RetrieveByGroupID(ctx context.Context, groupID string) (OrgsPage, error)

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -87,6 +87,11 @@ type GroupsPage struct {
 	Groups []Group
 }
 
+type GroupRelationPage struct {
+	PageMetadata
+	GroupRelations []GroupRelation
+ }
+
 type Member struct {
 	ID    string `json:"id"`
 	Role  string `json:"role"`
@@ -217,7 +222,7 @@ type OrgRepository interface {
 	UnassignGroups(ctx context.Context, orgID string, groupIDs ...string) error
 
 	// RetrieveGroups retrieves groups assigned to an org identified by orgID.
-	RetrieveGroups(ctx context.Context, orgID string, pm PageMetadata) (OrgGroupsPage, error)
+	RetrieveGroups(ctx context.Context, orgID string, pm PageMetadata) (GroupRelationPage, error)
 
 	// RetrieveByGroupID retrieves orgs where group is assigned.
 	RetrieveByGroupID(ctx context.Context, groupID string) (OrgsPage, error)

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -40,12 +40,12 @@ func NewOrgRepo(db Database) auth.OrgRepository {
 	}
 }
 
-func (or orgRepository) Save(ctx context.Context, g ...auth.Org) error {
+func (or orgRepository) Save(ctx context.Context, o ...auth.Org) error {
 	// For root org path is initialized with id
 	q := `INSERT INTO orgs (name, description, id, owner_id, metadata, created_at, updated_at)
 		  VALUES (:name, :description, :id, :owner_id, :metadata, :created_at, :updated_at)`
 
-	for _, org := range g {
+	for _, org := range o {
 		dbg, err := toDBOrg(org)
 		if err != nil {
 			return err
@@ -74,11 +74,11 @@ func (or orgRepository) Save(ctx context.Context, g ...auth.Org) error {
 	return nil
 }
 
-func (or orgRepository) Update(ctx context.Context, g auth.Org) error {
+func (or orgRepository) Update(ctx context.Context, o auth.Org) error {
 	q := `UPDATE orgs SET name = :name, description = :description, metadata = :metadata, updated_at = :updated_at WHERE id = :id
 		  RETURNING id, name, owner_id, description, metadata, created_at, updated_at`
 
-	dbu, err := toDBOrg(g)
+	dbu, err := toDBOrg(o)
 	if err != nil {
 		return errors.Wrap(errors.ErrUpdateEntity, err)
 	}

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -40,7 +40,7 @@ func NewOrgRepo(db Database) auth.OrgRepository {
 	}
 }
 
-func (gr orgRepository) Save(ctx context.Context, g ...auth.Org) error {
+func (or orgRepository) Save(ctx context.Context, g ...auth.Org) error {
 	// For root org path is initialized with id
 	q := `INSERT INTO orgs (name, description, id, owner_id, metadata, created_at, updated_at)
 		  VALUES (:name, :description, :id, :owner_id, :metadata, :created_at, :updated_at)`
@@ -51,7 +51,7 @@ func (gr orgRepository) Save(ctx context.Context, g ...auth.Org) error {
 			return err
 		}
 
-		_, err = gr.db.NamedExecContext(ctx, q, dbg)
+		_, err = or.db.NamedExecContext(ctx, q, dbg)
 		if err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {
@@ -74,7 +74,7 @@ func (gr orgRepository) Save(ctx context.Context, g ...auth.Org) error {
 	return nil
 }
 
-func (gr orgRepository) Update(ctx context.Context, g auth.Org) error {
+func (or orgRepository) Update(ctx context.Context, g auth.Org) error {
 	q := `UPDATE orgs SET name = :name, description = :description, metadata = :metadata, updated_at = :updated_at WHERE id = :id
 		  RETURNING id, name, owner_id, description, metadata, created_at, updated_at`
 
@@ -83,7 +83,7 @@ func (gr orgRepository) Update(ctx context.Context, g auth.Org) error {
 		return errors.Wrap(errors.ErrUpdateEntity, err)
 	}
 
-	row, err := gr.db.NamedQueryContext(ctx, q, dbu)
+	row, err := or.db.NamedQueryContext(ctx, q, dbu)
 	if err != nil {
 		pgErr, ok := err.(*pgconn.PgError)
 		if ok {
@@ -103,7 +103,7 @@ func (gr orgRepository) Update(ctx context.Context, g auth.Org) error {
 	return nil
 }
 
-func (gr orgRepository) Delete(ctx context.Context, owner, orgID string) error {
+func (or orgRepository) Delete(ctx context.Context, owner, orgID string) error {
 	qd := `DELETE FROM orgs WHERE id = :id AND owner_id = :owner_id;`
 	org := auth.Org{
 		ID:      orgID,
@@ -114,7 +114,7 @@ func (gr orgRepository) Delete(ctx context.Context, owner, orgID string) error {
 		return errors.Wrap(errors.ErrUpdateEntity, err)
 	}
 
-	res, err := gr.db.NamedExecContext(ctx, qd, dbg)
+	res, err := or.db.NamedExecContext(ctx, qd, dbg)
 	if err != nil {
 		pqErr, ok := err.(*pgconn.PgError)
 		if ok {
@@ -143,12 +143,12 @@ func (gr orgRepository) Delete(ctx context.Context, owner, orgID string) error {
 	return nil
 }
 
-func (gr orgRepository) RetrieveByID(ctx context.Context, id string) (auth.Org, error) {
+func (or orgRepository) RetrieveByID(ctx context.Context, id string) (auth.Org, error) {
 	dbu := dbOrg{
 		ID: id,
 	}
 	q := `SELECT id, name, owner_id, description, metadata, created_at, updated_at FROM orgs WHERE id = $1`
-	if err := gr.db.QueryRowxContext(ctx, q, id).StructScan(&dbu); err != nil {
+	if err := or.db.QueryRowxContext(ctx, q, id).StructScan(&dbu); err != nil {
 		if err == sql.ErrNoRows {
 			return auth.Org{}, errors.Wrap(errors.ErrNotFound, err)
 
@@ -158,16 +158,16 @@ func (gr orgRepository) RetrieveByID(ctx context.Context, id string) (auth.Org, 
 	return toOrg(dbu)
 }
 
-func (gr orgRepository) RetrieveByOwner(ctx context.Context, ownerID string, pm auth.PageMetadata) (auth.OrgsPage, error) {
+func (or orgRepository) RetrieveByOwner(ctx context.Context, ownerID string, pm auth.PageMetadata) (auth.OrgsPage, error) {
 	if ownerID == "" {
 		return auth.OrgsPage{}, errors.ErrRetrieveEntity
 	}
 
-	return gr.retrieve(ctx, ownerID, pm)
+	return or.retrieve(ctx, ownerID, pm)
 }
 
-func (gr orgRepository) RetrieveAll(ctx context.Context) ([]auth.Org, error) {
-	orPage, err := gr.retrieve(ctx, "", auth.PageMetadata{})
+func (or orgRepository) RetrieveAll(ctx context.Context) ([]auth.Org, error) {
+	orPage, err := or.retrieve(ctx, "", auth.PageMetadata{})
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (gr orgRepository) RetrieveAll(ctx context.Context) ([]auth.Org, error) {
 	return orPage.Orgs, nil
 }
 
-func (gr orgRepository) RetrieveMembers(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.OrgMembersPage, error) {
+func (or orgRepository) RetrieveMembers(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.OrgMembersPage, error) {
 	_, mq, err := getOrgsMetadataQuery("orgs", pm.Metadata)
 	if err != nil {
 		return auth.OrgMembersPage{}, errors.Wrap(auth.ErrFailedToRetrieveMembers, err)
@@ -189,7 +189,7 @@ func (gr orgRepository) RetrieveMembers(ctx context.Context, orgID string, pm au
 		return auth.OrgMembersPage{}, err
 	}
 
-	rows, err := gr.db.NamedQueryContext(ctx, q, params)
+	rows, err := or.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
 		return auth.OrgMembersPage{}, errors.Wrap(auth.ErrFailedToRetrieveMembers, err)
 	}
@@ -213,7 +213,7 @@ func (gr orgRepository) RetrieveMembers(ctx context.Context, orgID string, pm au
 	cq := fmt.Sprintf(`SELECT COUNT(*) FROM orgs o, org_relations ore
 					   WHERE ore.org_id = :org_id AND ore.org_id = o.id %s;`, mq)
 
-	total, err := total(ctx, gr.db, cq, params)
+	total, err := total(ctx, or.db, cq, params)
 	if err != nil {
 		return auth.OrgMembersPage{}, errors.Wrap(auth.ErrFailedToRetrieveMembers, err)
 	}
@@ -237,7 +237,7 @@ func toMember(dbmb dbMember) (auth.Member, error) {
 	}, nil
 }
 
-func (gr orgRepository) RetrieveMemberships(ctx context.Context, memberID string, pm auth.PageMetadata) (auth.OrgsPage, error) {
+func (or orgRepository) RetrieveMemberships(ctx context.Context, memberID string, pm auth.PageMetadata) (auth.OrgsPage, error) {
 	_, mq, err := getOrgsMetadataQuery("o", pm.Metadata)
 	if err != nil {
 		return auth.OrgsPage{}, errors.Wrap(auth.ErrFailedToRetrieveMembership, err)
@@ -263,7 +263,7 @@ func (gr orgRepository) RetrieveMemberships(ctx context.Context, memberID string
 		return auth.OrgsPage{}, err
 	}
 
-	rows, err := gr.db.NamedQueryContext(ctx, q, params)
+	rows, err := or.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
 		return auth.OrgsPage{}, errors.Wrap(auth.ErrFailedToRetrieveMembership, err)
 	}
@@ -285,7 +285,7 @@ func (gr orgRepository) RetrieveMemberships(ctx context.Context, memberID string
 	cq := fmt.Sprintf(`SELECT COUNT(*) FROM org_relations ore, orgs o
 		WHERE ore.org_id = o.id and ore.member_id = :member_id %s %s`, mq, nq)
 
-	total, err := total(ctx, gr.db, cq, params)
+	total, err := total(ctx, or.db, cq, params)
 	if err != nil {
 		return auth.OrgsPage{}, errors.Wrap(auth.ErrFailedToRetrieveMembership, err)
 	}
@@ -302,11 +302,11 @@ func (gr orgRepository) RetrieveMemberships(ctx context.Context, memberID string
 	return page, nil
 }
 
-func (gr orgRepository) RetrieveRole(ctx context.Context, memberID, orgID string) (string, error) {
+func (or orgRepository) RetrieveRole(ctx context.Context, memberID, orgID string) (string, error) {
 	q := `SELECT role FROM org_relations WHERE member_id = $1 AND org_id = $2`
 
 	member := auth.Member{}
-	if err := gr.db.QueryRowxContext(ctx, q, memberID, orgID).StructScan(&member); err != nil {
+	if err := or.db.QueryRowxContext(ctx, q, memberID, orgID).StructScan(&member); err != nil {
 		pgErr, ok := err.(*pgconn.PgError)
 		if err == sql.ErrNoRows || ok && pgerrcode.InvalidTextRepresentation == pgErr.Code {
 			return "", errors.Wrap(errors.ErrNotFound, err)
@@ -318,8 +318,8 @@ func (gr orgRepository) RetrieveRole(ctx context.Context, memberID, orgID string
 	return member.Role, nil
 }
 
-func (gr orgRepository) AssignMembers(ctx context.Context, orgID string, members ...auth.Member) error {
-	tx, err := gr.db.BeginTxx(ctx, nil)
+func (or orgRepository) AssignMembers(ctx context.Context, orgID string, members ...auth.Member) error {
+	tx, err := or.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(auth.ErrAssignToOrg, err)
 	}
@@ -362,8 +362,8 @@ func (gr orgRepository) AssignMembers(ctx context.Context, orgID string, members
 	return nil
 }
 
-func (gr orgRepository) UnassignMembers(ctx context.Context, orgID string, ids ...string) error {
-	tx, err := gr.db.BeginTxx(ctx, nil)
+func (or orgRepository) UnassignMembers(ctx context.Context, orgID string, ids ...string) error {
+	tx, err := or.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(auth.ErrAssignToOrg, err)
 	}
@@ -399,7 +399,7 @@ func (gr orgRepository) UnassignMembers(ctx context.Context, orgID string, ids .
 	return nil
 }
 
-func (gr orgRepository) UpdateMembers(ctx context.Context, orgID string, members ...auth.Member) error {
+func (or orgRepository) UpdateMembers(ctx context.Context, orgID string, members ...auth.Member) error {
 	qUpd := `UPDATE org_relations SET role = :role, updated_at = :updated_at
 			 WHERE org_id = :org_id AND member_id = :member_id`
 
@@ -410,7 +410,7 @@ func (gr orgRepository) UpdateMembers(ctx context.Context, orgID string, members
 		}
 		dbg.UpdatedAt = time.Now()
 
-		row, err := gr.db.NamedExecContext(ctx, qUpd, dbg)
+		row, err := or.db.NamedExecContext(ctx, qUpd, dbg)
 		if err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {
@@ -438,8 +438,8 @@ func (gr orgRepository) UpdateMembers(ctx context.Context, orgID string, members
 	return nil
 }
 
-func (gr orgRepository) AssignGroups(ctx context.Context, orgID string, groupIDs ...string) error {
-	tx, err := gr.db.BeginTxx(ctx, nil)
+func (or orgRepository) AssignGroups(ctx context.Context, orgID string, groupIDs ...string) error {
+	tx, err := or.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(auth.ErrAssignToOrg, err)
 	}
@@ -481,8 +481,8 @@ func (gr orgRepository) AssignGroups(ctx context.Context, orgID string, groupIDs
 	return nil
 }
 
-func (gr orgRepository) UnassignGroups(ctx context.Context, orgID string, groupIDs ...string) error {
-	tx, err := gr.db.BeginTxx(ctx, nil)
+func (or orgRepository) UnassignGroups(ctx context.Context, orgID string, groupIDs ...string) error {
+	tx, err := or.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(auth.ErrAssignToOrg, err)
 	}
@@ -518,7 +518,7 @@ func (gr orgRepository) UnassignGroups(ctx context.Context, orgID string, groupI
 	return nil
 }
 
-func (gr orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationPage, error) {
+func (or orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationPage, error) {
 	_, mq, err := getOrgsMetadataQuery("orgs", pm.Metadata)
 	if err != nil {
 		return auth.GroupRelationPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
@@ -532,7 +532,7 @@ func (gr orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm aut
 		return auth.GroupRelationPage{}, err
 	}
 
-	rows, err := gr.db.NamedQueryContext(ctx, q, params)
+	rows, err := or.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
 		return auth.GroupRelationPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
@@ -551,7 +551,7 @@ func (gr orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm aut
 	cq := fmt.Sprintf(`SELECT COUNT(*) FROM orgs o, group_relations gre
 					   WHERE gre.org_id = :org_id AND gre.org_id = o.id %s;`, mq)
 
-	total, err := total(ctx, gr.db, cq, params)
+	total, err := total(ctx, or.db, cq, params)
 	if err != nil {
 		return auth.GroupRelationPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
@@ -568,7 +568,7 @@ func (gr orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm aut
 	return page, nil
 }
 
-func (gr orgRepository) RetrieveByGroupID(ctx context.Context, groupID string) (auth.OrgsPage, error) {
+func (or orgRepository) RetrieveByGroupID(ctx context.Context, groupID string) (auth.OrgsPage, error) {
 	q := `SELECT o.id, o.owner_id, o.name, o.description, o.metadata
 		FROM group_relations gre, orgs o
 		WHERE gre.org_id = o.id and gre.group_id = :group_id;`
@@ -578,7 +578,7 @@ func (gr orgRepository) RetrieveByGroupID(ctx context.Context, groupID string) (
 		return auth.OrgsPage{}, err
 	}
 
-	rows, err := gr.db.NamedQueryContext(ctx, q, params)
+	rows, err := or.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
 		return auth.OrgsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
@@ -604,10 +604,10 @@ func (gr orgRepository) RetrieveByGroupID(ctx context.Context, groupID string) (
 	return page, nil
 }
 
-func (gr orgRepository) RetrieveAllMemberRelations(ctx context.Context) ([]auth.MemberRelation, error) {
+func (or orgRepository) RetrieveAllMemberRelations(ctx context.Context) ([]auth.MemberRelation, error) {
 	q := `SELECT org_id, member_id, role, created_at, updated_at FROM org_relations;`
 
-	rows, err := gr.db.NamedQueryContext(ctx, q, map[string]interface{}{})
+	rows, err := or.db.NamedQueryContext(ctx, q, map[string]interface{}{})
 	if err != nil {
 		return []auth.MemberRelation{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
@@ -626,10 +626,10 @@ func (gr orgRepository) RetrieveAllMemberRelations(ctx context.Context) ([]auth.
 	return memberRelations, nil
 }
 
-func (gr orgRepository) RetrieveAllGroupRelations(ctx context.Context) ([]auth.GroupRelation, error) {
+func (or orgRepository) RetrieveAllGroupRelations(ctx context.Context) ([]auth.GroupRelation, error) {
 	q := `SELECT org_id, group_id, created_at, updated_at FROM group_relations;`
 
-	rows, err := gr.db.NamedQueryContext(ctx, q, map[string]interface{}{})
+	rows, err := or.db.NamedQueryContext(ctx, q, map[string]interface{}{})
 	if err != nil {
 		return []auth.GroupRelation{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
@@ -648,7 +648,7 @@ func (gr orgRepository) RetrieveAllGroupRelations(ctx context.Context) ([]auth.G
 	return groupRelations, nil
 }
 
-func (gr orgRepository) retrieve(ctx context.Context, ownerID string, pm auth.PageMetadata) (auth.OrgsPage, error) {
+func (or orgRepository) retrieve(ctx context.Context, ownerID string, pm auth.PageMetadata) (auth.OrgsPage, error) {
 	var whereq string
 	if ownerID != "" {
 		whereq = "WHERE owner_id = :owner_id"
@@ -681,20 +681,20 @@ func (gr orgRepository) retrieve(ctx context.Context, ownerID string, pm auth.Pa
 		return auth.OrgsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
 
-	rows, err := gr.db.NamedQueryContext(ctx, q, dbPage)
+	rows, err := or.db.NamedQueryContext(ctx, q, dbPage)
 	if err != nil {
 		return auth.OrgsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
 	defer rows.Close()
 
-	items, err := gr.processRows(rows)
+	items, err := or.processRows(rows)
 	if err != nil {
 		return auth.OrgsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
 
 	cq := fmt.Sprintf("SELECT COUNT(*) FROM orgs %s;", whereq)
 
-	total, err := total(ctx, gr.db, cq, dbPage)
+	total, err := total(ctx, or.db, cq, dbPage)
 	if err != nil {
 		return auth.OrgsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
@@ -871,7 +871,7 @@ func getNameQuery(name string) string {
 	return nq
 }
 
-func (gr orgRepository) processRows(rows *sqlx.Rows) ([]auth.Org, error) {
+func (or orgRepository) processRows(rows *sqlx.Rows) ([]auth.Org, error) {
 	var items []auth.Org
 	for rows.Next() {
 		dbg := dbOrg{}

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -522,10 +522,10 @@ func (or orgRepository) UnassignGroups(ctx context.Context, orgID string, groupI
 	return nil
 }
 
-func (or orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationPage, error) {
+func (or orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationsPage, error) {
 	_, mq, err := getOrgsMetadataQuery("orgs", pm.Metadata)
 	if err != nil {
-		return auth.GroupRelationPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return auth.GroupRelationsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
 
 	q := fmt.Sprintf(`SELECT gre.group_id, gre.org_id, gre.created_at, gre.updated_at FROM group_relations gre
@@ -533,12 +533,12 @@ func (or orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm aut
 
 	params, err := toDBOrgMemberPage("", orgID, pm)
 	if err != nil {
-		return auth.GroupRelationPage{}, err
+		return auth.GroupRelationsPage{}, err
 	}
 
 	rows, err := or.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
-		return auth.GroupRelationPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return auth.GroupRelationsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
 	defer rows.Close()
 
@@ -546,7 +546,7 @@ func (or orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm aut
 	for rows.Next() {
 		dbgr := dbGroupRelation{}
 		if err := rows.StructScan(&dbgr); err != nil {
-			return auth.GroupRelationPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+			return auth.GroupRelationsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 		}
 
 		items = append(items, toGroupRelation(dbgr))
@@ -557,10 +557,10 @@ func (or orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm aut
 
 	total, err := total(ctx, or.db, cq, params)
 	if err != nil {
-		return auth.GroupRelationPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return auth.GroupRelationsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
 
-	page := auth.GroupRelationPage{
+	page := auth.GroupRelationsPage{
 		GroupRelations: items,
 		PageMetadata: auth.PageMetadata{
 			Total:  total,

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -1293,11 +1293,10 @@ func TestRetrieveGroups(t *testing.T) {
 		},
 	}
 
-	for desc, tc := range cases {
+	for _, tc := range cases {
 		page, err := repo.RetrieveGroups(context.Background(), tc.orgID, tc.pageMetadata)
-		size := len(page.GroupIDs)
-		assert.Equal(t, tc.pageMetadata.Total, uint64(size), fmt.Sprintf("%v: expected size %v got %v\n", desc, tc.pageMetadata.Total, size))
-		assert.Equal(t, tc.groupIDs, page.GroupIDs, fmt.Sprintf("%v: expected size %v got %v\n", desc, tc.groupIDs, page.GroupIDs))
+		size := len(page.GroupRelations)
+		assert.Equal(t, tc.pageMetadata.Total, uint64(size), fmt.Sprintf("%v: expected size %v got %v\n", tc.desc, tc.pageMetadata.Total, size))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }

--- a/auth/service.go
+++ b/auth/service.go
@@ -309,7 +309,12 @@ func (svc service) RemoveOrg(ctx context.Context, token, id string) error {
 		return err
 	}
 
-	if err := svc.orgs.UnassignGroups(ctx, id, gPage.GroupIDs...); err != nil {
+	var groupIDs []string
+	for _, g := range gPage.GroupRelations {
+		groupIDs = append(groupIDs, g.GroupID)
+	}
+
+	if err := svc.orgs.UnassignGroups(ctx, id, groupIDs...); err != nil {
 		return err
 	}
 
@@ -596,9 +601,14 @@ func (svc service) ListOrgGroups(ctx context.Context, token string, orgID string
 		return GroupsPage{}, errors.Wrap(ErrFailedToRetrieveMembers, err)
 	}
 
+	var groupIDs []string
+	for _, g := range mp.GroupRelations {
+		groupIDs = append(groupIDs, g.GroupID)
+	}
+
 	var groups []Group
-	if len(mp.GroupIDs) > 0 {
-		greq := mainflux.GroupsReq{Ids: mp.GroupIDs}
+	if len(groupIDs) > 0 {
+		greq := mainflux.GroupsReq{Ids: groupIDs}
 		resp, err := svc.things.GetGroupsByIDs(ctx, &greq)
 		if err != nil {
 			return GroupsPage{}, err

--- a/auth/tracing/orgs.go
+++ b/auth/tracing/orgs.go
@@ -166,7 +166,7 @@ func (orm orgRepositoryMiddleware) UnassignGroups(ctx context.Context, orgID str
 	return orm.repo.UnassignGroups(ctx, orgID, groupIDs...)
 }
 
-func (orm orgRepositoryMiddleware) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.OrgGroupsPage, error) {
+func (orm orgRepositoryMiddleware) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationPage, error) {
 	span := createSpan(ctx, orm.tracer, retrieveGroups)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)

--- a/auth/tracing/orgs.go
+++ b/auth/tracing/orgs.go
@@ -174,7 +174,7 @@ func (orm orgRepositoryMiddleware) UnassignGroups(ctx context.Context, orgID str
 	return orm.repo.UnassignGroups(ctx, orgID, groupIDs...)
 }
 
-func (orm orgRepositoryMiddleware) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationPage, error) {
+func (orm orgRepositoryMiddleware) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationsPage, error) {
 	span := createSpan(ctx, orm.tracer, retrieveGroups)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)


### PR DESCRIPTION
Returned group relations object in page instead of `GroupIDs`

Resolves #174 