### PR TITLE
NOISSUE - Remove PRIMARY KEY from messages and json tables

### DIFF
--- a/consumers/writers/postgres/init.go
+++ b/consumers/writers/postgres/init.go
@@ -77,6 +77,13 @@ func migrateDB(db *sqlx.DB) error {
 					"DROP TABLE json",
 				},
 			},
+			{
+				Id: "messages_2",
+				Up: []string{
+					`ALTER TABLE messages DROP CONSTRAINT messages_pkey`,
+					`ALTER TABLE json DROP CONSTRAINT json_pkey`,
+				},
+			},
 		},
 	}
 

--- a/readers/postgres/init.go
+++ b/readers/postgres/init.go
@@ -77,6 +77,13 @@ func migrateDB(db *sqlx.DB) error {
 					"DROP TABLE json",
 				},
 			},
+			{
+				Id: "messages_2",
+				Up: []string{
+					`ALTER TABLE messages DROP CONSTRAINT messages_pkey`,
+					`ALTER TABLE json DROP CONSTRAINT json_pkey`,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
To allow messages from a certain `publisher` with the same `creation time` to be stored in the database, it is necessary to remove the `PRIMARY KEY` that blocks it.
