### PR TITLE
MF-211 - Add Admin query parameter to list or not as admin

### DIFF
--- a/auth/api/http/orgs/endpoint.go
+++ b/auth/api/http/orgs/endpoint.go
@@ -107,7 +107,7 @@ func listOrgsEndpoint(svc auth.Service) endpoint.Endpoint {
 			Limit:    req.limit,
 		}
 
-		page, err := svc.ListOrgs(ctx, req.token, pm)
+		page, err := svc.ListOrgs(ctx, req.token, req.admin, pm)
 		if err != nil {
 			return nil, err
 		}

--- a/auth/api/http/orgs/requests.go
+++ b/auth/api/http/orgs/requests.go
@@ -49,6 +49,7 @@ type listOrgsReq struct {
 	name     string
 	offset   uint64
 	limit    uint64
+	admin    bool
 	metadata auth.OrgMetadata
 }
 

--- a/auth/api/http/orgs/transport.go
+++ b/auth/api/http/orgs/transport.go
@@ -24,6 +24,7 @@ const (
 	limitKey    = "limit"
 	metadataKey = "metadata"
 	nameKey     = "name"
+	adminKey    = "admin"
 	defOffset   = 0
 	defLimit    = 10
 	defLevel    = 1
@@ -162,6 +163,11 @@ func decodeListOrgsRequest(_ context.Context, r *http.Request) (interface{}, err
 		return nil, err
 	}
 
+	a, err := apiutil.ReadBoolQuery(r, adminKey, false)
+	if err != nil {
+		return nil, err
+	}
+
 	req := listOrgsReq{
 		token:    apiutil.ExtractBearerToken(r),
 		id:       bone.GetValue(r, orgIDKey),
@@ -169,6 +175,7 @@ func decodeListOrgsRequest(_ context.Context, r *http.Request) (interface{}, err
 		offset:   o,
 		limit:    l,
 		metadata: m,
+		admin:    a,
 	}
 
 	return req, nil

--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -146,7 +146,7 @@ func (lm *loggingMiddleware) ViewOrg(ctx context.Context, token, id string) (o a
 	return lm.svc.ViewOrg(ctx, token, id)
 }
 
-func (lm *loggingMiddleware) ListOrgs(ctx context.Context, token string, pm auth.PageMetadata) (gp auth.OrgsPage, err error) {
+func (lm *loggingMiddleware) ListOrgs(ctx context.Context, token string, admin bool, pm auth.PageMetadata) (gp auth.OrgsPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_orgs for token %s took %s to complete", token, time.Since(begin))
 		if err != nil {
@@ -156,7 +156,7 @@ func (lm *loggingMiddleware) ListOrgs(ctx context.Context, token string, pm auth
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.ListOrgs(ctx, token, pm)
+	return lm.svc.ListOrgs(ctx, token, admin, pm)
 }
 
 func (lm *loggingMiddleware) ListOrgMembers(ctx context.Context, token, orgID string, pm auth.PageMetadata) (op auth.MembersPage, err error) {

--- a/auth/api/metrics.go
+++ b/auth/api/metrics.go
@@ -107,13 +107,13 @@ func (ms *metricsMiddleware) ViewOrg(ctx context.Context, token, id string) (aut
 	return ms.svc.ViewOrg(ctx, token, id)
 }
 
-func (ms *metricsMiddleware) ListOrgs(ctx context.Context, token string, pm auth.PageMetadata) (auth.OrgsPage, error) {
+func (ms *metricsMiddleware) ListOrgs(ctx context.Context, token string, admin bool, pm auth.PageMetadata) (auth.OrgsPage, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "list_orgs").Add(1)
 		ms.latency.With("method", "list_orgs").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.ListOrgs(ctx, token, pm)
+	return ms.svc.ListOrgs(ctx, token, admin, pm)
 }
 
 func (ms *metricsMiddleware) ListOrgMemberships(ctx context.Context, token, memberID string, pm auth.PageMetadata) (auth.OrgsPage, error) {

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -135,7 +135,7 @@ type OrgService interface {
 	ViewOrg(ctx context.Context, token, id string) (Org, error)
 
 	// ListOrgs retrieves orgs.
-	ListOrgs(ctx context.Context, token string, pm PageMetadata) (OrgsPage, error)
+	ListOrgs(ctx context.Context, token string, admin bool, pm PageMetadata) (OrgsPage, error)
 
 	// ListOrgMemberships retrieves all orgs for member that is identified with memberID belongs to.
 	ListOrgMemberships(ctx context.Context, token, memberID string, pm PageMetadata) (OrgsPage, error)

--- a/auth/service.go
+++ b/auth/service.go
@@ -274,14 +274,16 @@ func (svc service) CreateOrg(ctx context.Context, token string, o Org) (Org, err
 	return org, nil
 }
 
-func (svc service) ListOrgs(ctx context.Context, token string, pm PageMetadata) (OrgsPage, error) {
+func (svc service) ListOrgs(ctx context.Context, token string, admin bool, pm PageMetadata) (OrgsPage, error) {
 	user, err := svc.Identify(ctx, token)
 	if err != nil {
 		return OrgsPage{}, err
 	}
 
-	if err := svc.Authorize(ctx, AuthzReq{Email: user.Email}); err == nil {
-		return svc.orgs.RetrieveByAdmin(ctx, pm)
+	if admin {
+		if err := svc.Authorize(ctx, AuthzReq{Email: user.Email}); err == nil {
+			return svc.orgs.RetrieveByAdmin(ctx, pm)
+		}
 	}
 
 	return svc.orgs.RetrieveByOwner(ctx, user.ID, pm)

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -407,6 +407,7 @@ func TestListOrgs(t *testing.T) {
 	cases := []struct {
 		desc  string
 		token string
+		admin bool
 		meta  auth.PageMetadata
 		size  uint64
 		err   error
@@ -414,6 +415,7 @@ func TestListOrgs(t *testing.T) {
 		{
 			desc:  "list orgs",
 			token: ownerToken,
+			admin: false,
 			meta: auth.PageMetadata{
 				Offset: 0,
 				Limit:  n,
@@ -423,6 +425,7 @@ func TestListOrgs(t *testing.T) {
 		}, {
 			desc:  "list orgs as system admin",
 			token: superAdminToken,
+			admin: true,
 			meta: auth.PageMetadata{
 				Offset: 0,
 				Limit:  n,
@@ -432,18 +435,21 @@ func TestListOrgs(t *testing.T) {
 		}, {
 			desc:  "list orgs with wrong credentials",
 			token: invalid,
+			admin: false,
 			meta:  auth.PageMetadata{},
 			size:  0,
 			err:   errors.ErrAuthentication,
 		}, {
 			desc:  "list orgs without credentials",
 			token: "",
+			admin: false,
 			meta:  auth.PageMetadata{},
 			size:  0,
 			err:   errors.ErrAuthentication,
 		}, {
 			desc:  "list half of total orgs",
 			token: ownerToken,
+			admin: false,
 			meta: auth.PageMetadata{
 				Offset: n / 2,
 				Limit:  n,
@@ -453,6 +459,7 @@ func TestListOrgs(t *testing.T) {
 		}, {
 			desc:  "list last org",
 			token: ownerToken,
+			admin: false,
 			meta: auth.PageMetadata{
 				Offset: n - 1,
 				Limit:  n,
@@ -463,7 +470,7 @@ func TestListOrgs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		page, err := svc.ListOrgs(context.Background(), tc.token, tc.meta)
+		page, err := svc.ListOrgs(context.Background(), tc.token, tc.admin, tc.meta)
 		size := uint64(len(page.Orgs))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected %d got %d\n", tc.desc, tc.size, size))

--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -173,7 +173,7 @@ func (svc *mainfluxThings) UpdateKey(context.Context, string, string, string) er
 	panic("not implemented")
 }
 
-func (svc *mainfluxThings) ListThings(context.Context, string, things.PageMetadata) (things.Page, error) {
+func (svc *mainfluxThings) ListThings(context.Context, string, bool, things.PageMetadata) (things.Page, error) {
 	panic("not implemented")
 }
 

--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -261,7 +261,7 @@ func (svc *mainfluxThings) CreateGroup(ctx context.Context, token string, group 
 	panic("not implemented")
 }
 
-func (svc *mainfluxThings) ListGroups(ctx context.Context, token string, pm things.PageMetadata) (things.GroupPage, error) {
+func (svc *mainfluxThings) ListGroups(ctx context.Context, token string, admin bool, pm things.PageMetadata) (things.GroupPage, error) {
 	panic("not implemented")
 }
 

--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -215,7 +215,7 @@ func (svc *mainfluxThings) UpdateChannel(context.Context, string, things.Channel
 	panic("not implemented")
 }
 
-func (svc *mainfluxThings) ListChannels(context.Context, string, things.PageMetadata) (things.ChannelsPage, error) {
+func (svc *mainfluxThings) ListChannels(context.Context, string, bool, things.PageMetadata) (things.ChannelsPage, error) {
 	panic("not implemented")
 }
 

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -357,7 +357,7 @@ func (lm *loggingMiddleware) ViewGroup(ctx context.Context, token, id string) (g
 	return lm.svc.ViewGroup(ctx, token, id)
 }
 
-func (lm *loggingMiddleware) ListGroups(ctx context.Context, token string, pm things.PageMetadata) (g things.GroupPage, err error) {
+func (lm *loggingMiddleware) ListGroups(ctx context.Context, token string, admin bool, pm things.PageMetadata) (g things.GroupPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_groups for token %s took %s to complete", token, time.Since(begin))
 		if err != nil {
@@ -367,7 +367,7 @@ func (lm *loggingMiddleware) ListGroups(ctx context.Context, token string, pm th
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.ListGroups(ctx, token, pm)
+	return lm.svc.ListGroups(ctx, token, admin, pm)
 }
 
 func (lm *loggingMiddleware) ListGroupsByIDs(ctx context.Context, groupIDs []string) (g []things.Group, err error) {

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -172,7 +172,7 @@ func (lm *loggingMiddleware) ViewChannel(ctx context.Context, token, id string) 
 	return lm.svc.ViewChannel(ctx, token, id)
 }
 
-func (lm *loggingMiddleware) ListChannels(ctx context.Context, token string, pm things.PageMetadata) (_ things.ChannelsPage, err error) {
+func (lm *loggingMiddleware) ListChannels(ctx context.Context, token string, admin bool, pm things.PageMetadata) (_ things.ChannelsPage, err error) {
 	defer func(begin time.Time) {
 		nlog := ""
 		if pm.Name != "" {
@@ -186,7 +186,7 @@ func (lm *loggingMiddleware) ListChannels(ctx context.Context, token string, pm 
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.ListChannels(ctx, token, pm)
+	return lm.svc.ListChannels(ctx, token, admin, pm)
 }
 
 func (lm *loggingMiddleware) ListChannelsByThing(ctx context.Context, token, thID string, pm things.PageMetadata) (_ things.ChannelsPage, err error) {

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -78,7 +78,7 @@ func (lm *loggingMiddleware) ViewThing(ctx context.Context, token, id string) (t
 	return lm.svc.ViewThing(ctx, token, id)
 }
 
-func (lm *loggingMiddleware) ListThings(ctx context.Context, token string, pm things.PageMetadata) (_ things.Page, err error) {
+func (lm *loggingMiddleware) ListThings(ctx context.Context, token string, admin bool, pm things.PageMetadata) (_ things.Page, err error) {
 	defer func(begin time.Time) {
 		nlog := ""
 		if pm.Name != "" {
@@ -92,7 +92,7 @@ func (lm *loggingMiddleware) ListThings(ctx context.Context, token string, pm th
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.ListThings(ctx, token, pm)
+	return lm.svc.ListThings(ctx, token, admin, pm)
 }
 
 func (lm *loggingMiddleware) ListThingsByIDs(ctx context.Context, ids []string) (page things.Page, err error) {

--- a/things/api/metrics.go
+++ b/things/api/metrics.go
@@ -66,13 +66,13 @@ func (ms *metricsMiddleware) ViewThing(ctx context.Context, token, id string) (t
 	return ms.svc.ViewThing(ctx, token, id)
 }
 
-func (ms *metricsMiddleware) ListThings(ctx context.Context, token string, pm things.PageMetadata) (things.Page, error) {
+func (ms *metricsMiddleware) ListThings(ctx context.Context, token string, admin bool, pm things.PageMetadata) (things.Page, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "list_things").Add(1)
 		ms.latency.With("method", "list_things").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.ListThings(ctx, token, pm)
+	return ms.svc.ListThings(ctx, token, admin, pm)
 }
 
 func (ms *metricsMiddleware) ListThingsByIDs(ctx context.Context, ids []string) (things.Page, error) {

--- a/things/api/metrics.go
+++ b/things/api/metrics.go
@@ -255,13 +255,13 @@ func (ms *metricsMiddleware) ViewGroup(ctx context.Context, token, id string) (t
 	return ms.svc.ViewGroup(ctx, token, id)
 }
 
-func (ms *metricsMiddleware) ListGroups(ctx context.Context, token string, pm things.PageMetadata) (things.GroupPage, error) {
+func (ms *metricsMiddleware) ListGroups(ctx context.Context, token string, admin bool, pm things.PageMetadata) (things.GroupPage, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "list_group").Add(1)
 		ms.latency.With("method", "list_group").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.ListGroups(ctx, token, pm)
+	return ms.svc.ListGroups(ctx, token, admin, pm)
 }
 
 func (ms *metricsMiddleware) ListGroupsByIDs(ctx context.Context, groupIDs []string) ([]things.Group, error) {

--- a/things/api/metrics.go
+++ b/things/api/metrics.go
@@ -129,13 +129,13 @@ func (ms *metricsMiddleware) ViewChannel(ctx context.Context, token, id string) 
 	return ms.svc.ViewChannel(ctx, token, id)
 }
 
-func (ms *metricsMiddleware) ListChannels(ctx context.Context, token string, pm things.PageMetadata) (things.ChannelsPage, error) {
+func (ms *metricsMiddleware) ListChannels(ctx context.Context, token string, admin bool, pm things.PageMetadata) (things.ChannelsPage, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "list_channels").Add(1)
 		ms.latency.With("method", "list_channels").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.ListChannels(ctx, token, pm)
+	return ms.svc.ListChannels(ctx, token, admin, pm)
 }
 
 func (ms *metricsMiddleware) ListChannelsByThing(ctx context.Context, token, thID string, pm things.PageMetadata) (things.ChannelsPage, error) {

--- a/things/api/things/http/endpoint.go
+++ b/things/api/things/http/endpoint.go
@@ -598,7 +598,7 @@ func listGroupsEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		page, err := svc.ListGroups(ctx, req.token, req.pageMetadata)
+		page, err := svc.ListGroups(ctx, req.token,req.admin, req.pageMetadata)
 		if err != nil {
 			return nil, err
 		}

--- a/things/api/things/http/endpoint.go
+++ b/things/api/things/http/endpoint.go
@@ -311,7 +311,7 @@ func listChannelsEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		page, err := svc.ListChannels(ctx, req.token, req.pageMetadata)
+		page, err := svc.ListChannels(ctx, req.token, req.admin, req.pageMetadata)
 		if err != nil {
 			return nil, err
 		}

--- a/things/api/things/http/endpoint.go
+++ b/things/api/things/http/endpoint.go
@@ -126,7 +126,7 @@ func listThingsEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		page, err := svc.ListThings(ctx, req.token, req.pageMetadata)
+		page, err := svc.ListThings(ctx, req.token, req.admin, req.pageMetadata)
 		if err != nil {
 			return nil, err
 		}

--- a/things/api/things/http/requests.go
+++ b/things/api/things/http/requests.go
@@ -359,6 +359,7 @@ func (req updateGroupReq) validate() error {
 type listGroupsReq struct {
 	token        string
 	id           string
+	admin        bool
 	pageMetadata things.PageMetadata
 }
 

--- a/things/api/things/http/requests.go
+++ b/things/api/things/http/requests.go
@@ -176,6 +176,7 @@ func (req viewResourceReq) validate() error {
 
 type listResourcesReq struct {
 	token        string
+	admin        bool
 	pageMetadata things.PageMetadata
 }
 

--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -522,6 +522,11 @@ func decodeListGroupsRequest(_ context.Context, r *http.Request) (interface{}, e
 		return nil, err
 	}
 
+	a, err := apiutil.ReadBoolQuery(r, adminKey, false)
+	if err != nil {
+		return nil, err
+	}
+
 	req := listGroupsReq{
 		token: apiutil.ExtractBearerToken(r),
 		pageMetadata: things.PageMetadata{
@@ -530,7 +535,8 @@ func decodeListGroupsRequest(_ context.Context, r *http.Request) (interface{}, e
 			Metadata: m,
 			Name:     n,
 		},
-		id: bone.GetValue(r, groupIDKey),
+		id:    bone.GetValue(r, groupIDKey),
+		admin: a,
 	}
 	return req, nil
 }

--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -32,6 +32,7 @@ const (
 	metadataKey = "metadata"
 	disconnKey  = "disconnected"
 	groupIDKey  = "groupID"
+	adminKey    = "admin"
 	defOffset   = 0
 	defLimit    = 10
 )
@@ -367,6 +368,11 @@ func decodeList(_ context.Context, r *http.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	a, err := apiutil.ReadBoolQuery(r, adminKey, false)
+	if err != nil {
+		return nil, err
+	}
+
 	req := listResourcesReq{
 		token: apiutil.ExtractBearerToken(r),
 		pageMetadata: things.PageMetadata{
@@ -377,6 +383,7 @@ func decodeList(_ context.Context, r *http.Request) (interface{}, error) {
 			Dir:      d,
 			Metadata: m,
 		},
+		admin: a,
 	}
 
 	return req, nil

--- a/things/mocks/things.go
+++ b/things/mocks/things.go
@@ -310,7 +310,28 @@ func (trm *thingRepositoryMock) RetrieveAll(_ context.Context) ([]things.Thing, 
 }
 
 func (trm *thingRepositoryMock) RetrieveByAdmin(ctx context.Context, pm things.PageMetadata) (things.Page, error) {
-	panic("not implemented")
+	trm.mu.Lock()
+	defer trm.mu.Unlock()
+
+	i := uint64(0)
+	var ths []things.Thing
+	for _, th := range trm.things {
+		if i >= pm.Offset && i < pm.Offset+pm.Limit {
+			ths = append(ths, th)
+		}
+		i++
+	}
+
+	page := things.Page{
+		Things: ths,
+		PageMetadata: things.PageMetadata{
+			Total:  trm.counter,
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
+		},
+	}
+
+	return page, nil
 }
 
 type thingCacheMock struct {

--- a/things/redis/streams.go
+++ b/things/redis/streams.go
@@ -86,8 +86,8 @@ func (es eventStore) ViewThing(ctx context.Context, token, id string) (things.Th
 	return es.svc.ViewThing(ctx, token, id)
 }
 
-func (es eventStore) ListThings(ctx context.Context, token string, pm things.PageMetadata) (things.Page, error) {
-	return es.svc.ListThings(ctx, token, pm)
+func (es eventStore) ListThings(ctx context.Context, token string, admin bool, pm things.PageMetadata) (things.Page, error) {
+	return es.svc.ListThings(ctx, token, admin, pm)
 }
 
 func (es eventStore) ListThingsByIDs(ctx context.Context, ids []string) (things.Page, error) {

--- a/things/redis/streams.go
+++ b/things/redis/streams.go
@@ -172,8 +172,8 @@ func (es eventStore) ViewChannel(ctx context.Context, token, id string) (things.
 	return es.svc.ViewChannel(ctx, token, id)
 }
 
-func (es eventStore) ListChannels(ctx context.Context, token string, pm things.PageMetadata) (things.ChannelsPage, error) {
-	return es.svc.ListChannels(ctx, token, pm)
+func (es eventStore) ListChannels(ctx context.Context, token string, admin bool, pm things.PageMetadata) (things.ChannelsPage, error) {
+	return es.svc.ListChannels(ctx, token, admin, pm)
 }
 
 func (es eventStore) ListChannelsByThing(ctx context.Context, token, thID string, pm things.PageMetadata) (things.ChannelsPage, error) {

--- a/things/redis/streams.go
+++ b/things/redis/streams.go
@@ -268,8 +268,8 @@ func (es eventStore) CreateGroup(ctx context.Context, token string, group things
 	return es.svc.CreateGroup(ctx, token, group)
 }
 
-func (es eventStore) ListGroups(ctx context.Context, token string, pm things.PageMetadata) (things.GroupPage, error) {
-	return es.svc.ListGroups(ctx, token, pm)
+func (es eventStore) ListGroups(ctx context.Context, token string, admin bool, pm things.PageMetadata) (things.GroupPage, error) {
+	return es.svc.ListGroups(ctx, token, admin, pm)
 }
 
 func (es eventStore) ListGroupsByIDs(ctx context.Context, groupIDs []string) ([]things.Group, error) {

--- a/things/redis/streams_test.go
+++ b/things/redis/streams_test.go
@@ -431,8 +431,8 @@ func TestListChannels(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error %s", err))
 
 	essvc := redis.NewEventStoreMiddleware(svc, redisClient)
-	eschs, eserr := essvc.ListChannels(context.Background(), token, things.PageMetadata{Offset: 0, Limit: 10})
-	chs, err := svc.ListChannels(context.Background(), token, things.PageMetadata{Offset: 0, Limit: 10})
+	eschs, eserr := essvc.ListChannels(context.Background(), token, false, things.PageMetadata{Offset: 0, Limit: 10})
+	chs, err := svc.ListChannels(context.Background(), token, false, things.PageMetadata{Offset: 0, Limit: 10})
 	assert.Equal(t, chs, eschs, fmt.Sprintf("event sourcing changed service behavior: expected %v got %v", chs, eschs))
 	assert.Equal(t, err, eserr, fmt.Sprintf("event sourcing changed service behavior: expected %v got %v", err, eserr))
 }

--- a/things/redis/streams_test.go
+++ b/things/redis/streams_test.go
@@ -195,8 +195,8 @@ func TestListThings(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error %s", err))
 
 	essvc := redis.NewEventStoreMiddleware(svc, redisClient)
-	esths, eserr := essvc.ListThings(context.Background(), token, things.PageMetadata{Offset: 0, Limit: 10})
-	ths, err := svc.ListThings(context.Background(), token, things.PageMetadata{Offset: 0, Limit: 10})
+	esths, eserr := essvc.ListThings(context.Background(), token, false, things.PageMetadata{Offset: 0, Limit: 10})
+	ths, err := svc.ListThings(context.Background(), token, false, things.PageMetadata{Offset: 0, Limit: 10})
 	assert.Equal(t, ths, esths, fmt.Sprintf("event sourcing changed service behavior: expected %v got %v", ths, esths))
 	assert.Equal(t, err, eserr, fmt.Sprintf("event sourcing changed service behavior: expected %v got %v", err, eserr))
 }

--- a/things/service.go
+++ b/things/service.go
@@ -108,7 +108,7 @@ type Service interface {
 	ViewGroup(ctx context.Context, token, id string) (Group, error)
 
 	// ListGroups retrieves groups.
-	ListGroups(ctx context.Context, token string, pm PageMetadata) (GroupPage, error)
+	ListGroups(ctx context.Context, token string, admin bool, pm PageMetadata) (GroupPage, error)
 
 	// ListGroupsByIDs retrieves groups by their IDs.
 	ListGroupsByIDs(ctx context.Context, ids []string) ([]Group, error)
@@ -699,14 +699,16 @@ func (ts *thingsService) CreateGroup(ctx context.Context, token string, group Gr
 	return group, nil
 }
 
-func (ts *thingsService) ListGroups(ctx context.Context, token string, pm PageMetadata) (GroupPage, error) {
+func (ts *thingsService) ListGroups(ctx context.Context, token string, admin bool, pm PageMetadata) (GroupPage, error) {
 	user, err := ts.auth.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
 		return GroupPage{}, err
 	}
 
-	if err := ts.authorize(ctx, user.Email); err == nil {
-		return ts.groups.RetrieveByAdmin(ctx, pm)
+	if admin {
+		if err := ts.authorize(ctx, user.Email); err == nil {
+			return ts.groups.RetrieveByAdmin(ctx, pm)
+		}
 	}
 
 	return ts.groups.RetrieveByOwner(ctx, user.GetId(), pm)

--- a/things/service.go
+++ b/things/service.go
@@ -59,7 +59,7 @@ type Service interface {
 
 	// ListChannels retrieves data about subset of channels that belongs to the
 	// user identified by the provided key.
-	ListChannels(ctx context.Context, token string, pm PageMetadata) (ChannelsPage, error)
+	ListChannels(ctx context.Context, token string, admin bool, pm PageMetadata) (ChannelsPage, error)
 
 	// ListChannelsByThing retrieves data about subset of channels that have
 	// specified thing connected or not connected to them and belong to the user identified by
@@ -404,14 +404,16 @@ func (ts *thingsService) ViewChannel(ctx context.Context, token, id string) (Cha
 	return channel, nil
 }
 
-func (ts *thingsService) ListChannels(ctx context.Context, token string, pm PageMetadata) (ChannelsPage, error) {
+func (ts *thingsService) ListChannels(ctx context.Context, token string, admin bool, pm PageMetadata) (ChannelsPage, error) {
 	res, err := ts.auth.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
 		return ChannelsPage{}, errors.Wrap(errors.ErrAuthentication, err)
 	}
 
-	if err := ts.authorize(ctx, res.Email); err == nil {
-		return ts.channels.RetrieveByAdmin(ctx, pm)
+	if admin {
+		if err := ts.authorize(ctx, res.Email); err == nil {
+			return ts.channels.RetrieveByAdmin(ctx, pm)
+		}
 	}
 
 	return ts.channels.RetrieveByOwner(ctx, res.GetId(), pm)

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -724,7 +724,7 @@ func TestViewChannel(t *testing.T) {
 }
 
 func TestListChannels(t *testing.T) {
-	svc := newService(map[string]string{token: email})
+	svc := newService(map[string]string{token: email, adminToken: adminEmail})
 	meta := things.Metadata{}
 	meta["name"] = "test-channel"
 	channel.Metadata = meta
@@ -741,12 +741,24 @@ func TestListChannels(t *testing.T) {
 
 	cases := map[string]struct {
 		token        string
+		admin        bool
 		pageMetadata things.PageMetadata
 		size         uint64
 		err          error
 	}{
 		"list all channels": {
 			token: token,
+			admin: false,
+			pageMetadata: things.PageMetadata{
+				Offset: 0,
+				Limit:  n,
+			},
+			size: n,
+			err:  nil,
+		},
+		"list all channels as admin": {
+			token: adminToken,
+			admin: true,
 			pageMetadata: things.PageMetadata{
 				Offset: 0,
 				Limit:  n,
@@ -756,6 +768,7 @@ func TestListChannels(t *testing.T) {
 		},
 		"list all channels with no limit": {
 			token: token,
+			admin: false,
 			pageMetadata: things.PageMetadata{
 				Limit: 0,
 			},
@@ -764,6 +777,7 @@ func TestListChannels(t *testing.T) {
 		},
 		"list half": {
 			token: token,
+			admin: false,
 			pageMetadata: things.PageMetadata{
 				Offset: n / 2,
 				Limit:  n,
@@ -773,6 +787,7 @@ func TestListChannels(t *testing.T) {
 		},
 		"list last channel": {
 			token: token,
+			admin: false,
 			pageMetadata: things.PageMetadata{
 				Offset: n - 1,
 				Limit:  n,
@@ -782,6 +797,7 @@ func TestListChannels(t *testing.T) {
 		},
 		"list empty set": {
 			token: token,
+			admin: false,
 			pageMetadata: things.PageMetadata{
 				Offset: n + 1,
 				Limit:  n,
@@ -791,6 +807,7 @@ func TestListChannels(t *testing.T) {
 		},
 		"list with wrong credentials": {
 			token: wrongValue,
+			admin: false,
 			pageMetadata: things.PageMetadata{
 				Offset: 0,
 				Limit:  0,
@@ -800,6 +817,7 @@ func TestListChannels(t *testing.T) {
 		},
 		"list with existing name": {
 			token: token,
+			admin: false,
 			pageMetadata: things.PageMetadata{
 				Offset: 0,
 				Limit:  n,
@@ -810,6 +828,7 @@ func TestListChannels(t *testing.T) {
 		},
 		"list with non-existent name": {
 			token: token,
+			admin: false,
 			pageMetadata: things.PageMetadata{
 				Offset: 0,
 				Limit:  n,
@@ -820,6 +839,7 @@ func TestListChannels(t *testing.T) {
 		},
 		"list all channels with metadata": {
 			token: token,
+			admin: false,
 			pageMetadata: things.PageMetadata{
 				Offset:   0,
 				Limit:    n,
@@ -830,6 +850,7 @@ func TestListChannels(t *testing.T) {
 		},
 		"list all channels sorted by name ascendent": {
 			token: token,
+			admin: false,
 			pageMetadata: things.PageMetadata{
 				Offset: 0,
 				Limit:  n,
@@ -841,6 +862,7 @@ func TestListChannels(t *testing.T) {
 		},
 		"list all channels sorted by name descendent": {
 			token: token,
+			admin: false,
 			pageMetadata: things.PageMetadata{
 				Offset: 0,
 				Limit:  n,
@@ -853,7 +875,7 @@ func TestListChannels(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		page, err := svc.ListChannels(context.Background(), tc.token, tc.pageMetadata)
+		page, err := svc.ListChannels(context.Background(), tc.token, tc.admin, tc.pageMetadata)
 		size := uint64(len(page.Channels))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected %d got %d\n", desc, tc.size, size))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))


### PR DESCRIPTION
Added query parameter `admin` which will enable to list  orgs, things, channels and groups fro all users.
If the administrator sends a request without `admin` query parameter , the data will be listed as a regular user.

Resolves #211 