### PR TITLE
NOISSUE- Fix unassign members

### DIFF
--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -514,8 +514,13 @@ func (or orgRepository) RetrieveGroups(ctx context.Context, orgID string, pm aut
 		return auth.OrgGroupsPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
 	}
 
+	olq := "LIMIT :limit OFFSET :offset"
+	if pm.Limit == 0 {
+		olq = ""
+	}
+
 	q := fmt.Sprintf(`SELECT gre.group_id, gre.org_id, gre.created_at, gre.updated_at FROM group_relations gre
-					  WHERE gre.org_id = :org_id %s LIMIT :limit OFFSET :offset`, mq)
+					  WHERE gre.org_id = :org_id %s %s`, mq, olq)
 
 	dbmp, err := toDBOrgMemberPage("", orgID, pm)
 	if err != nil {

--- a/auth/service.go
+++ b/auth/service.go
@@ -408,7 +408,7 @@ func (svc service) AssignMembers(ctx context.Context, token, orgID string, oms .
 }
 
 func (svc service) UnassignMembers(ctx context.Context, token string, orgID string, memberIDs ...string) error {
-	if err := svc.canAssignMembers(ctx, token, orgID, memberIDs...); err != nil {
+	if err := svc.canAssignMembers(ctx, orgID, token, memberIDs...); err != nil {
 		return err
 	}
 
@@ -971,8 +971,8 @@ func (svc service) orgRolesAuth(ctx context.Context, token, orgID string, action
 	return errors.ErrAuthorization
 }
 
-func (svc service) canAssignMembers(ctx context.Context, orgID, userID string, memberIDs ...string) error {
-	if err := svc.orgRolesAuth(ctx, orgID, userID, AdminRole); err != nil {
+func (svc service) canAssignMembers(ctx context.Context, orgID, token string, memberIDs ...string) error {
+	if err := svc.orgRolesAuth(ctx, token, orgID, AdminRole); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixed `canAssignMembers` which should accept `token` instead of `id`.
