### PR TITLE
MF-338 - Add members emails for create and update policies

### DIFF
--- a/auth/api/http/orgs/endpoint.go
+++ b/auth/api/http/orgs/endpoint.go
@@ -286,16 +286,16 @@ func createPoliciesEndpint(svc auth.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		var membersPolicies []auth.MemberPolicy
+		var giByEmails []auth.GroupInvitationByEmail
 		for _, m := range req.MembersPolicies {
-			memberPolicy := auth.MemberPolicy{
-				MemberID: m.MemberID,
-				Policy:   m.Policy,
+			giByEmail := auth.GroupInvitationByEmail{
+				Email:  m.Email,
+				Policy: m.Policy,
 			}
-			membersPolicies = append(membersPolicies, memberPolicy)
+			giByEmails = append(giByEmails, giByEmail)
 		}
 
-		if err := svc.CreatePolicies(ctx, req.token, req.groupID, membersPolicies...); err != nil {
+		if err := svc.CreatePolicies(ctx, req.token, req.groupID, giByEmails...); err != nil {
 			return nil, err
 		}
 
@@ -310,17 +310,17 @@ func updatePoliciesEndpoint(svc auth.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		var membersPolicies []auth.MemberPolicy
+		var giByEmails []auth.GroupInvitationByEmail
 		for _, mp := range req.MembersPolicies {
-			memberPolicy := auth.MemberPolicy{
-				MemberID: mp.MemberID,
-				Policy:   mp.Policy,
+			giByEmail := auth.GroupInvitationByEmail{
+				Email:  mp.Email,
+				Policy: mp.Policy,
 			}
 
-			membersPolicies = append(membersPolicies, memberPolicy)
+			giByEmails = append(giByEmails, giByEmail)
 		}
 
-		if err := svc.UpdatePolicies(ctx, req.token, req.groupID, membersPolicies...); err != nil {
+		if err := svc.UpdatePolicies(ctx, req.token, req.groupID, giByEmails...); err != nil {
 			return nil, err
 		}
 

--- a/auth/api/http/orgs/requests.go
+++ b/auth/api/http/orgs/requests.go
@@ -241,7 +241,7 @@ func (req listMembersPoliciesReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	if req.groupID == ""  {
+	if req.groupID == "" {
 		return apiutil.ErrMissingID
 	}
 
@@ -261,8 +261,8 @@ func (req backupReq) validate() error {
 }
 
 type memberPolicy struct {
-	MemberID string `json:"member_id"`
-	Policy   string `json:"policy"`
+	Email  string `json:"email"`
+	Policy string `json:"policy"`
 }
 
 type membersPoliciesReq struct {
@@ -289,7 +289,7 @@ func (req membersPoliciesReq) validate() error {
 			return apiutil.ErrInvalidPolicy
 		}
 
-		if mp.MemberID == "" {
+		if mp.Email == "" {
 			return apiutil.ErrMissingID
 		}
 	}

--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -353,7 +353,7 @@ func (lm *loggingMiddleware) AssignRole(ctx context.Context, id, role string) (e
 	return lm.svc.AssignRole(ctx, id, role)
 }
 
-func (lm *loggingMiddleware) CreatePolicies(ctx context.Context, token, groupID string, mp ...auth.MemberPolicy) (err error) {
+func (lm *loggingMiddleware) CreatePolicies(ctx context.Context, token, groupID string, giByEmails ...auth.GroupInvitationByEmail) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method create_policies for token %s and group id %s took %s to complete", token, groupID, time.Since(begin))
 		if err != nil {
@@ -362,7 +362,7 @@ func (lm *loggingMiddleware) CreatePolicies(ctx context.Context, token, groupID 
 		}
 	}(time.Now())
 
-	return lm.svc.CreatePolicies(ctx, token, groupID, mp...)
+	return lm.svc.CreatePolicies(ctx, token, groupID, giByEmails...)
 }
 
 func (lm *loggingMiddleware) ListMembersPolicies(ctx context.Context, token, groupID string, pm auth.PageMetadata) (mpp auth.GroupMembersPoliciesPage, err error) {
@@ -377,7 +377,7 @@ func (lm *loggingMiddleware) ListMembersPolicies(ctx context.Context, token, gro
 	return lm.svc.ListMembersPolicies(ctx, token, groupID, pm)
 }
 
-func (lm *loggingMiddleware) UpdatePolicies(ctx context.Context, token, groupID string, mp ...auth.MemberPolicy) (err error) {
+func (lm *loggingMiddleware) UpdatePolicies(ctx context.Context, token, groupID string, giByEmails ...auth.GroupInvitationByEmail) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method update_policies for token %s and group id %s took %s to complete", token, groupID, time.Since(begin))
 		if err != nil {
@@ -386,7 +386,7 @@ func (lm *loggingMiddleware) UpdatePolicies(ctx context.Context, token, groupID 
 		}
 	}(time.Now())
 
-	return lm.svc.UpdatePolicies(ctx, token, groupID, mp...)
+	return lm.svc.UpdatePolicies(ctx, token, groupID, giByEmails...)
 }
 
 func (lm *loggingMiddleware) RemovePolicies(ctx context.Context, token, groupID string, memberIDs ...string) (err error) {

--- a/auth/api/metrics.go
+++ b/auth/api/metrics.go
@@ -251,13 +251,13 @@ func (ms *metricsMiddleware) AssignRole(ctx context.Context, id, role string) er
 	return ms.svc.AssignRole(ctx, id, role)
 }
 
-func (ms *metricsMiddleware) CreatePolicies(ctx context.Context, token, groupID string, mp ...auth.MemberPolicy) error {
+func (ms *metricsMiddleware) CreatePolicies(ctx context.Context, token, groupID string, gis ...auth.GroupInvitationByEmail) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "create_policies").Add(1)
 		ms.latency.With("method", "create_policies").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.CreatePolicies(ctx, token, groupID, mp...)
+	return ms.svc.CreatePolicies(ctx, token, groupID, gis...)
 }
 
 func (ms *metricsMiddleware) ListMembersPolicies(ctx context.Context, token, groupID string, pm auth.PageMetadata) (auth.GroupMembersPoliciesPage, error) {
@@ -269,13 +269,13 @@ func (ms *metricsMiddleware) ListMembersPolicies(ctx context.Context, token, gro
 	return ms.svc.ListMembersPolicies(ctx, token, groupID, pm)
 }
 
-func (ms *metricsMiddleware) UpdatePolicies(ctx context.Context, token, groupID string, mp ...auth.MemberPolicy) error {
+func (ms *metricsMiddleware) UpdatePolicies(ctx context.Context, token, groupID string, gise ...auth.GroupInvitationByEmail) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "update_policies").Add(1)
 		ms.latency.With("method", "update_policies").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.UpdatePolicies(ctx, token, groupID, mp...)
+	return ms.svc.UpdatePolicies(ctx, token, groupID, gise...)
 }
 
 func (ms *metricsMiddleware) RemovePolicies(ctx context.Context, token, groupID string, memberIDs ...string) error {

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -17,7 +17,7 @@ type orgRepositoryMock struct {
 	orgs            map[string]auth.Org
 	members         map[string]auth.Member
 	groups          map[string]auth.Group
-	membersPolicies map[string]auth.MemberPolicy
+	membersPolicies map[string]auth.GroupInvitationByID
 }
 
 // NewOrgRepository returns mock of org repository
@@ -26,7 +26,7 @@ func NewOrgRepository() auth.OrgRepository {
 		orgs:            make(map[string]auth.Org),
 		members:         make(map[string]auth.Member),
 		groups:          make(map[string]auth.Group),
-		membersPolicies: make(map[string]auth.MemberPolicy),
+		membersPolicies: make(map[string]auth.GroupInvitationByID),
 	}
 }
 
@@ -367,18 +367,18 @@ func (orm *orgRepositoryMock) RetrieveAllGroupRelations(ctx context.Context) ([]
 	return grs, nil
 }
 
-func (orm *orgRepositoryMock) SavePolicies(ctx context.Context, groupID string, mp ...auth.MemberPolicy) error {
+func (orm *orgRepositoryMock) SavePolicies(ctx context.Context, groupID string, giByIDs ...auth.GroupInvitationByID) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	for _, m := range mp {
-		if _, ok := orm.members[m.MemberID]; !ok {
+	for _, g := range giByIDs {
+		if _, ok := orm.members[g.MemberID]; !ok {
 			return errors.ErrNotFound
 		}
 
-		orm.membersPolicies[m.MemberID] = auth.MemberPolicy{
-			MemberID: m.MemberID,
-			Policy:   m.Policy,
+		orm.membersPolicies[g.MemberID] = auth.GroupInvitationByID{
+			MemberID: g.MemberID,
+			Policy:   g.Policy,
 		}
 	}
 
@@ -393,7 +393,7 @@ func (orm *orgRepositoryMock) RetrievePolicies(ctx context.Context, groupID stri
 	panic("not implemented")
 }
 
-func (orm *orgRepositoryMock) UpdatePolicies(ctx context.Context, groupID string, mp ...auth.MemberPolicy) error {
+func (orm *orgRepositoryMock) UpdatePolicies(ctx context.Context, groupID string, giByIDs ...auth.GroupInvitationByID) error {
 	panic("not implemented")
 }
 

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -101,9 +101,14 @@ type GroupsPolicy struct {
 	Policy   string
 }
 
-type MemberPolicy struct {
+type GroupInvitationByID struct {
 	MemberID string
 	Policy   string
+}
+
+type GroupInvitationByEmail struct {
+	Email  string
+	Policy string
 }
 
 type GroupMemberPolicy struct {
@@ -196,13 +201,13 @@ type Orgs interface {
 	ListOrgGroups(ctx context.Context, token, orgID string, pm PageMetadata) (GroupsPage, error)
 
 	// CreatePolicies creates group members policies.
-	CreatePolicies(ctx context.Context, token, groupID string, mp ...MemberPolicy) error
+	CreatePolicies(ctx context.Context, token, groupID string, giByEmails ...GroupInvitationByEmail) error
 
 	// ListMembersPolicies retrieves page of group members policies.
 	ListMembersPolicies(ctx context.Context, token, groupID string, pm PageMetadata) (GroupMembersPoliciesPage, error)
 
 	// UpdatePolicies updates group members policies.
-	UpdatePolicies(ctx context.Context, token, groupID string, mp ...MemberPolicy) error
+	UpdatePolicies(ctx context.Context, token, groupID string, giByEmails ...GroupInvitationByEmail) error
 
 	// RemovePolicies removes group members policies.
 	RemovePolicies(ctx context.Context, token, groupID string, memberIDs ...string) error
@@ -274,7 +279,7 @@ type OrgRepository interface {
 	RetrieveAllGroupRelations(ctx context.Context) ([]GroupRelation, error)
 
 	// SavePolicies saves group members policies.
-	SavePolicies(ctx context.Context, groupID string, mp ...MemberPolicy) error
+	SavePolicies(ctx context.Context, groupID string, giByIDs ...GroupInvitationByID) error
 
 	// RetrievePolicy retrieves group policy for a user.
 	RetrievePolicy(ctc context.Context, gp GroupsPolicy) (string, error)
@@ -286,5 +291,5 @@ type OrgRepository interface {
 	RemovePolicies(ctx context.Context, groupID string, memberIDs ...string) error
 
 	// UpdatePolicies updates group members policies.
-	UpdatePolicies(ctx context.Context, groupID string, mp ...MemberPolicy) error
+	UpdatePolicies(ctx context.Context, groupID string, giByIDs ...GroupInvitationByID) error
 }

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -651,7 +651,7 @@ func (or orgRepository) RetrieveAllGroupRelations(ctx context.Context) ([]auth.G
 	return grs, nil
 }
 
-func (or orgRepository) SavePolicies(ctx context.Context, groupID string, mp ...auth.MemberPolicy) error {
+func (or orgRepository) SavePolicies(ctx context.Context, groupID string, giByIDs ...auth.GroupInvitationByID) error {
 	tx, err := or.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(auth.ErrAssignToOrg, err)
@@ -659,11 +659,11 @@ func (or orgRepository) SavePolicies(ctx context.Context, groupID string, mp ...
 
 	q := `INSERT INTO group_policies (member_id, group_id, policy) VALUES (:member_id, :group_id, :policy);`
 
-	for _, m := range mp {
+	for _, g := range giByIDs {
 		gp := auth.GroupsPolicy{
-			MemberID: m.MemberID,
+			MemberID: g.MemberID,
 			GroupID:  groupID,
-			Policy:   m.Policy,
+			Policy:   g.Policy,
 		}
 
 		dbgp, err := toDBGroupPolicy(gp)
@@ -784,14 +784,14 @@ func (or orgRepository) RemovePolicies(ctx context.Context, groupID string, memb
 	return nil
 }
 
-func (or orgRepository) UpdatePolicies(ctx context.Context, groupID string, mp ...auth.MemberPolicy) error {
+func (or orgRepository) UpdatePolicies(ctx context.Context, groupID string, giByIDs ...auth.GroupInvitationByID) error {
 	q := `UPDATE group_policies SET policy = :policy WHERE member_id = :member_id AND group_id = :group_id;`
 
-	for _, m := range mp {
+	for _, g := range giByIDs {
 		gp := auth.GroupsPolicy{
-			MemberID: m.MemberID,
+			MemberID: g.MemberID,
 			GroupID:  groupID,
-			Policy:   m.Policy,
+			Policy:   g.Policy,
 		}
 
 		dbgp, err := toDBGroupPolicy(gp)

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -1660,7 +1660,7 @@ func TestSavePolicies(t *testing.T) {
 	err = repo.AssignGroups(context.Background(), gr)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	mp := []auth.MemberPolicy{
+	giByIDs := []auth.GroupInvitationByID{
 		{
 			MemberID: memberID,
 			Policy:   auth.RwPolicy,
@@ -1671,7 +1671,7 @@ func TestSavePolicies(t *testing.T) {
 		},
 	}
 
-	mpWithoutMemberIDs := []auth.MemberPolicy{
+	giWithoutMemberIDs := []auth.GroupInvitationByID{
 		{
 			MemberID: "",
 			Policy:   auth.RwPolicy,
@@ -1683,39 +1683,39 @@ func TestSavePolicies(t *testing.T) {
 	}
 
 	cases := []struct {
-		desc         string
-		groupID      string
-		memberPolicy []auth.MemberPolicy
-		err          error
+		desc    string
+		groupID string
+		giByIDs []auth.GroupInvitationByID
+		err     error
 	}{
 		{
-			desc:         "save group policies",
-			memberPolicy: mp,
-			groupID:      groupID,
-			err:          nil,
+			desc:    "save group policies",
+			giByIDs: giByIDs,
+			groupID: groupID,
+			err:     nil,
 		},
 		{
-			desc:         "save group policies without group ids",
-			memberPolicy: mpWithoutMemberIDs,
-			groupID:      "",
-			err:          errors.ErrMalformedEntity,
+			desc:    "save group policies without group ids",
+			giByIDs: giByIDs,
+			groupID: "",
+			err:     errors.ErrMalformedEntity,
 		},
 		{
-			desc:         "save group policies without member id",
-			memberPolicy: mpWithoutMemberIDs,
-			groupID:      groupID,
-			err:          errors.ErrMalformedEntity,
+			desc:    "save group policies without member id",
+			giByIDs: giWithoutMemberIDs,
+			groupID: groupID,
+			err:     errors.ErrMalformedEntity,
 		},
 		{
-			desc:         "save existing group policies",
-			memberPolicy: mp,
-			groupID:      groupID,
-			err:          errors.ErrConflict,
+			desc:    "save existing group policies",
+			giByIDs: giByIDs,
+			groupID: groupID,
+			err:     errors.ErrConflict,
 		},
 	}
 
 	for _, tc := range cases {
-		err := repo.SavePolicies(context.Background(), tc.groupID, tc.memberPolicy...)
+		err := repo.SavePolicies(context.Background(), tc.groupID, tc.giByIDs...)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }
@@ -1758,12 +1758,12 @@ func TestRetrievePolicy(t *testing.T) {
 		MemberID: memberID,
 	}
 
-	mp := auth.MemberPolicy{
+	giByID := auth.GroupInvitationByID{
 		MemberID: memberID,
 		Policy:   auth.RwPolicy,
 	}
 
-	err = repo.SavePolicies(context.Background(), groupID, mp)
+	err = repo.SavePolicies(context.Background(), groupID, giByID)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
@@ -1840,11 +1840,11 @@ func TestRetrievePolicies(t *testing.T) {
 	for i := uint64(0); i < n; i++ {
 		memberID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-		mp := auth.MemberPolicy{
+		giByID := auth.GroupInvitationByID{
 			MemberID: memberID,
 			Policy:   auth.RwPolicy,
 		}
-		err = repo.SavePolicies(context.Background(), groupID, mp)
+		err = repo.SavePolicies(context.Background(), groupID, giByID)
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	}
 
@@ -1946,12 +1946,12 @@ func TestRemovePolicies(t *testing.T) {
 		memberID, err := idProvider.ID()
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-		mp := auth.MemberPolicy{
+		giByID := auth.GroupInvitationByID{
 			MemberID: memberID,
 			Policy:   auth.RwPolicy,
 		}
 
-		err = repo.SavePolicies(context.Background(), groupID, mp)
+		err = repo.SavePolicies(context.Background(), groupID, giByID)
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 		memberIDs = append(memberIDs, memberID)
@@ -2023,7 +2023,7 @@ func TestUpdatePolicies(t *testing.T) {
 	err = repo.AssignGroups(context.Background(), gr)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
-	mp := []auth.MemberPolicy{
+	giByIDs := []auth.GroupInvitationByID{
 		{
 			MemberID: memberID,
 			Policy:   auth.RwPolicy,
@@ -2034,19 +2034,19 @@ func TestUpdatePolicies(t *testing.T) {
 		},
 	}
 
-	err = repo.SavePolicies(context.Background(), groupID, mp...)
+	err = repo.SavePolicies(context.Background(), groupID, giByIDs...)
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
-		desc         string
-		groupID      string
-		memberPolicy auth.MemberPolicy
-		err          error
+		desc    string
+		groupID string
+		giByID  auth.GroupInvitationByID
+		err     error
 	}{
 		{
 			desc:    "update policy without group id",
 			groupID: "",
-			memberPolicy: auth.MemberPolicy{
+			giByID: auth.GroupInvitationByID{
 				MemberID: "",
 				Policy:   auth.RPolicy,
 			},
@@ -2055,7 +2055,7 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			desc:    "update policy without member id",
 			groupID: groupID,
-			memberPolicy: auth.MemberPolicy{
+			giByID: auth.GroupInvitationByID{
 				MemberID: "",
 				Policy:   auth.RPolicy,
 			},
@@ -2064,7 +2064,7 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			desc:    "update policy",
 			groupID: groupID,
-			memberPolicy: auth.MemberPolicy{
+			giByID: auth.GroupInvitationByID{
 				MemberID: memberID,
 				Policy:   auth.RPolicy,
 			},
@@ -2073,7 +2073,7 @@ func TestUpdatePolicies(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		err := repo.UpdatePolicies(context.Background(), tc.groupID, tc.memberPolicy)
+		err := repo.UpdatePolicies(context.Background(), tc.groupID, tc.giByID)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }

--- a/auth/tracing/orgs.go
+++ b/auth/tracing/orgs.go
@@ -203,12 +203,12 @@ func (orm orgRepositoryMiddleware) RetrieveAllGroupRelations(ctx context.Context
 	return orm.repo.RetrieveAllGroupRelations(ctx)
 }
 
-func (orm orgRepositoryMiddleware) SavePolicies(ctx context.Context, groupID string, mp ...auth.MemberPolicy) error {
+func (orm orgRepositoryMiddleware) SavePolicies(ctx context.Context, groupID string, giByIDs ...auth.GroupInvitationByID) error {
 	span := createSpan(ctx, orm.tracer, savePolicies)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.SavePolicies(ctx, groupID, mp...)
+	return orm.repo.SavePolicies(ctx, groupID, giByIDs...)
 }
 
 func (orm orgRepositoryMiddleware) RetrievePolicy(ctx context.Context, gp auth.GroupsPolicy) (string, error) {
@@ -227,12 +227,12 @@ func (orm orgRepositoryMiddleware) RetrievePolicies(ctx context.Context, groupID
 	return orm.repo.RetrievePolicies(ctx, groupID, pm)
 }
 
-func (orm orgRepositoryMiddleware) UpdatePolicies(ctx context.Context, groupID string, mp ...auth.MemberPolicy) error {
+func (orm orgRepositoryMiddleware) UpdatePolicies(ctx context.Context, groupID string, giByIDs ...auth.GroupInvitationByID) error {
 	span := createSpan(ctx, orm.tracer, updatePolicies)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.UpdatePolicies(ctx, groupID, mp...)
+	return orm.repo.UpdatePolicies(ctx, groupID, giByIDs...)
 }
 
 func (orm orgRepositoryMiddleware) RemovePolicies(ctx context.Context, groupID string, memberIDs ...string) error {


### PR DESCRIPTION
 Add members emails  instead of IDs for create and update policies

Resolves: #338 
