### PR TITLE
MF-197 - Add admin rights in view channel endpoint

### DIFF
--- a/things/service.go
+++ b/things/service.go
@@ -388,6 +388,10 @@ func (ts *thingsService) ViewChannel(ctx context.Context, token, id string) (Cha
 		return Channel{}, err
 	}
 
+	if err := ts.authorize(ctx, res.Email); err == nil {
+		return channel, nil
+	}
+
 	if channel.Owner != res.GetId() {
 		return Channel{}, errors.ErrAuthorization
 	}
@@ -400,8 +404,9 @@ func (ts *thingsService) ListChannels(ctx context.Context, token string, pm Page
 	if err != nil {
 		return ChannelsPage{}, errors.Wrap(errors.ErrAuthentication, err)
 	}
-
+	print("I'm herreee11 ")
 	if err := ts.authorize(ctx, res.Email); err == nil {
+		print("I'm herreee22 ")
 		return ts.channels.RetrieveByAdmin(ctx, pm)
 	}
 

--- a/things/service.go
+++ b/things/service.go
@@ -404,9 +404,8 @@ func (ts *thingsService) ListChannels(ctx context.Context, token string, pm Page
 	if err != nil {
 		return ChannelsPage{}, errors.Wrap(errors.ErrAuthentication, err)
 	}
-	print("I'm herreee11 ")
+
 	if err := ts.authorize(ctx, res.Email); err == nil {
-		print("I'm herreee22 ")
 		return ts.channels.RetrieveByAdmin(ctx, pm)
 	}
 

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -23,8 +23,8 @@ const (
 	wrongValue = "wrong-value"
 	adminEmail = "admin@example.com"
 	email      = "user@example.com"
-	email2     = "user2@example.com"
 	token      = "token"
+	adminToken = "adminToken"
 	token2     = "token2"
 	n          = uint64(102)
 	prefix     = "fe6b4e92-cc98-425e-b0aa-"
@@ -641,7 +641,7 @@ func TestUpdateChannel(t *testing.T) {
 }
 
 func TestViewChannel(t *testing.T) {
-	svc := newService(map[string]string{token: email, token2: adminEmail})
+	svc := newService(map[string]string{token: email, adminToken: adminEmail})
 	chs, err := svc.CreateChannels(context.Background(), token, channel)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
 	ch := chs[0]
@@ -659,7 +659,7 @@ func TestViewChannel(t *testing.T) {
 		},
 		"view existing channel as admin": {
 			id:    ch.ID,
-			token: token2,
+			token: adminToken,
 			err:   nil,
 		},
 		"view channel with wrong credentials": {

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -641,7 +641,7 @@ func TestUpdateChannel(t *testing.T) {
 }
 
 func TestViewChannel(t *testing.T) {
-	svc := newService(map[string]string{token: adminEmail})
+	svc := newService(map[string]string{token: email, token2: adminEmail})
 	chs, err := svc.CreateChannels(context.Background(), token, channel)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
 	ch := chs[0]
@@ -655,6 +655,11 @@ func TestViewChannel(t *testing.T) {
 		"view existing channel": {
 			id:    ch.ID,
 			token: token,
+			err:   nil,
+		},
+		"view existing channel as admin": {
+			id:    ch.ID,
+			token: token2,
 			err:   nil,
 		},
 		"view channel with wrong credentials": {


### PR DESCRIPTION
Added admin rights in `viewChannelEndpoin`t so that admin can see the details of the users channel

Resolves #197 