### PR TITLE
MF-257 - Add unassigned query parameter in group members list

### DIFF
--- a/things/api/things/http/endpoint.go
+++ b/things/api/things/http/endpoint.go
@@ -602,9 +602,10 @@ func listMembersEndpoint(svc things.Service) endpoint.Endpoint {
 		}
 
 		pm := things.PageMetadata{
-			Offset:   req.offset,
-			Limit:    req.limit,
-			Metadata: req.metadata,
+			Offset:     req.offset,
+			Limit:      req.limit,
+			Metadata:   req.metadata,
+			Unassigned: req.unassigned,
 		}
 		page, err := svc.ListMembers(ctx, req.token, req.id, pm)
 		if err != nil {

--- a/things/api/things/http/requests.go
+++ b/things/api/things/http/requests.go
@@ -417,11 +417,12 @@ func (req listGroupsReq) validate() error {
 }
 
 type listMembersReq struct {
-	token    string
-	id       string
-	offset   uint64
-	limit    uint64
-	metadata things.GroupMetadata
+	token      string
+	id         string
+	unassigned bool
+	offset     uint64
+	limit      uint64
+	metadata   things.GroupMetadata
 }
 
 func (req listMembersReq) validate() error {

--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -23,18 +23,19 @@ import (
 )
 
 const (
-	contentType = "application/json"
-	offsetKey   = "offset"
-	limitKey    = "limit"
-	nameKey     = "name"
-	orderKey    = "order"
-	dirKey      = "dir"
-	metadataKey = "metadata"
-	disconnKey  = "disconnected"
-	groupIDKey  = "groupID"
-	adminKey    = "admin"
-	defOffset   = 0
-	defLimit    = 10
+	contentType   = "application/json"
+	offsetKey     = "offset"
+	limitKey      = "limit"
+	nameKey       = "name"
+	orderKey      = "order"
+	dirKey        = "dir"
+	metadataKey   = "metadata"
+	disconnKey    = "disconnected"
+	groupIDKey    = "groupID"
+	unassignedKey = "unassigned"
+	adminKey      = "admin"
+	defOffset     = 0
+	defLimit      = 10
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
@@ -478,12 +479,18 @@ func decodeListMembersRequest(_ context.Context, r *http.Request) (interface{}, 
 		return nil, err
 	}
 
+	u, err := apiutil.ReadBoolQuery(r, unassignedKey, false)
+	if err != nil {
+		return nil, err
+	}
+
 	req := listMembersReq{
-		token:    apiutil.ExtractBearerToken(r),
-		id:       bone.GetValue(r, groupIDKey),
-		offset:   o,
-		limit:    l,
-		metadata: m,
+		token:      apiutil.ExtractBearerToken(r),
+		id:         bone.GetValue(r, groupIDKey),
+		unassigned: u,
+		offset:     o,
+		limit:      l,
+		metadata:   m,
 	}
 	return req, nil
 }

--- a/things/service.go
+++ b/things/service.go
@@ -140,6 +140,7 @@ type PageMetadata struct {
 	Dir          string                 `json:"dir,omitempty"`
 	Metadata     map[string]interface{} `json:"metadata,omitempty"`
 	Disconnected bool                   // Used for connected or disconnected lists
+	Unassigned   bool                   // Used for assigned or unassigned lists
 }
 
 type Backup struct {


### PR DESCRIPTION
Added unassigned query parameter in group members list. If it is `true` endpoint will return all unassigned members

Resolves #257 
