### PR TITLE
MF-270 - Move group_channels to new init

### DIFF
--- a/pkg/sdk/go/groups.go
+++ b/pkg/sdk/go/groups.go
@@ -71,7 +71,7 @@ func (sdk mfSDK) AssignThing(memberIDs []string, groupID string, token string) e
 	var ids []string
 	url := fmt.Sprintf("%s/%s/%s/things", sdk.thingsURL, groupsEndpoint, groupID)
 	ids = append(ids, memberIDs...)
-	assignThingReq := thingMembersReq{
+	assignThingReq := groupThingsReq{
 		Things: ids,
 	}
 
@@ -101,7 +101,7 @@ func (sdk mfSDK) UnassignThing(token, groupID string, thingIDs ...string) error 
 	var ids []string
 	url := fmt.Sprintf("%s/%s/%s/things", sdk.thingsURL, groupsEndpoint, groupID)
 	ids = append(ids, thingIDs...)
-	unassignThingReq := thingMembersReq{
+	unassignThingReq := groupThingsReq{
 		Things: ids,
 	}
 
@@ -161,7 +161,7 @@ func (sdk mfSDK) AssignChannel(channelIDs []string, groupID string, token string
 	var ids []string
 	url := fmt.Sprintf("%s/%s/%s/channels", sdk.thingsURL, groupsEndpoint, groupID)
 	ids = append(ids, channelIDs...)
-	assignChannelReq := channelMembersReq{
+	assignChannelReq := groupChannelsReq{
 		Channels: ids,
 	}
 
@@ -191,7 +191,7 @@ func (sdk mfSDK) UnassignChannel(token, groupID string, thingIDs ...string) erro
 	var ids []string
 	url := fmt.Sprintf("%s/%s/%s/channels", sdk.thingsURL, groupsEndpoint, groupID)
 	ids = append(ids, thingIDs...)
-	unassignChannelReq := channelMembersReq{
+	unassignChannelReq := groupChannelsReq{
 		Channels: ids,
 	}
 

--- a/pkg/sdk/go/groups.go
+++ b/pkg/sdk/go/groups.go
@@ -71,7 +71,7 @@ func (sdk mfSDK) AssignThing(memberIDs []string, groupID string, token string) e
 	var ids []string
 	url := fmt.Sprintf("%s/%s/%s/things", sdk.thingsURL, groupsEndpoint, groupID)
 	ids = append(ids, memberIDs...)
-	assignThingReq := memberReq{
+	assignThingReq := thingMembersReq{
 		Things: ids,
 	}
 
@@ -101,7 +101,7 @@ func (sdk mfSDK) UnassignThing(token, groupID string, thingIDs ...string) error 
 	var ids []string
 	url := fmt.Sprintf("%s/%s/%s/things", sdk.thingsURL, groupsEndpoint, groupID)
 	ids = append(ids, thingIDs...)
-	unassignThingReq := memberReq{
+	unassignThingReq := thingMembersReq{
 		Things: ids,
 	}
 
@@ -161,7 +161,7 @@ func (sdk mfSDK) AssignChannel(channelIDs []string, groupID string, token string
 	var ids []string
 	url := fmt.Sprintf("%s/%s/%s/channels", sdk.thingsURL, groupsEndpoint, groupID)
 	ids = append(ids, channelIDs...)
-	assignChannelReq := memberReq{
+	assignChannelReq := channelMembersReq{
 		Channels: ids,
 	}
 
@@ -191,7 +191,7 @@ func (sdk mfSDK) UnassignChannel(token, groupID string, thingIDs ...string) erro
 	var ids []string
 	url := fmt.Sprintf("%s/%s/%s/channels", sdk.thingsURL, groupsEndpoint, groupID)
 	ids = append(ids, thingIDs...)
-	unassignChannelReq := memberReq{
+	unassignChannelReq := channelMembersReq{
 		Channels: ids,
 	}
 

--- a/pkg/sdk/go/requests.go
+++ b/pkg/sdk/go/requests.go
@@ -3,8 +3,11 @@
 
 package sdk
 
-type memberReq struct {
-	Things   []string `json:"things"`
+type thingMembersReq struct {
+	Things []string `json:"things"`
+}
+
+type channelMembersReq struct {
 	Channels []string `json:"channels"`
 }
 

--- a/pkg/sdk/go/requests.go
+++ b/pkg/sdk/go/requests.go
@@ -3,11 +3,11 @@
 
 package sdk
 
-type thingMembersReq struct {
+type groupThingsReq struct {
 	Things []string `json:"things"`
 }
 
-type channelMembersReq struct {
+type groupChannelsReq struct {
 	Channels []string `json:"channels"`
 }
 

--- a/things/api/things/http/endpoint.go
+++ b/things/api/things/http/endpoint.go
@@ -645,7 +645,7 @@ func viewThingMembershipEndpoint(svc things.Service) endpoint.Endpoint {
 
 func assignThingsEndpoint(svc things.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(thingMembersReq)
+		req := request.(groupThingsReq)
 		if err := req.validate(); err != nil {
 			return nil, err
 		}
@@ -660,7 +660,7 @@ func assignThingsEndpoint(svc things.Service) endpoint.Endpoint {
 
 func unassignThingsEndpoint(svc things.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(thingMembersReq)
+		req := request.(groupThingsReq)
 		if err := req.validate(); err != nil {
 			return nil, err
 		}
@@ -724,7 +724,7 @@ func viewChannelMembershipEndpoint(svc things.Service) endpoint.Endpoint {
 
 func assignChannelsEndpoint(svc things.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(channelMembersReq)
+		req := request.(groupChannelsReq)
 		if err := req.validate(); err != nil {
 			return nil, err
 		}
@@ -739,7 +739,7 @@ func assignChannelsEndpoint(svc things.Service) endpoint.Endpoint {
 
 func unassignChannelsEndpoint(svc things.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(channelMembersReq)
+		req := request.(groupChannelsReq)
 		if err := req.validate(); err != nil {
 			return nil, err
 		}

--- a/things/api/things/http/requests.go
+++ b/things/api/things/http/requests.go
@@ -437,13 +437,13 @@ func (req listMembersReq) validate() error {
 	return nil
 }
 
-type thingMembersReq struct {
+type groupThingsReq struct {
 	token   string
 	groupID string
 	Things  []string `json:"things"`
 }
 
-func (req thingMembersReq) validate() error {
+func (req groupThingsReq) validate() error {
 	if req.token == "" {
 		return apiutil.ErrBearerToken
 	}
@@ -459,13 +459,13 @@ func (req thingMembersReq) validate() error {
 	return nil
 }
 
-type channelMembersReq struct {
+type groupChannelsReq struct {
 	token    string
 	groupID  string
 	Channels []string `json:"channels"`
 }
 
-func (req channelMembersReq) validate() error {
+func (req groupChannelsReq) validate() error {
 	if req.token == "" {
 		return apiutil.ErrBearerToken
 	}

--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -211,14 +211,14 @@ func MakeHandler(tracer opentracing.Tracer, svc things.Service, logger log.Logge
 
 	r.Post("/groups/:groupID/things", kithttp.NewServer(
 		kitot.TraceServer(tracer, "assign_things")(assignThingsEndpoint(svc)),
-		decodeThingMembersRequest,
+		decodeGroupThingsRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Delete("/groups/:groupID/things", kithttp.NewServer(
 		kitot.TraceServer(tracer, "unassign_things")(unassignThingsEndpoint(svc)),
-		decodeThingMembersRequest,
+		decodeGroupThingsRequest,
 		encodeResponse,
 		opts...,
 	))
@@ -239,14 +239,14 @@ func MakeHandler(tracer opentracing.Tracer, svc things.Service, logger log.Logge
 
 	r.Post("/groups/:groupID/channels", kithttp.NewServer(
 		kitot.TraceServer(tracer, "assign_channels")(assignChannelsEndpoint(svc)),
-		decodeChannelMembersRequest,
+		decodeGroupChannelsRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Delete("/groups/:groupID/channels", kithttp.NewServer(
 		kitot.TraceServer(tracer, "unassign_channels")(unassignChannelsEndpoint(svc)),
-		decodeChannelMembersRequest,
+		decodeGroupChannelsRequest,
 		encodeResponse,
 		opts...,
 	))
@@ -603,8 +603,8 @@ func decodeGroupRequest(_ context.Context, r *http.Request) (interface{}, error)
 	return req, nil
 }
 
-func decodeThingMembersRequest(_ context.Context, r *http.Request) (interface{}, error) {
-	req := thingMembersReq{
+func decodeGroupThingsRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	req := groupThingsReq{
 		token:   apiutil.ExtractBearerToken(r),
 		groupID: bone.GetValue(r, groupIDKey),
 	}
@@ -616,8 +616,8 @@ func decodeThingMembersRequest(_ context.Context, r *http.Request) (interface{},
 	return req, nil
 }
 
-func decodeChannelMembersRequest(_ context.Context, r *http.Request) (interface{}, error) {
-	req := channelMembersReq{
+func decodeGroupChannelsRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	req := groupChannelsReq{
 		token:   apiutil.ExtractBearerToken(r),
 		groupID: bone.GetValue(r, groupIDKey),
 	}

--- a/things/groups.go
+++ b/things/groups.go
@@ -13,9 +13,6 @@ var (
 	// ErrUnassignGroupThing indicates failure to unassign thing from a group.
 	ErrUnassignGroupThing = errors.New("failed to unassign thing from a group")
 
-	// ErrGroupNotEmpty indicates group is not empty, can't be deleted.
-	ErrGroupNotEmpty = errors.New("group is not empty")
-
 	// ErrThingAlreadyAssigned indicates that thing is already assigned.
 	ErrThingAlreadyAssigned = errors.New("thing is already assigned")
 

--- a/things/mocks/groups.go
+++ b/things/mocks/groups.go
@@ -73,7 +73,15 @@ func (grm *groupRepositoryMock) Remove(ctx context.Context, id string) error {
 	if _, ok := grm.groups[id]; !ok {
 		return errors.ErrNotFound
 	}
-	
+
+	for _, thingID := range grm.things[id] {
+		delete(grm.thingMembership, thingID)
+	}
+
+	for _, channelID := range grm.channels[id] {
+		delete(grm.channelMembership, channelID)
+	}
+
 	// This is not quite exact, it should go in depth
 	delete(grm.groups, id)
 

--- a/things/mocks/groups.go
+++ b/things/mocks/groups.go
@@ -139,8 +139,8 @@ func (grm *groupRepositoryMock) UnassignThing(ctx context.Context, groupID strin
 			return errors.ErrNotFound
 		}
 
-		for i, member := range things {
-			if member == thingID {
+		for i, th := range things {
+			if th == thingID {
 				grm.things[groupID] = append(things[:i], things[i+1:]...)
 				delete(grm.thingMembership, thingID)
 				break
@@ -257,8 +257,8 @@ func (grm *groupRepositoryMock) UnassignChannel(ctx context.Context, groupID str
 			return errors.ErrNotFound
 		}
 
-		for i, member := range channels {
-			if member == channelID {
+		for i, ch := range channels {
+			if ch == channelID {
 				grm.channels[groupID] = append(channels[:i], channels[i+1:]...)
 				delete(grm.channelMembership, channelID)
 				break

--- a/things/mocks/groups.go
+++ b/things/mocks/groups.go
@@ -73,10 +73,7 @@ func (grm *groupRepositoryMock) Remove(ctx context.Context, id string) error {
 	if _, ok := grm.groups[id]; !ok {
 		return errors.ErrNotFound
 	}
-
-	if len(grm.things[id]) > 0 {
-		return things.ErrGroupNotEmpty
-	}
+	
 	// This is not quite exact, it should go in depth
 	delete(grm.groups, id)
 

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -125,10 +125,6 @@ func (gr groupRepository) Remove(ctx context.Context, groupID string) error {
 			case pgerrcode.InvalidTextRepresentation:
 				return errors.Wrap(errors.ErrMalformedEntity, err)
 			case pgerrcode.ForeignKeyViolation:
-				switch pqErr.ConstraintName {
-				case groupIDFkeyy:
-					return errors.Wrap(things.ErrGroupNotEmpty, err)
-				}
 				return errors.Wrap(errors.ErrConflict, err)
 			}
 		}

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -17,7 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-var groupIDFkeyy = "group_relations_group_id_fkey"
+var groupIDFkeyy = "group_things_group_id_fkey"
 
 var _ things.GroupRepository = (*groupRepository)(nil)
 
@@ -243,16 +243,16 @@ func (gr groupRepository) RetrieveGroupThings(ctx context.Context, groupID strin
 	case true:
 		q = fmt.Sprintf(`SELECT t.id, t.owner, t.name, t.metadata, t.key
 			FROM  things t
-			WHERE t.id NOT IN (SELECT gr.member_id FROM group_relations gr WHERE gr.group_id = :group_id)
+			WHERE t.id NOT IN (SELECT gr.thing_id FROM group_things gr WHERE gr.group_id = :group_id)
 			%s %s;`, mq, olq)
 		qc = fmt.Sprintf(`SELECT COUNT(*) FROM things t
-			WHERE t.id NOT IN (SELECT gr.member_id FROM group_relations gr WHERE gr.group_id = :group_id) %s;`, mq)
+			WHERE t.id NOT IN (SELECT gr.thing_id FROM group_things gr WHERE gr.group_id = :group_id) %s;`, mq)
 	default:
 		q = fmt.Sprintf(`SELECT t.id, t.owner, t.name, t.metadata, t.key
-			FROM group_relations gr, things t
-			WHERE gr.group_id = :group_id and gr.member_id = t.id
+			FROM group_things gr, things t
+			WHERE gr.group_id = :group_id and gr.thing_id = t.id
 			%s %s;`, mq, olq)
-		qc = fmt.Sprintf(`SELECT COUNT(*) FROM group_relations gr WHERE gr.group_id = :group_id %s;`, mq)
+		qc = fmt.Sprintf(`SELECT COUNT(*) FROM group_things gr WHERE gr.group_id = :group_id %s;`, mq)
 	}
 
 	params, err := toDBGroupThingsPage("", groupID, pm)
@@ -299,9 +299,9 @@ func (gr groupRepository) RetrieveGroupThings(ctx context.Context, groupID strin
 }
 
 func (gr groupRepository) RetrieveThingMembership(ctx context.Context, thingID string) (string, error) {
-	q := `SELECT group_id FROM group_relations WHERE member_id = :member_id;`
+	q := `SELECT group_id FROM group_things WHERE thing_id = :thing_id;`
 
-	params := map[string]interface{}{"member_id": thingID}
+	params := map[string]interface{}{"thing_id": thingID}
 
 	rows, err := gr.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
@@ -320,7 +320,7 @@ func (gr groupRepository) RetrieveThingMembership(ctx context.Context, thingID s
 }
 
 func (gr groupRepository) RetrieveAllThingRelations(ctx context.Context) ([]things.GroupThingRelation, error) {
-	q := `SELECT group_id, member_id, created_at, updated_at FROM group_relations`
+	q := `SELECT group_id, thing_id, created_at, updated_at FROM group_things`
 
 	rows, err := gr.db.NamedQueryContext(ctx, q, map[string]interface{}{})
 	if err != nil {
@@ -351,8 +351,8 @@ func (gr groupRepository) AssignThing(ctx context.Context, groupID string, ids .
 		return errors.Wrap(things.ErrAssignGroupThing, err)
 	}
 
-	qIns := `INSERT INTO group_relations (group_id, member_id, created_at, updated_at)
-		VALUES(:group_id, :member_id, :created_at, :updated_at)`
+	qIns := `INSERT INTO group_things (group_id, thing_id, created_at, updated_at)
+		VALUES(:group_id, :thing_id, :created_at, :updated_at)`
 
 	for _, id := range ids {
 		created := time.Now()
@@ -395,7 +395,7 @@ func (gr groupRepository) UnassignThing(ctx context.Context, groupID string, ids
 		return errors.Wrap(things.ErrUnassignGroupThing, err)
 	}
 
-	qDel := `DELETE from group_relations WHERE group_id = :group_id AND member_id = :member_id`
+	qDel := `DELETE from group_things WHERE group_id = :group_id AND thing_id = :thing_id`
 
 	for _, id := range ids {
 		dbt, err := toDBThingRelation(id, groupID)
@@ -694,7 +694,7 @@ type dbGroup struct {
 
 type dbGroupThingsPage struct {
 	GroupID  string     `db:"group_id"`
-	ThingID  string     `db:"member_id"`
+	ThingID  string     `db:"thing_id"`
 	Metadata dbMetadata `db:"metadata"`
 	Limit    uint64     `db:"limit"`
 	Offset   uint64     `db:"offset"`
@@ -736,7 +736,7 @@ func toGroup(dbu dbGroup) (things.Group, error) {
 
 type dbThingRelation struct {
 	GroupID   sql.NullString `db:"group_id"`
-	ThingID   sql.NullString `db:"member_id"`
+	ThingID   sql.NullString `db:"thing_id"`
 	CreatedAt time.Time      `db:"created_at"`
 	UpdatedAt time.Time      `db:"updated_at"`
 }

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -17,7 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-var groupIDFkeyy = "group_things_group_id_fkey"
+var groupIDFkey = "group_things_group_id_fkey"
 
 var _ things.GroupRepository = (*groupRepository)(nil)
 

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -17,8 +17,6 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-var groupIDFkey = "group_things_group_id_fkey"
-
 var _ things.GroupRepository = (*groupRepository)(nil)
 
 type groupRepository struct {

--- a/things/postgres/groups_test.go
+++ b/things/postgres/groups_test.go
@@ -275,7 +275,7 @@ func TestGroupRemove(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("thing assign got unexpected error: %s", err))
 
 	err = groupRepo.Remove(context.Background(), group1.ID)
-	assert.True(t, errors.Contains(err, things.ErrGroupNotEmpty), fmt.Sprintf("delete non empty group: expected %v got %v\n", things.ErrGroupNotEmpty, err))
+	assert.True(t, errors.Contains(err, nil), fmt.Sprintf("delete non empty group: expected %v got %v\n", nil, err))
 
 	err = groupRepo.Remove(context.Background(), group2.ID)
 	assert.True(t, errors.Contains(err, nil), fmt.Sprintf("delete empty group: expected %v got %v\n", nil, err))

--- a/things/postgres/groups_test.go
+++ b/things/postgres/groups_test.go
@@ -785,7 +785,7 @@ func TestRetrieveAllGroupRelations(t *testing.T) {
 }
 
 func cleanUp(t *testing.T) {
-	_, err := db.Exec("delete from group_relations")
+	_, err := db.Exec("delete from group_things")
 	require.Nil(t, err, fmt.Sprintf("clean relations unexpected error: %s", err))
 	_, err = db.Exec("delete from group_channels")
 	require.Nil(t, err, fmt.Sprintf("clean relations unexpected error: %s", err))

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -124,7 +124,6 @@ func migrateDB(db *sqlx.DB) error {
 				Down: []string{
 					"DROP TABLE groups",
 					"DROP TABLE group_relations",
-					"DROP TABLE group_channels",
 				},
 			},
 			{
@@ -146,6 +145,9 @@ func migrateDB(db *sqlx.DB) error {
 						FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE,
 						PRIMARY KEY (channel_id, group_id)
 					)`,
+				},
+				Down: []string{
+					"DROP TABLE group_channels",
 				},
 			},
 		},

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -136,7 +136,8 @@ func migrateDB(db *sqlx.DB) error {
 			{
 				Id: "things_7",
 				Up: []string{
-					`ALTER TABLE group_relations ADD CONSTRAINT group_id_fkey FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE;`,
+					`ALTER TABLE group_relations ADD CONSTRAINT group_id_fkey 
+					 FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE;`,
 				},
 			},
 			{

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -129,25 +129,27 @@ func migrateDB(db *sqlx.DB) error {
 			{
 				Id: "things_6",
 				Up: []string{
-					`ALTER TABLE group_relations ADD CONSTRAINT member_id_unique UNIQUE (member_id);`,
-					`ALTER TABLE group_relations ADD CONSTRAINT group_id_fkey
-					 FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE;`,
-				},
-			},
-			{
-				Id: "things_7",
-				Up: []string{
+					`DROP TABLE group_relations`,
+					`CREATE TABLE IF NOT EXISTS group_things (
+                                                thing_id    UUID UNIQUE NOT NULL,
+                                                group_id    UUID NOT NULL,
+                                                created_at  TIMESTAMPTZ,
+                                                updated_at  TIMESTAMPTZ,
+                                                FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE,
+                                                PRIMARY KEY (thing_id, group_id)
+                                        )`,
 					`CREATE TABLE IF NOT EXISTS group_channels (
-						channel_id  UUID UNIQUE NOT NULL,
-						group_id    UUID NOT NULL,
-						created_at  TIMESTAMPTZ,
-						updated_at  TIMESTAMPTZ,
-						FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE,
-						PRIMARY KEY (channel_id, group_id)
-					)`,
+                                                channel_id  UUID UNIQUE NOT NULL,
+                                                group_id    UUID NOT NULL,
+                                                created_at  TIMESTAMPTZ,
+                                                updated_at  TIMESTAMPTZ,
+                                                FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE,
+                                                PRIMARY KEY (channel_id, group_id)
+                                        )`,
 				},
 				Down: []string{
 					"DROP TABLE group_channels",
+					"DROP TABLE group_things",
 				},
 			},
 		},

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -131,17 +131,12 @@ func migrateDB(db *sqlx.DB) error {
 				Id: "things_6",
 				Up: []string{
 					`ALTER TABLE group_relations ADD CONSTRAINT member_id_unique UNIQUE (member_id);`,
-				},
-			},
-			{
-				Id: "things_7",
-				Up: []string{
-					`ALTER TABLE group_relations ADD CONSTRAINT group_id_fkey 
+					`ALTER TABLE group_relations ADD CONSTRAINT group_id_fkey
 					 FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE;`,
 				},
 			},
 			{
-				Id: "things_8",
+				Id: "things_7",
 				Up: []string{
 					`CREATE TABLE IF NOT EXISTS group_channels (
 						channel_id  UUID UNIQUE NOT NULL,

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -120,14 +120,6 @@ func migrateDB(db *sqlx.DB) error {
 						FOREIGN KEY (group_id) REFERENCES groups (id),
 						PRIMARY KEY (member_id, group_id)
 				        )`,
-					`CREATE TABLE IF NOT EXISTS group_channels (
-					       channel_id  UUID UNIQUE NOT NULL,
-					       group_id    UUID NOT NULL,
-					       created_at  TIMESTAMPTZ,
-					       updated_at  TIMESTAMPTZ,
-					       FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE,
-					       PRIMARY KEY (channel_id, group_id)
-			                )`,
 				},
 				Down: []string{
 					"DROP TABLE groups",
@@ -139,6 +131,25 @@ func migrateDB(db *sqlx.DB) error {
 				Id: "things_6",
 				Up: []string{
 					`ALTER TABLE group_relations ADD CONSTRAINT member_id_unique UNIQUE (member_id);`,
+				},
+			},
+			{
+				Id: "things_7",
+				Up: []string{
+					`ALTER TABLE group_relations ADD CONSTRAINT group_id_fkey FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE;`,
+				},
+			},
+			{
+				Id: "things_8",
+				Up: []string{
+					`CREATE TABLE IF NOT EXISTS group_channels (
+						channel_id  UUID UNIQUE NOT NULL,
+						group_id    UUID NOT NULL,
+						created_at  TIMESTAMPTZ,
+						updated_at  TIMESTAMPTZ,
+						FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE,
+						PRIMARY KEY (channel_id, group_id)
+					)`,
 				},
 			},
 		},

--- a/things/service.go
+++ b/things/service.go
@@ -234,7 +234,6 @@ func (ts *thingsService) createThing(ctx context.Context, thing *Thing, identity
 	if len(ths) == 0 {
 		return Thing{}, errors.ErrCreateEntity
 	}
-
 	return ths[0], nil
 }
 

--- a/things/service.go
+++ b/things/service.go
@@ -781,20 +781,6 @@ func (ts *thingsService) RemoveGroup(ctx context.Context, token, id string) erro
 		return errors.ErrAuthorization
 	}
 
-	thp, err := ts.groups.RetrieveGroupThings(ctx, id, PageMetadata{})
-	if err != nil {
-		return err
-	}
-
-	var thIDs []string
-	for _, th := range thp.Things {
-		thIDs = append(thIDs, th.ID)
-	}
-
-	if err := ts.groups.UnassignThing(ctx, id, thIDs...); err != nil {
-		return err
-	}
-
 	return ts.groups.Remove(ctx, id)
 }
 


### PR DESCRIPTION
Moved `group_channels` table to new init

This is related to issue:
#270 