### PR TITLE
MF-190 - Add admin rights in view thing endpoint

### DIFF
--- a/things/service.go
+++ b/things/service.go
@@ -262,6 +262,10 @@ func (ts *thingsService) ViewThing(ctx context.Context, token, id string) (Thing
 		return Thing{}, err
 	}
 
+	if err := ts.authorize(ctx, res.Email); err == nil {
+		return thing, nil
+	}
+
 	if thing.Owner == res.GetId() {
 		return thing, nil
 	}

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -23,8 +23,8 @@ const (
 	wrongValue = "wrong-value"
 	adminEmail = "admin@example.com"
 	email      = "user@example.com"
-	email2     = "user2@example.com"
 	token      = "token"
+	adminToken = "admin-token"
 	token2     = "token2"
 	n          = uint64(102)
 	prefix     = "fe6b4e92-cc98-425e-b0aa-"
@@ -183,7 +183,7 @@ func TestUpdateKey(t *testing.T) {
 }
 
 func TestViewThing(t *testing.T) {
-	svc := newService(map[string]string{token: email})
+	svc := newService(map[string]string{token: email, adminToken: adminEmail})
 	ths, err := svc.CreateThings(context.Background(), token, thingList[0])
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
 	th := ths[0]
@@ -196,6 +196,11 @@ func TestViewThing(t *testing.T) {
 		"view existing thing": {
 			id:    th.ID,
 			token: token,
+			err:   nil,
+		},
+		"view existing thing as admin": {
+			id:    th.ID,
+			token: adminToken,
 			err:   nil,
 		},
 		"view thing with wrong credentials": {

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -24,7 +24,7 @@ const (
 	adminEmail = "admin@example.com"
 	email      = "user@example.com"
 	token      = "token"
-	adminToken = "admin-token"
+	adminToken = "adminToken"
 	token2     = "token2"
 	n          = uint64(102)
 	prefix     = "fe6b4e92-cc98-425e-b0aa-"


### PR DESCRIPTION
Added admin rights in `viewThingEndpoint` so that admin can see the details of the users thing

Resolves #190 
