### PR TITLE
MF-617 - Return ErrAuthorization in getGroupIDByThingID if ID is empty

### DIFF
--- a/things/service.go
+++ b/things/service.go
@@ -817,6 +817,9 @@ func (ts *thingsService) canAccessOrg(ctx context.Context, token, orgID, subject
 }
 
 func (ts *thingsService) getGroupIDByThingID(ctx context.Context, thID string) (string, error) {
+	if thID == "" {
+		return "", errors.ErrAuthorization
+	}
 	grID, err := ts.thingCache.ViewGroup(ctx, thID)
 	if err != nil {
 		th, err := ts.things.RetrieveByID(ctx, thID)


### PR DESCRIPTION
### What does this do?
Ensures that GetGroupIDByThingID returns ErrAuthorization if ID is empty

### Which issue(s) does this PR fix/relate to?
Resolves #617 

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No
