### PR TITLE
MF-328 - Add permission to admin to see group channels

### DIFF
--- a/things/service.go
+++ b/things/service.go
@@ -993,6 +993,10 @@ func (ts *thingsService) ListGroupThingsByChannel(ctx context.Context, token, gr
 		return GroupThingsPage{}, err
 	}
 
+	if err := ts.authorize(ctx, auth.RootSubject, token); err == nil {
+		return ts.groups.RetrieveGroupThingsByChannel(ctx, grID, chID, pm)
+	}
+
 	_, err = ts.auth.Authorize(ctx, &mainflux.AuthorizeReq{Token: token, Subject: auth.GroupSubject, Object: grID, Action: auth.ReadAction})
 	if user.GetId() != group.OwnerID && err != nil {
 		return GroupThingsPage{}, err
@@ -1012,13 +1016,17 @@ func (ts *thingsService) ListGroupChannels(ctx context.Context, token, groupID s
 		return GroupChannelsPage{}, err
 	}
 
-	if user.GetId() != group.OwnerID {
-		return GroupChannelsPage{}, errors.ErrAuthorization
-	}
-
 	gchp, err := ts.groups.RetrieveGroupChannels(ctx, user.GetId(), groupID, pm)
 	if err != nil {
 		return GroupChannelsPage{}, err
+	}
+
+	if err := ts.authorize(ctx, auth.RootSubject, token); err == nil {
+		return gchp, nil
+	}
+
+	if user.GetId() != group.OwnerID {
+		return GroupChannelsPage{}, errors.ErrAuthorization
 	}
 
 	return gchp, nil


### PR DESCRIPTION
Added permission to admin so he can see assigned and unassigned group channels.

Resolves: #328