### PR TITLE
MF-194 - Remove omitempty tag from org page response

### DIFF
--- a/auth/api/http/orgs/responses.go
+++ b/auth/api/http/orgs/responses.go
@@ -120,8 +120,8 @@ type orgsPageRes struct {
 }
 
 type pageRes struct {
-	Limit  uint64 `json:"limit,omitempty"`
-	Offset uint64 `json:"offset,omitempty"`
+	Limit  uint64 `json:"limit"`
+	Offset uint64 `json:"offset"`
 	Total  uint64 `json:"total"`
 	Name   string `json:"name"`
 }


### PR DESCRIPTION
Removed redundant `omitempty` JSON tag in org page response.
Resolves #194 