### PR TITLE
MF-175 - Add pagemetadata to RetrieveByGroupID in orgs DB layer

### DIFF
--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -279,9 +279,7 @@ func (orm *orgRepositoryMock) RetrieveByGroupID(ctx context.Context, groupID str
 	return auth.OrgsPage{
 		Orgs: orgs,
 		PageMetadata: auth.PageMetadata{
-			Total:  uint64(len(orgs)),
-			Offset: 0,
-			Limit:  uint64(len(orgs)),
+			Total: uint64(len(orm.orgs)),
 		},
 	}, nil
 }

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -601,13 +601,23 @@ func (gr orgRepository) RetrieveByGroupID(ctx context.Context, groupID string) (
 		items = append(items, gr)
 	}
 
+	cq := `SELECT COUNT(*) FROM group_relations gre, orgs o
+		WHERE gre.org_id = o.id and gre.group_id = :group_id;`
+
+	total, err := total(ctx, gr.db, cq, params)
+	if err != nil {
+		return auth.OrgsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+	}
+
 	page := auth.OrgsPage{
 		Orgs: items,
+		PageMetadata: auth.PageMetadata{
+			Total: total,
+		},
 	}
 
 	return page, nil
 }
-
 func (gr orgRepository) RetrieveAllMemberRelations(ctx context.Context) ([]auth.MemberRelation, error) {
 	q := `SELECT org_id, member_id, role, created_at, updated_at FROM org_relations;`
 

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -618,6 +618,7 @@ func (gr orgRepository) RetrieveByGroupID(ctx context.Context, groupID string) (
 
 	return page, nil
 }
+
 func (gr orgRepository) RetrieveAllMemberRelations(ctx context.Context) ([]auth.MemberRelation, error) {
 	q := `SELECT org_id, member_id, role, created_at, updated_at FROM org_relations;`
 

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -1333,34 +1333,47 @@ func TestRetrieveByGroupID(t *testing.T) {
 	}
 
 	cases := []struct {
-		desc    string
-		groupID string
-		size    uint64
-		err     error
+		desc         string
+		groupID      string
+		pageMetadata auth.PageMetadata
+		size         uint64
+		err          error
 	}{
 		{
 			desc:    "retrieve orgs by group",
 			groupID: groupID,
-			size:    n,
-			err:     nil,
+			pageMetadata: auth.PageMetadata{
+				Total: n,
+			},
+			size: n,
+			err:  nil,
 		},
 		{
 			desc:    "retrieve orgs by invalid group id",
 			groupID: invalidID,
-			size:    0,
-			err:     errors.ErrRetrieveEntity,
+			pageMetadata: auth.PageMetadata{
+				Total: 0,
+			},
+			size: 0,
+			err:  errors.ErrRetrieveEntity,
 		},
 		{
 			desc:    "retrieve orgs by empty group id",
 			groupID: "",
-			size:    0,
-			err:     errors.ErrRetrieveEntity,
+			pageMetadata: auth.PageMetadata{
+				Total: 0,
+			},
+			size: 0,
+			err:  errors.ErrRetrieveEntity,
 		},
 		{
 			desc:    "retrieve orgs by unknown group id",
 			groupID: unknownID,
-			size:    0,
-			err:     nil,
+			pageMetadata: auth.PageMetadata{
+				Total: 0,
+			},
+			size: 0,
+			err:  nil,
 		},
 	}
 
@@ -1368,6 +1381,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 		page, err := repo.RetrieveByGroupID(context.Background(), tc.groupID)
 		size := len(page.Orgs)
 		assert.Equal(t, tc.size, uint64(size), fmt.Sprintf("%v: expected size %v got %v\n", desc, tc.size, size))
+		assert.Equal(t, tc.pageMetadata.Total, page.Total, fmt.Sprintf("%v: expected size %v got %v\n", desc, tc.pageMetadata.Total, page.Total))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -1333,34 +1333,34 @@ func TestRetrieveByGroupID(t *testing.T) {
 	}
 
 	cases := []struct {
-		desc         string
-		groupID      string
-		size         uint64
-		err          error
+		desc    string
+		groupID string
+		size    uint64
+		err     error
 	}{
 		{
 			desc:    "retrieve orgs by group",
 			groupID: groupID,
-			size: n,
-			err:  nil,
+			size:    n,
+			err:     nil,
 		},
 		{
 			desc:    "retrieve orgs by invalid group id",
 			groupID: invalidID,
-			size: 0,
-			err:  errors.ErrRetrieveEntity,
+			size:    0,
+			err:     errors.ErrRetrieveEntity,
 		},
 		{
 			desc:    "retrieve orgs by empty group id",
 			groupID: "",
-			size: 0,
-			err:  errors.ErrRetrieveEntity,
+			size:    0,
+			err:     errors.ErrRetrieveEntity,
 		},
 		{
 			desc:    "retrieve orgs by unknown group id",
 			groupID: unknownID,
-			size: 0,
-			err:  nil,
+			size:    0,
+			err:     nil,
 		},
 	}
 

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -1335,43 +1335,30 @@ func TestRetrieveByGroupID(t *testing.T) {
 	cases := []struct {
 		desc         string
 		groupID      string
-		pageMetadata auth.PageMetadata
 		size         uint64
 		err          error
 	}{
 		{
 			desc:    "retrieve orgs by group",
 			groupID: groupID,
-			pageMetadata: auth.PageMetadata{
-				Total: n,
-			},
 			size: n,
 			err:  nil,
 		},
 		{
 			desc:    "retrieve orgs by invalid group id",
 			groupID: invalidID,
-			pageMetadata: auth.PageMetadata{
-				Total: 0,
-			},
 			size: 0,
 			err:  errors.ErrRetrieveEntity,
 		},
 		{
 			desc:    "retrieve orgs by empty group id",
 			groupID: "",
-			pageMetadata: auth.PageMetadata{
-				Total: 0,
-			},
 			size: 0,
 			err:  errors.ErrRetrieveEntity,
 		},
 		{
 			desc:    "retrieve orgs by unknown group id",
 			groupID: unknownID,
-			pageMetadata: auth.PageMetadata{
-				Total: 0,
-			},
 			size: 0,
 			err:  nil,
 		},
@@ -1381,7 +1368,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 		page, err := repo.RetrieveByGroupID(context.Background(), tc.groupID)
 		size := len(page.Orgs)
 		assert.Equal(t, tc.size, uint64(size), fmt.Sprintf("%v: expected size %v got %v\n", desc, tc.size, size))
-		assert.Equal(t, tc.pageMetadata.Total, page.Total, fmt.Sprintf("%v: expected size %v got %v\n", desc, tc.pageMetadata.Total, page.Total))
+		assert.Equal(t, tc.size, page.Total, fmt.Sprintf("%v: expected size %v got %v\n", desc, tc.size, page.Total))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }


### PR DESCRIPTION
Added total count to `orgsPage`  metadata.

Resolves #175 
