### PR TITLE
MF-212 - Create helper DB methods in auth, things and users.

### DIFF
--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -244,14 +244,12 @@ func toMember(dbmb dbMember) (auth.Member, error) {
 
 func (or orgRepository) RetrieveMemberships(ctx context.Context, memberID string, pm auth.PageMetadata) (auth.OrgsPage, error) {
 	meta, mq, err := dbutil.GetMetadataQuery("o", pm.Metadata)
-	fmt.Printf("meta: %v, mq: %v\n", meta, mq)
 	if err != nil {
 		return auth.OrgsPage{}, errors.Wrap(auth.ErrFailedToRetrieveMembership, err)
 	}
 
 	nq, name := dbutil.GetNameQuery(pm.Name)
 
-	fmt.Printf("nq: %v, name: %v\n", nq, name)
 	if mq != "" {
 		mq = fmt.Sprintf("AND %s", mq)
 	}

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -13,10 +13,13 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux/auth"
+	"github.com/MainfluxLabs/mainflux/internal/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 )
+
+const ownerDbId = "owner_id"
 
 var _ auth.OrgRepository = (*orgRepository)(nil)
 
@@ -178,7 +181,7 @@ func (or orgRepository) RetrieveAll(ctx context.Context) ([]auth.Org, error) {
 }
 
 func (or orgRepository) RetrieveMembers(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.OrgMembersPage, error) {
-	_, mq, err := getOrgsMetadataQuery("orgs", pm.Metadata)
+	_, mq, err := dbutil.GetMetadataQuery("orgs", pm.Metadata)
 	if err != nil {
 		return auth.OrgMembersPage{}, errors.Wrap(auth.ErrFailedToRetrieveMembers, err)
 	}
@@ -240,13 +243,15 @@ func toMember(dbmb dbMember) (auth.Member, error) {
 }
 
 func (or orgRepository) RetrieveMemberships(ctx context.Context, memberID string, pm auth.PageMetadata) (auth.OrgsPage, error) {
-	meta, mq, err := getOrgsMetadataQuery("o", pm.Metadata)
+	meta, mq, err := dbutil.GetMetadataQuery("o", pm.Metadata)
+	fmt.Printf("meta: %v, mq: %v\n", meta, mq)
 	if err != nil {
 		return auth.OrgsPage{}, errors.Wrap(auth.ErrFailedToRetrieveMembership, err)
 	}
 
-	nq, name := getNameQuery(pm.Name)
+	nq, name := dbutil.GetNameQuery(pm.Name)
 
+	fmt.Printf("nq: %v, name: %v\n", nq, name)
 	if mq != "" {
 		mq = fmt.Sprintf("AND %s", mq)
 	}
@@ -526,7 +531,7 @@ func (or orgRepository) UnassignGroups(ctx context.Context, orgID string, groupI
 }
 
 func (or orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm auth.PageMetadata) (auth.GroupRelationsPage, error) {
-	_, mq, err := getOrgsMetadataQuery("orgs", pm.Metadata)
+	_, mq, err := dbutil.GetMetadataQuery("orgs", pm.Metadata)
 	if err != nil {
 		return auth.GroupRelationsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
@@ -653,9 +658,9 @@ func (or orgRepository) RetrieveAllGroupRelations(ctx context.Context) ([]auth.G
 }
 
 func (or orgRepository) retrieve(ctx context.Context, ownerID string, pm auth.PageMetadata) (auth.OrgsPage, error) {
-	ownq := getOwnerQuery(ownerID)
-	nq, name := getNameQuery(pm.Name)
-	meta, mq, err := getOrgsMetadataQuery("orgs", pm.Metadata)
+	ownq := dbutil.GetOwnerQuery(ownerID, ownerDbId)
+	nq, name := dbutil.GetNameQuery(pm.Name)
+	meta, mq, err := dbutil.GetMetadataQuery("orgs", pm.Metadata)
 	if err != nil {
 		return auth.OrgsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
@@ -844,39 +849,6 @@ func toGroupRelation(gr dbGroupRelation) auth.GroupRelation {
 		CreatedAt: gr.CreatedAt,
 		UpdatedAt: gr.UpdatedAt,
 	}
-}
-
-func getOrgsMetadataQuery(db string, m auth.OrgMetadata) (mb []byte, mq string, err error) {
-	if len(m) > 0 {
-		mq = `metadata @> :metadata`
-		if db != "" {
-			mq = db + "." + mq
-		}
-
-		b, err := json.Marshal(m)
-		if err != nil {
-			return nil, "", errors.Wrap(err, errCreateMetadataQuery)
-		}
-		mb = b
-	}
-	return mb, mq, nil
-}
-
-func getNameQuery(name string) (string, string) {
-	if name == "" {
-		return "", ""
-	}
-
-	name = fmt.Sprintf(`%%%s%%`, strings.ToLower(name))
-	nq := `LOWER(name) LIKE :name`
-	return nq, name
-}
-
-func getOwnerQuery(owner string) string {
-	if owner == "" {
-		return ""
-	}
-	return "owner_id = :owner_id"
 }
 
 func total(ctx context.Context, db Database, query string, params interface{}) (uint64, error) {

--- a/auth/service.go
+++ b/auth/service.go
@@ -345,6 +345,7 @@ func (svc service) UpdateOrg(ctx context.Context, token string, o Org) (Org, err
 		OwnerID:     user.ID,
 		Name:        o.Name,
 		Description: o.Description,
+		Metadata:    o.Metadata,
 		UpdatedAt:   getTimestmap(),
 	}
 

--- a/internal/dbutil/helper.go
+++ b/internal/dbutil/helper.go
@@ -1,0 +1,46 @@
+package dbutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/MainfluxLabs/mainflux/pkg/errors"
+)
+
+var errCreateMetadataQuery = errors.New("failed to create query for metadata")
+
+func GetNameQuery(name string) (string, string) {
+	if name == "" {
+		return "", ""
+	}
+
+	name = fmt.Sprintf(`%%%s%%`, strings.ToLower(name))
+	nq := `LOWER(name) LIKE :name`
+
+	return nq, name
+}
+
+func GetOwnerQuery(owner, ownerDbId string) string {
+	if owner == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s = :%s", ownerDbId, ownerDbId)
+}
+
+func GetMetadataQuery(db string, m map[string]interface{}) (mb []byte, mq string, err error) {
+	if len(m) > 0 {
+		mq = `metadata @> :metadata`
+		if db != "" {
+			mq = db + "." + mq
+		}
+
+		b, err := json.Marshal(m)
+		if err != nil {
+			return nil, "", errors.Wrap(err, errCreateMetadataQuery)
+		}
+		mb = b
+	}
+	return mb, mq, nil
+}

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/MainfluxLabs/mainflux/internal/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/things"
 	"github.com/jackc/pgerrcode"
@@ -181,12 +182,12 @@ func (tr thingRepository) RetrieveByIDs(ctx context.Context, thingIDs []string, 
 		return things.Page{}, nil
 	}
 
-	nq, name := getNameQuery(pm.Name)
+	nq, name := dbutil.GetNameQuery(pm.Name)
 	oq := getOrderQuery(pm.Order)
 	dq := getDirQuery(pm.Dir)
 	idq := fmt.Sprintf("WHERE id IN ('%s') ", strings.Join(thingIDs, "','"))
 
-	m, mq, err := getMetadataQuery(pm.Metadata)
+	m, mq, err := dbutil.GetMetadataQuery("", pm.Metadata)
 	if err != nil {
 		return things.Page{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
@@ -370,11 +371,11 @@ func (tr thingRepository) Remove(ctx context.Context, owner, id string) error {
 }
 
 func (tr thingRepository) retrieve(ctx context.Context, owner string, includeOwner bool, pm things.PageMetadata) (things.Page, error) {
-	ownq := getOwnerQuery(owner)
-	nq, name := getNameQuery(pm.Name)
+	ownq := dbutil.GetOwnerQuery(owner, ownerDbId)
+	nq, name := dbutil.GetNameQuery(pm.Name)
 	oq := getOrderQuery(pm.Order)
 	dq := getDirQuery(pm.Dir)
-	m, mq, err := getMetadataQuery(pm.Metadata)
+	m, mq, err := dbutil.GetMetadataQuery("", pm.Metadata)
 	if err != nil {
 		return things.Page{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}

--- a/users/postgres/users.go
+++ b/users/postgres/users.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/MainfluxLabs/mainflux/internal/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/users"
 	"github.com/jackc/pgerrcode"
@@ -138,7 +139,7 @@ func (ur userRepository) RetrieveByIDs(ctx context.Context, userIDs []string, pm
 		return users.UserPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
 
-	mq, mp, err := createMetadataQuery("", pm.Metadata)
+	mp, mq, err := dbutil.GetMetadataQuery("", pm.Metadata)
 	if err != nil {
 		return users.UserPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
@@ -343,20 +344,6 @@ func createEmailQuery(entity string, email string) (string, string, error) {
 	// Create LIKE operator to search Users with email containing a given string
 	param := fmt.Sprintf(`%%%s%%`, email)
 	query := fmt.Sprintf("%semail LIKE :email", entity)
-
-	return query, param, nil
-}
-
-func createMetadataQuery(entity string, um users.Metadata) (string, []byte, error) {
-	if len(um) == 0 {
-		return "", nil, nil
-	}
-
-	param, err := json.Marshal(um)
-	if err != nil {
-		return "", nil, err
-	}
-	query := fmt.Sprintf("%smetadata @> :metadata", entity)
 
 	return query, param, nil
 }


### PR DESCRIPTION
Created helper DB methods  which is used in `users`, `things` and `auth` db layer.

Resolves #212