### PR TITLE
MF-178 Add group per org in RetrieveByGroupID DB method

### DIFF
--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -265,23 +265,22 @@ func (orm *orgRepositoryMock) RetrieveGroups(ctx context.Context, orgID string, 
 
 }
 
-func (orm *orgRepositoryMock) RetrieveByGroupID(ctx context.Context, groupID string) (auth.OrgsPage, error) {
+func (orm *orgRepositoryMock) RetrieveByGroupID(ctx context.Context, groupID string) (auth.Org, error) {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	orgs := []auth.Org{}
-	for _, org := range orm.orgs {
+	org := auth.Org{}
+	for _, g := range orm.orgs {
 		if _, ok := orm.groups[groupID]; ok {
-			orgs = append(orgs, org)
+			org = g
 		}
 	}
 
-	return auth.OrgsPage{
-		Orgs: orgs,
-		PageMetadata: auth.PageMetadata{
-			Total: uint64(len(orm.orgs)),
-		},
-	}, nil
+	if org.ID == "" {
+		return auth.Org{}, errors.ErrNotFound
+	}
+
+	return org, nil
 }
 
 func (orm *orgRepositoryMock) RetrieveAll(ctx context.Context) ([]auth.Org, error) {

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -270,11 +270,12 @@ func (orm *orgRepositoryMock) RetrieveByGroupID(ctx context.Context, groupID str
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	if orgID, ok := orm.groups[groupID]; ok {
-		return orm.orgs[orgID], nil
+	orgID, ok := orm.groups[groupID]
+	if !ok {
+		return auth.Org{}, errors.ErrNotFound
 	}
 
-	return auth.Org{}, errors.ErrNotFound
+	return orm.orgs[orgID], nil
 }
 
 func (orm *orgRepositoryMock) RetrieveAll(ctx context.Context) ([]auth.Org, error) {

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -269,18 +269,11 @@ func (orm *orgRepositoryMock) RetrieveByGroupID(ctx context.Context, groupID str
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	org := auth.Org{}
-	for _, g := range orm.orgs {
-		if _, ok := orm.groups[groupID]; ok {
-			org = g
-		}
+	if orgID, ok := orm.groups[groupID]; ok {
+		return orm.orgs[orgID], nil
 	}
 
-	if org.ID == "" {
-		return auth.Org{}, errors.ErrNotFound
-	}
-
-	return org, nil
+	return auth.Org{}, errors.ErrNotFound
 }
 
 func (orm *orgRepositoryMock) RetrieveAll(ctx context.Context) ([]auth.Org, error) {

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -277,12 +277,12 @@ func (orm *orgRepositoryMock) RetrieveByGroupID(ctx context.Context, groupID str
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	orgID, ok := orm.groups[groupID]
+	org, ok := orm.groups[groupID]
 	if !ok {
 		return auth.Org{}, errors.ErrNotFound
 	}
 
-	return orm.orgs[orgID.ID], nil
+	return orm.orgs[org.ID], nil
 }
 
 func (orm *orgRepositoryMock) RetrieveAll(ctx context.Context) ([]auth.Org, error) {

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -70,11 +70,12 @@ func (orm *orgRepositoryMock) RetrieveByID(ctx context.Context, id string) (auth
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	if org, ok := orm.orgs[id]; ok {
-		return org, nil
+	org, ok := orm.orgs[id]
+	if !ok {
+		return auth.Org{}, errors.ErrNotFound
 	}
 
-	return auth.Org{}, errors.ErrNotFound
+	return org, nil
 }
 
 func (orm *orgRepositoryMock) RetrieveByOwner(ctx context.Context, ownerID string, pm auth.PageMetadata) (auth.OrgsPage, error) {

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -18,6 +18,9 @@ var (
 
 	// ErrOrgMemberAlreadyAssigned indicates that members is already assigned.
 	ErrOrgMemberAlreadyAssigned = errors.New("org member is already assigned")
+
+	// ErrOrgGgroupAlreadyAssigned indicates that group is already assigned.
+	ErrOrgGgroupAlreadyAssigned = errors.New("org group is already assigned")
 )
 
 // OrgMetadata defines the Metadata type.

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -219,8 +219,8 @@ type OrgRepository interface {
 	// RetrieveGroups retrieves groups assigned to an org identified by orgID.
 	RetrieveGroups(ctx context.Context, orgID string, pm PageMetadata) (OrgGroupsPage, error)
 
-	// RetrieveByGroupID retrieves orgs where group is assigned.
-	RetrieveByGroupID(ctx context.Context, groupID string) (OrgsPage, error)
+	// RetrieveByGroupID retrieves org where group is assigned.
+	RetrieveByGroupID(ctx context.Context, groupID string) (Org, error)
 
 	// RetrieveAllGroupRelations retrieves all group relations.
 	RetrieveAllGroupRelations(ctx context.Context) ([]GroupRelation, error)

--- a/auth/postgres/init.go
+++ b/auth/postgres/init.go
@@ -92,7 +92,7 @@ func migrateDB(db *sqlx.DB) error {
 				Id: "auth_3",
 				Up: []string{
 					`CREATE TABLE IF NOT EXISTS group_relations (
-							group_id    UUID NOT NULL,
+							group_id    UUID UNIQUE NOT NULL,
 							org_id      UUID NOT NULL,
 							created_at  TIMESTAMPTZ,
 							updated_at  TIMESTAMPTZ,

--- a/auth/postgres/init.go
+++ b/auth/postgres/init.go
@@ -92,10 +92,11 @@ func migrateDB(db *sqlx.DB) error {
 				Id: "auth_3",
 				Up: []string{
 					`CREATE TABLE IF NOT EXISTS group_relations (
-							group_id    UUID NOT NULL,
+							group_id    UUID NOT NULL UNIQUE,
 							org_id      UUID NOT NULL,
 							created_at  TIMESTAMPTZ,
 							updated_at  TIMESTAMPTZ,
+							FOREIGN KEY (org_id) REFERENCES orgs (id),
 							PRIMARY KEY (group_id, org_id)
 						 )`,
 				},

--- a/auth/postgres/init.go
+++ b/auth/postgres/init.go
@@ -92,7 +92,7 @@ func migrateDB(db *sqlx.DB) error {
 				Id: "auth_3",
 				Up: []string{
 					`CREATE TABLE IF NOT EXISTS group_relations (
-							group_id    UUID NOT NULL UNIQUE,
+							group_id    UUID NOT NULL,
 							org_id      UUID NOT NULL,
 							created_at  TIMESTAMPTZ,
 							updated_at  TIMESTAMPTZ,

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -470,7 +470,7 @@ func (gr orgRepository) AssignGroups(ctx context.Context, orgID string, groupIDs
 				case pgerrcode.ForeignKeyViolation:
 					return errors.Wrap(errors.ErrConflict, errors.New(pgErr.Detail))
 				case pgerrcode.UniqueViolation:
-					return errors.Wrap(auth.ErrOrgMemberAlreadyAssigned, errors.New(pgErr.Detail))
+					return errors.Wrap(auth.ErrOrgGgroupAlreadyAssigned, errors.New(pgErr.Detail))
 				}
 			}
 

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -1073,7 +1073,7 @@ func TestAssignGroups(t *testing.T) {
 			desc:     "assign already assigned groups to org",
 			orgID:    orgID,
 			groupIDs: groupIDs,
-			err:      auth.ErrOrgMemberAlreadyAssigned,
+			err:      auth.ErrOrgGgroupAlreadyAssigned,
 		},
 		{
 			desc:     "assign groups to org with invalid org id",
@@ -1091,7 +1091,7 @@ func TestAssignGroups(t *testing.T) {
 			desc:     "assign groups to org with unknown org id",
 			orgID:    unknownID,
 			groupIDs: groupIDs,
-			err:      nil,
+			err:      auth.ErrOrgGgroupAlreadyAssigned,
 		},
 		{
 			desc:     "assign groups to org without group ids",
@@ -1337,25 +1337,25 @@ func TestRetrieveByGroupID(t *testing.T) {
 		err     error
 	}{
 		{
-			desc:    "retrieve orgs by group",
+			desc:    "retrieve org by group",
 			groupID: groupID,
 			org:     org,
 			err:     nil,
 		},
 		{
-			desc:    "retrieve orgs by invalid group id",
+			desc:    "retrieve org by invalid group id",
 			groupID: invalidID,
 			org:     auth.Org{},
 			err:     errors.ErrRetrieveEntity,
 		},
 		{
-			desc:    "retrieve orgs by empty group id",
+			desc:    "retrieve org by empty group id",
 			groupID: "",
 			org:     auth.Org{},
 			err:     errors.ErrRetrieveEntity,
 		},
 		{
-			desc:    "retrieve orgs by unknown group id",
+			desc:    "retrieve org by unknown group id",
 			groupID: unknownID,
 			org:     auth.Org{},
 			err:     nil,

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -1313,62 +1313,58 @@ func TestRetrieveByGroupID(t *testing.T) {
 	unknownID, err := idProvider.ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	for i := uint64(0); i < n; i++ {
-		orgID, err := idProvider.ID()
-		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	orgID, err := idProvider.ID()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		org := auth.Org{
-			ID:          orgID,
-			OwnerID:     ownerID,
-			Name:        orgName,
-			Description: orgDesc,
-			Metadata:    map[string]interface{}{"key": "value"},
-		}
-
-		err = repo.Save(context.Background(), org)
-		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-
-		err = repo.AssignGroups(context.Background(), orgID, groupID)
-		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	org := auth.Org{
+		ID:          orgID,
+		OwnerID:     ownerID,
+		Name:        orgName,
+		Description: orgDesc,
+		Metadata:    map[string]interface{}{"key": "value"},
 	}
+
+	err = repo.Save(context.Background(), org)
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	err = repo.AssignGroups(context.Background(), orgID, groupID)
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
 		desc    string
 		groupID string
-		size    uint64
+		org     auth.Org
 		err     error
 	}{
 		{
 			desc:    "retrieve orgs by group",
 			groupID: groupID,
-			size:    n,
+			org:     org,
 			err:     nil,
 		},
 		{
 			desc:    "retrieve orgs by invalid group id",
 			groupID: invalidID,
-			size:    0,
+			org:     auth.Org{},
 			err:     errors.ErrRetrieveEntity,
 		},
 		{
 			desc:    "retrieve orgs by empty group id",
 			groupID: "",
-			size:    0,
+			org:     auth.Org{},
 			err:     errors.ErrRetrieveEntity,
 		},
 		{
 			desc:    "retrieve orgs by unknown group id",
 			groupID: unknownID,
-			size:    0,
+			org:     auth.Org{},
 			err:     nil,
 		},
 	}
 
-	for desc, tc := range cases {
-		page, err := repo.RetrieveByGroupID(context.Background(), tc.groupID)
-		size := len(page.Orgs)
-		assert.Equal(t, tc.size, uint64(size), fmt.Sprintf("%v: expected size %v got %v\n", desc, tc.size, size))
-		assert.Equal(t, tc.size, page.Total, fmt.Sprintf("%v: expected size %v got %v\n", desc, tc.size, page.Total))
+	for _, tc := range cases {
+		or, err := repo.RetrieveByGroupID(context.Background(), tc.groupID)
+		assert.Equal(t, tc.org, or, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.org, or))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }

--- a/auth/service.go
+++ b/auth/service.go
@@ -646,16 +646,14 @@ func (svc service) CanAccessGroup(ctx context.Context, token, groupID string) er
 		return err
 	}
 
-	// Retrieve orgs where group is assigned
-	op, err := svc.orgs.RetrieveByGroupID(ctx, groupID)
+	// Retrieve org where group is assigned
+	or, err := svc.orgs.RetrieveByGroupID(ctx, groupID)
 	if err != nil {
 		return err
 	}
 
-	for _, org := range op.Orgs {
-		if err := svc.canAccessOrg(ctx, org.ID, user.ID); err == nil {
-			return nil
-		}
+	if err := svc.canAccessOrg(ctx, or.ID, user.ID); err == nil {
+		return nil
 	}
 
 	return errors.ErrAuthorization

--- a/auth/service.go
+++ b/auth/service.go
@@ -651,12 +651,12 @@ func (svc service) CanAccessGroup(ctx context.Context, token, groupID string) er
 	}
 
 	// Retrieve org where group is assigned
-	or, err := svc.orgs.RetrieveByGroupID(ctx, groupID)
+	org, err := svc.orgs.RetrieveByGroupID(ctx, groupID)
 	if err != nil {
 		return err
 	}
 
-	if err := svc.canAccessOrg(ctx, or.ID, user.ID); err == nil {
+	if err := svc.canAccessOrg(ctx, org.ID, user.ID); err == nil {
 		return nil
 	}
 

--- a/auth/tracing/orgs.go
+++ b/auth/tracing/orgs.go
@@ -174,7 +174,7 @@ func (orm orgRepositoryMiddleware) RetrieveGroups(ctx context.Context, orgID str
 	return orm.repo.RetrieveGroups(ctx, orgID, pm)
 }
 
-func (orm orgRepositoryMiddleware) RetrieveByGroupID(ctx context.Context, groupID string) (auth.OrgsPage, error) {
+func (orm orgRepositoryMiddleware) RetrieveByGroupID(ctx context.Context, groupID string) (auth.Org, error) {
 	span := createSpan(ctx, orm.tracer, retrieveByGroupID)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)


### PR DESCRIPTION
Fixed `RetrieveByGroupID`  org DB  method to return `org` object

resolves #178 