### PR TITLE
MF-292 - Fix unassigned Things and Channels by group list

### DIFF
--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -246,7 +246,7 @@ func MakeHandler(tracer opentracing.Tracer, svc things.Service, logger log.Logge
 
 	r.Get("/groups/:groupID/channels/:channelID/things", kithttp.NewServer(
 		kitot.TraceServer(tracer, "list_group_things_by_channel")(listGroupThingsByChannelEndpoint(svc)),
-		listGroupThingsByChannel,
+		decodeListGroupThingsByChannel,
 		encodeResponse,
 		opts...,
 	))
@@ -463,7 +463,7 @@ func decodeListByConnection(_ context.Context, r *http.Request) (interface{}, er
 	return req, nil
 }
 
-func listGroupThingsByChannel(_ context.Context, r *http.Request) (interface{}, error) {
+func decodeListGroupThingsByChannel(_ context.Context, r *http.Request) (interface{}, error) {
 	o, err := apiutil.ReadUintQuery(r, offsetKey, defOffset)
 	if err != nil {
 		return nil, err

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -237,10 +237,10 @@ func (gr groupRepository) RetrieveGroupThings(ctx context.Context, groupID strin
 	case true:
 		q = fmt.Sprintf(`SELECT t.id, t.owner, t.name, t.metadata, t.key
 			FROM  things t
-			WHERE t.id NOT IN (SELECT gr.thing_id FROM group_things gr WHERE gr.group_id = :group_id)
+			WHERE t.id NOT IN (SELECT gr.thing_id FROM group_things gr)
 			%s %s;`, mq, olq)
 		qc = fmt.Sprintf(`SELECT COUNT(*) FROM things t
-			WHERE t.id NOT IN (SELECT gr.thing_id FROM group_things gr WHERE gr.group_id = :group_id) %s;`, mq)
+			WHERE t.id NOT IN (SELECT gr.thing_id FROM group_things gr) %s;`, mq)
 	default:
 		q = fmt.Sprintf(`SELECT t.id, t.owner, t.name, t.metadata, t.key
 			FROM group_things gr, things t
@@ -503,10 +503,10 @@ func (gr groupRepository) RetrieveGroupChannels(ctx context.Context, groupID str
 	case true:
 		q = fmt.Sprintf(`SELECT c.id, c.owner, c.name, c.metadata
 			FROM channels c
-			WHERE c.id NOT IN (SELECT gr.channel_id FROM group_channels gr WHERE gr.group_id = :group_id)
+			WHERE c.id NOT IN (SELECT gr.channel_id FROM group_channels gr)
 			%s %s;`, mq, olq)
 		qc = fmt.Sprintf(`SELECT COUNT(*) FROM channels c
-			WHERE c.id NOT IN (SELECT gr.channel_id FROM group_channels gr WHERE gr.group_id = :group_id) %s;`, mq)
+			WHERE c.id NOT IN (SELECT gr.channel_id FROM group_channels gr) %s;`, mq)
 	default:
 		q = fmt.Sprintf(`SELECT c.id, c.owner, c.name, c.metadata
 			FROM group_channels gr, channels c


### PR DESCRIPTION
Fixed queries to list unassigned things and channels from all groups instead of specific one.

Resolves: #292 