### PR TITLE
MF-287 - List disconnected things by channel within the same group

### DIFF
--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -255,6 +255,10 @@ func (svc *mainfluxThings) ListGroupThings(ctx context.Context, token, groupID s
 	panic("not implemented")
 }
 
+func (svc *mainfluxThings) ListGroupThingsByChannel(ctx context.Context, token, grID, chID string, pm things.PageMetadata) (things.GroupThingsPage, error) {
+	panic("not implemented")
+}
+
 func (svc *mainfluxThings) CreateGroups(ctx context.Context, token string, groups ...things.Group) ([]things.Group, error) {
 	panic("not implemented")
 }

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -396,6 +396,19 @@ func (lm *loggingMiddleware) ListGroupThings(ctx context.Context, token, groupID
 	return lm.svc.ListGroupThings(ctx, token, groupID, pm)
 }
 
+func (lm *loggingMiddleware) ListGroupThingsByChannel(ctx context.Context, token, grID, chID string, pm things.PageMetadata) (tp things.GroupThingsPage, err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method list_group_things_by_channel for token %s, group %s and channel %s took %s to complete", token, grID, chID, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.ListGroupThingsByChannel(ctx, token, grID, chID, pm)
+}
+
 func (lm *loggingMiddleware) ViewThingMembership(ctx context.Context, token, thingID string) (gr things.Group, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_thing_membership for token %s took %s to complete", token, time.Since(begin))

--- a/things/api/metrics.go
+++ b/things/api/metrics.go
@@ -282,6 +282,15 @@ func (ms *metricsMiddleware) ListGroupThings(ctx context.Context, token, groupID
 	return ms.svc.ListGroupThings(ctx, token, groupID, pm)
 }
 
+func (ms *metricsMiddleware) ListGroupThingsByChannel(ctx context.Context, token, grID, chID string, pm things.PageMetadata) (things.GroupThingsPage, error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "list_group_things_by_channel").Add(1)
+		ms.latency.With("method", "list_group_things_by_channel").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.ListGroupThingsByChannel(ctx, token, grID, chID, pm)
+}
+
 func (ms *metricsMiddleware) ViewThingMembership(ctx context.Context, token, thingID string) (things.Group, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "view_thing_membership").Add(1)

--- a/things/api/things/http/endpoint.go
+++ b/things/api/things/http/endpoint.go
@@ -672,6 +672,22 @@ func listGroupChannelsEndpoint(svc things.Service) endpoint.Endpoint {
 	}
 }
 
+func listGroupThingsByChannelEndpoint(svc things.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(listGroupThingsByChannelReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+		
+		page, err := svc.ListGroupThingsByChannel(ctx, req.token, req.groupID, req.channelID, req.pageMetadata)
+		if err != nil {
+			return nil, err
+		}
+
+		return buildGroupThingsResponse(page), nil
+	}
+}
+
 func viewChannelMembershipEndpoint(svc things.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listMembersReq)

--- a/things/api/things/http/requests.go
+++ b/things/api/things/http/requests.go
@@ -473,6 +473,25 @@ func (req groupChannelsReq) validate() error {
 	return nil
 }
 
+type listGroupThingsByChannelReq struct {
+	token        string
+	groupID      string
+	channelID    string
+	pageMetadata things.PageMetadata
+}
+
+func (req listGroupThingsByChannelReq) validate() error {
+	if req.token == "" {
+		return apiutil.ErrBearerToken
+	}
+
+	if req.channelID == "" || req.groupID == "" {
+		return apiutil.ErrMissingID
+	}
+
+	return nil
+}
+
 type groupReq struct {
 	token string
 	id    string

--- a/things/groups.go
+++ b/things/groups.go
@@ -19,6 +19,9 @@ var (
 	// ErrRetrieveGroupThings indicates failure to retrieve group things.
 	ErrRetrieveGroupThings = errors.New("failed to retrieve group things")
 
+	// ErrRetrieveGroupThingsByChannel indicates failure to retrieve group things by channel.
+	ErrRetrieveGroupThingsByChannel = errors.New("failed to retrieve group things by channel")
+
 	// ErrRetrieveThingMembership indicates failure to retrieve thing membership
 	ErrRetrieveThingMembership = errors.New("failed to retrieve thing membership")
 
@@ -118,6 +121,9 @@ type GroupRepository interface {
 
 	// RetrieveGroupThings retrieves page of things that are assigned to a group identified by groupID.
 	RetrieveGroupThings(ctx context.Context, groupID string, pm PageMetadata) (GroupThingsPage, error)
+
+	// RetrieveGroupThingsByChannel retrieves page of disconnected things by channel that are assigned to a group same as channel.
+	RetrieveGroupThingsByChannel(ctx context.Context, grID, chID string, pm PageMetadata) (GroupThingsPage, error)
 
 	// AssignThing adds a thing to a group
 	AssignThing(ctx context.Context, groupID string, thingIDs ...string) error

--- a/things/mocks/groups.go
+++ b/things/mocks/groups.go
@@ -290,6 +290,10 @@ func (grm *groupRepositoryMock) RetrieveGroupChannels(ctx context.Context, group
 	panic("not implemented")
 }
 
+func (grm *groupRepositoryMock) RetrieveGroupThingsByChannel(ctx context.Context, groupID, channelID string, pm things.PageMetadata) (things.GroupThingsPage, error) {
+	panic("not implemented")
+}
+
 func (grm *groupRepositoryMock) RetrieveByAdmin(ctx context.Context, pm things.PageMetadata) (things.GroupPage, error) {
 	panic("not implemented")
 }

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -292,6 +292,72 @@ func (gr groupRepository) RetrieveGroupThings(ctx context.Context, groupID strin
 	return page, nil
 }
 
+func (gr groupRepository) RetrieveGroupThingsByChannel(ctx context.Context, groupID, channelID string, pm things.PageMetadata) (things.GroupThingsPage, error) {
+	_, mq, err := dbutil.GetMetadataQuery("groups", pm.Metadata)
+	if err != nil {
+		return things.GroupThingsPage{}, errors.Wrap(things.ErrRetrieveGroupThings, err)
+	}
+
+	olq := "LIMIT :limit OFFSET :offset"
+	if pm.Limit == 0 {
+		olq = ""
+	}
+
+	q := fmt.Sprintf(`SELECT t.id, t.owner, t.name, t.metadata, t.key
+		FROM group_things gr, things t, group_channels gc
+		WHERE gr.group_id = :group_id and gr.thing_id = t.id and gc.group_id = gr.group_id and gc.channel_id = :channel_id and t.id
+		NOT IN (SELECT c.thing_id FROM connections c WHERE c.channel_id = :channel_id)
+		%s %s;`, mq, olq)
+
+	qc := fmt.Sprintf(`SELECT COUNT(*) FROM group_things gr, things t, group_channels gc
+		WHERE gr.group_id = :group_id and gr.thing_id = t.id and gc.group_id = gr.group_id and gc.channel_id = :channel_id and t.id
+		NOT IN (SELECT ct.thing_id FROM connections ct WHERE ct.channel_id = :channel_id) %s;`, mq)
+
+	params := map[string]interface{}{
+		"group_id":   groupID,
+		"channel_id": channelID,
+		"limit":      pm.Limit,
+		"offset":     pm.Offset,
+	}
+
+	rows, err := gr.db.NamedQueryContext(ctx, q, params)
+	if err != nil {
+		return things.GroupThingsPage{}, errors.Wrap(things.ErrRetrieveGroupThingsByChannel, err)
+	}
+	defer rows.Close()
+
+	var items []things.Thing
+	for rows.Next() {
+		dbt := dbThing{}
+		if err := rows.StructScan(&dbt); err != nil {
+			return things.GroupThingsPage{}, errors.Wrap(things.ErrRetrieveGroupThingsByChannel, err)
+		}
+
+		th, err := toThing(dbt)
+		if err != nil {
+			return things.GroupThingsPage{}, err
+		}
+
+		items = append(items, th)
+	}
+
+	total, err := total(ctx, gr.db, qc, params)
+	if err != nil {
+		return things.GroupThingsPage{}, errors.Wrap(things.ErrRetrieveGroupThingsByChannel, err)
+	}
+
+	page := things.GroupThingsPage{
+		Things: items,
+		PageMetadata: things.PageMetadata{
+			Total:  total,
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
+		},
+	}
+
+	return page, nil
+}
+
 func (gr groupRepository) RetrieveThingMembership(ctx context.Context, thingID string) (string, error) {
 	q := `SELECT group_id FROM group_things WHERE thing_id = :thing_id;`
 

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -311,7 +311,8 @@ func (gr groupRepository) RetrieveGroupThingsByChannel(ctx context.Context, grou
 
 	qc := fmt.Sprintf(`SELECT COUNT(*) FROM group_things gr, things t, group_channels gc
 		WHERE gr.group_id = :group_id and gr.thing_id = t.id and gc.group_id = gr.group_id and gc.channel_id = :channel_id and t.id
-		NOT IN (SELECT ct.thing_id FROM connections ct) %s;`, mq)
+		NOT IN (SELECT ct.thing_id FROM connections ct)
+		%s;`, mq)
 
 	params := map[string]interface{}{
 		"group_id":   groupID,

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -306,12 +306,12 @@ func (gr groupRepository) RetrieveGroupThingsByChannel(ctx context.Context, grou
 	q := fmt.Sprintf(`SELECT t.id, t.owner, t.name, t.metadata, t.key
 		FROM group_things gr, things t, group_channels gc
 		WHERE gr.group_id = :group_id and gr.thing_id = t.id and gc.group_id = gr.group_id and gc.channel_id = :channel_id and t.id
-		NOT IN (SELECT c.thing_id FROM connections c WHERE c.channel_id = :channel_id)
+		NOT IN (SELECT c.thing_id FROM connections c)
 		%s %s;`, mq, olq)
 
 	qc := fmt.Sprintf(`SELECT COUNT(*) FROM group_things gr, things t, group_channels gc
 		WHERE gr.group_id = :group_id and gr.thing_id = t.id and gc.group_id = gr.group_id and gc.channel_id = :channel_id and t.id
-		NOT IN (SELECT ct.thing_id FROM connections ct WHERE ct.channel_id = :channel_id) %s;`, mq)
+		NOT IN (SELECT ct.thing_id FROM connections ct) %s;`, mq)
 
 	params := map[string]interface{}{
 		"group_id":   groupID,

--- a/things/redis/streams.go
+++ b/things/redis/streams.go
@@ -260,6 +260,10 @@ func (es eventStore) ListGroupThings(ctx context.Context, token, groupID string,
 	return es.svc.ListGroupThings(ctx, token, groupID, pm)
 }
 
+func (es eventStore) ListGroupThingsByChannel(ctx context.Context, token, grID, chID string, pm things.PageMetadata) (things.GroupThingsPage, error) {
+	return es.svc.ListGroupThingsByChannel(ctx, token, grID, chID, pm)
+}
+
 func (es eventStore) CreateGroups(ctx context.Context, token string, grs ...things.Group) ([]things.Group, error) {
 	return es.svc.CreateGroups(ctx, token, grs...)
 }

--- a/things/service.go
+++ b/things/service.go
@@ -986,8 +986,9 @@ func (ts *thingsService) ListGroupThingsByChannel(ctx context.Context, token, gr
 		return GroupThingsPage{}, err
 	}
 
-	if user.GetId() != group.OwnerID {
-		return GroupThingsPage{}, errors.ErrAuthorization
+	_, err = ts.auth.Authorize(ctx, &mainflux.AuthorizeReq{Token: token, Subject: auth.GroupSubject, Object: grID, Action: auth.ReadAction})
+	if user.GetId() != group.OwnerID && err != nil {
+		return GroupThingsPage{}, err
 	}
 
 	return ts.groups.RetrieveGroupThingsByChannel(ctx, grID, chID, pm)

--- a/things/tracing/groups.go
+++ b/things/tracing/groups.go
@@ -8,22 +8,23 @@ import (
 )
 
 const (
-	saveGroupOp                 = "save_group"
-	updateGroupOp               = "update_group"
-	removeGroupOp               = "remove_group"
-	retrieveAllOp               = "retrieve_all"
-	retrieveGroupByIDOp         = "retrieve_group_by_id"
-	retrieveGroupByIDsOp        = "retrieve_group_by_ids"
-	retrieveByOwnerOp           = "retrieve_by_owner"
-	retrieveThingMembershipOp   = "retrieve_thing_membership"
-	retrieveChannelMembershipOp = "retrieve_channel_membership"
-	retrieveGroupThingsOp       = "retrieve_group_things"
-	retrieveGroupChannelsOp     = "retrieve_group_channels"
-	assignThingOp               = "assign_thing"
-	unassignThingOp             = "unassign_thing"
-	assignChannelOp             = "assign_channel"
-	unassignChannelOp           = "unassign_channel"
-	retrieveAllThingRelationsOp = "retrieve_all_thing_relations"
+	saveGroupOp                    = "save_group"
+	updateGroupOp                  = "update_group"
+	removeGroupOp                  = "remove_group"
+	retrieveAllOp                  = "retrieve_all"
+	retrieveGroupByIDOp            = "retrieve_group_by_id"
+	retrieveGroupByIDsOp           = "retrieve_group_by_ids"
+	retrieveByOwnerOp              = "retrieve_by_owner"
+	retrieveThingMembershipOp      = "retrieve_thing_membership"
+	retrieveChannelMembershipOp    = "retrieve_channel_membership"
+	retrieveGroupThingsOp          = "retrieve_group_things"
+	retrieveGroupThingsByChannelOp = "retrieve_group_things_by_channel"
+	retrieveGroupChannelsOp        = "retrieve_group_channels"
+	assignThingOp                  = "assign_thing"
+	unassignThingOp                = "unassign_thing"
+	assignChannelOp                = "assign_channel"
+	unassignChannelOp              = "unassign_channel"
+	retrieveAllThingRelationsOp    = "retrieve_all_thing_relations"
 )
 
 var _ things.GroupRepository = (*groupRepositoryMiddleware)(nil)
@@ -118,6 +119,14 @@ func (grm groupRepositoryMiddleware) RetrieveGroupThings(ctx context.Context, gr
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
 	return grm.repo.RetrieveGroupThings(ctx, groupID, pm)
+}
+
+func (grm groupRepositoryMiddleware) RetrieveGroupThingsByChannel(ctx context.Context, groupID, channelID string, pm things.PageMetadata) (things.GroupThingsPage, error) {
+	span := createSpan(ctx, grm.tracer, retrieveGroupThingsByChannelOp)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return grm.repo.RetrieveGroupThingsByChannel(ctx, groupID, channelID, pm)
 }
 
 func (grm groupRepositoryMiddleware) RetrieveAllThingRelations(ctx context.Context) ([]things.GroupThingRelation, error) {


### PR DESCRIPTION
Added endpoint to list all  disconnected things assigned to the same group as channel.

Resolves #287 
