### PR TITLE
MF-648 - Add Delete endpoint in postgres-reader

### DIFF
--- a/api/openapi/readers.yml
+++ b/api/openapi/readers.yml
@@ -63,7 +63,7 @@ paths:
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
       responses:
-        '204':
+        '200':
           description: Messages successfully deleted.
         '400':
           description: Invalid or missing parameters.

--- a/api/openapi/readers.yml
+++ b/api/openapi/readers.yml
@@ -27,13 +27,13 @@ paths:
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
       responses:
-        "200":
+        '200':
           $ref: "#/components/responses/MessagesPageRes"
-        "400":
+        '400':
           description: Failed due to malformed query parameters.
-        "401":
+        '401':
           description: Missing or invalid access token provided.
-        "500":
+        '500':
           $ref: "#/components/responses/ServiceError"
   /health:
     get:
@@ -41,9 +41,9 @@ paths:
       tags:
         - health
       responses:
-        "200":
+        '200':
           $ref: "#/components/responses/HealthRes"
-        "500":
+        '500':
           $ref: "#/components/responses/ServiceError"
 
   /messages/{publisherID}:

--- a/api/openapi/readers.yml
+++ b/api/openapi/readers.yml
@@ -27,13 +27,13 @@ paths:
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
       responses:
-        '200':
+        "200":
           $ref: "#/components/responses/MessagesPageRes"
-        '400':
+        "400":
           description: Failed due to malformed query parameters.
-        '401':
+        "401":
           description: Missing or invalid access token provided.
-        '500':
+        "500":
           $ref: "#/components/responses/ServiceError"
   /health:
     get:
@@ -41,8 +41,34 @@ paths:
       tags:
         - health
       responses:
-        '200':
+        "200":
           $ref: "#/components/responses/HealthRes"
+        "500":
+          $ref: "#/components/responses/ServiceError"
+
+  /messages/{publisherID}:
+    delete:
+      summary: Delete messages for a publisher in a time range.
+      description: |
+        Deletes all JSON or SenML messages for a given publisher within the specified time range.
+      tags:
+        - messages
+      parameters:
+        - name: publisherID
+          in: path
+          required: true
+          description: Publisher's unique identifier.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/From"
+        - $ref: "#/components/parameters/To"
+      responses:
+        '204':
+          description: Messages successfully deleted.
+        '400':
+          description: Invalid or missing parameters.
+        '401':
+          description: Unauthorized access token or thing key.
         '500':
           $ref: "#/components/responses/ServiceError"
 

--- a/pkg/apiutil/errors.go
+++ b/pkg/apiutil/errors.go
@@ -155,4 +155,7 @@ var (
 
 	// ErrMissingActionID indicates a missing action id
 	ErrMissingActionID = errors.New("missing action id")
+
+	// ErrMissingPublisherID indicated a missing publisher id
+	ErrMissingPublisherID = errors.New("missing publisher ID")
 )

--- a/pkg/apiutil/errors.go
+++ b/pkg/apiutil/errors.go
@@ -157,5 +157,5 @@ var (
 	ErrMissingActionID = errors.New("missing action id")
 
 	// ErrMissingPublisherID indicated a missing publisher id
-	ErrMissingPublisherID = errors.New("missing publisher ID")
+	ErrMissingPublisherID = errors.New("missing publisher id")
 )

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -37,6 +37,9 @@ var (
 	// ErrSaveMessage indicates failure occurred while saving message to database.
 	ErrSaveMessage = New("failed to save message to database")
 
+	// ErrDeleteMEssage indicated failure occurred while deleting messaged in the database.
+	ErrDeleteMessage = New("fail while deleting messages")
+
 	// ErrMessage indicates an error converting a message to Mainflux message.
 	ErrMessage = New("failed to convert to Mainflux message")
 )

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -37,8 +37,8 @@ var (
 	// ErrSaveMessage indicates failure occurred while saving message to database.
 	ErrSaveMessage = New("failed to save message to database")
 
-	// ErrDeleteMessage indicated failure occurred while deleting messaged in the database.
-	ErrDeleteMessage = New("failed to delete messages")
+	// ErrDeleteMessage indicated failure occurred while deleting messages in the database.
+	ErrDeleteMessages = New("failed to delete messages")
 
 	// ErrMessage indicates an error converting a message to Mainflux message.
 	ErrMessage = New("failed to convert to Mainflux message")

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -37,8 +37,8 @@ var (
 	// ErrSaveMessage indicates failure occurred while saving message to database.
 	ErrSaveMessage = New("failed to save message to database")
 
-	// ErrDeleteMEssage indicated failure occurred while deleting messaged in the database.
-	ErrDeleteMessage = New("fail while deleting messages")
+	// ErrDeleteMessage indicated failure occurred while deleting messaged in the database.
+	ErrDeleteMessage = New("failed to delete messages")
 
 	// ErrMessage indicates an error converting a message to Mainflux message.
 	ErrMessage = New("failed to convert to Mainflux message")

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -82,18 +82,16 @@ func deleteMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 		}
 
 		// this if statement could be deleted, owner shold also be able to delete messages
-		if err := isAdmin(ctx, req.Token); err != nil {
+		if err := isAdmin(ctx, req.token); err != nil {
 			return nil, err
 		}
 
-		deletecCount = svc.DeleteMessages(ctx, req.PageMetadata)
+		deletedCount, err := svc.DeleteMessages(ctx, req.pageMeta)
 		if err != nil {
 			return nil, err
 		}
 
-		return deleteMessagesRes {
-			DeletedCount: deletedCount
-		}, nil
+		return deleteMessagesRes { DeletedCount: deletedCount }, nil
 	}
 }
 

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -86,7 +86,7 @@ func deleteMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 			return nil, err
 		}
 
-		deletecCount = svc.DeleteMEssages(ctx, req.publisherID, req.from, req.to)
+		deletecCount = svc.DeleteMEssages(ctx, req.PageMetadata)
 		if err != nil {
 			return nil, err
 		}

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -82,8 +82,9 @@ func deleteMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 			return nil, err
 		}
 
-		if req.key != "" {
-			pc ,err := getPubConfByKey(ctx, req.key)
+		switch {
+		case req.key != "":
+			pc, err := getPubConfByKey(ctx, req.key)
 			if err != nil {
 				return nil, errors.Wrap(errors.ErrAuthentication, err)
 			}
@@ -91,16 +92,15 @@ func deleteMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 			if pc.PublisherID != req.pageMeta.Publisher {
 				return nil, errors.ErrAuthentication
 			}
-		} else if req.token != "" {
+		case req.token != "":
 			if err := isAdmin(ctx, req.token); err != nil {
 				return nil, err
 			}
-		} else {
+		default:
 			return nil, errors.ErrAuthentication
 		}
 
-
-		err := svc.DeleteMessages(ctx, req.pageMeta)
+		err :=  svc.DeleteMessages(ctx, req.pageMeta)
 		if err != nil {
 			return nil, err
 		}

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -86,7 +86,7 @@ func deleteMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 			return nil, err
 		}
 
-		deletecCount = svc.DeleteMEssages(ctx, req.PageMetadata)
+		deletecCount = svc.DeleteMessages(ctx, req.PageMetadata)
 		if err != nil {
 			return nil, err
 		}

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -100,12 +100,12 @@ func deleteMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 		}
 
 
-		deletedCount, err := svc.DeleteMessages(ctx, req.pageMeta)
+		err := svc.DeleteMessages(ctx, req.pageMeta)
 		if err != nil {
 			return nil, err
 		}
 
-		return deleteMessagesRes { DeletedCount: deletedCount }, nil
+		return nil, nil
 	}
 }
 

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -74,6 +74,29 @@ func listAllMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 	}
 }
 
+func deleteMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(deleteMessagesReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		// this if statement could be deleted, owner shold also be able to delete messages
+		if err := isAdmin(ctx, req.Token); err != nil {
+			return nil, err
+		}
+
+		deletecCount = svc.DeleteMEssages(ctx, req.publisherID, req.from, req.to)
+		if err != nil {
+			return nil, err
+		}
+
+		return deleteMessagesRes {
+			DeletecCount: deletedCount
+		}, nil
+	}
+}
+
 func backupEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listAllMessagesReq)

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -92,7 +92,7 @@ func deleteMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 		}
 
 		return deleteMessagesRes {
-			DeletecCount: deletedCount
+			DeletedCount: deletedCount
 		}, nil
 	}
 }

--- a/readers/api/logging.go
+++ b/readers/api/logging.go
@@ -43,7 +43,7 @@ func (lm *loggingMiddleware) ListAllMessages(rpm readers.PageMetadata) (page rea
 	return lm.svc.ListAllMessages(rpm)
 }
 
-func (lm *loggingMiddleware) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (totalDeleted uint64, err error) {
+func (lm *loggingMiddleware) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method delete_messages took %s to complete", time.Since(begin))
 		if err != nil {

--- a/readers/api/logging.go
+++ b/readers/api/logging.go
@@ -43,6 +43,19 @@ func (lm *loggingMiddleware) ListAllMessages(rpm readers.PageMetadata) (page rea
 	return lm.svc.ListAllMessages(rpm)
 }
 
+func (lm *loggingMiddleware) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (totalDeleted uint64, err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method delete_messages took %s to complete", time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.DeleteMessages(ctx, rpm)
+}
+
 func (lm *loggingMiddleware) Backup(rpm readers.PageMetadata) (page readers.MessagesPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup took %s to complete", time.Since(begin))

--- a/readers/api/metrics.go
+++ b/readers/api/metrics.go
@@ -40,7 +40,7 @@ func (mm *metricsMiddleware) ListAllMessages(rpm readers.PageMetadata) (readers.
 	return mm.svc.ListAllMessages(rpm)
 }
 
-func (mm *metricsMiddleware) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (uint64, error) {
+func (mm *metricsMiddleware) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) error {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "delete_messages").Add(1)
 		mm.latency.With("method", "delete_messages").Observe(time.Since(begin).Seconds())

--- a/readers/api/metrics.go
+++ b/readers/api/metrics.go
@@ -40,6 +40,15 @@ func (mm *metricsMiddleware) ListAllMessages(rpm readers.PageMetadata) (readers.
 	return mm.svc.ListAllMessages(rpm)
 }
 
+func (mm *metricsMiddleware) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (uint64, error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "delete_messages").Add(1)
+		mm.latency.With("method", "delete_messages").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.DeleteMessages(ctx, rpm)
+}
+
 func (mm *metricsMiddleware) Backup(rpm readers.PageMetadata) (readers.MessagesPage, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "backup").Add(1)

--- a/readers/api/requests.go
+++ b/readers/api/requests.go
@@ -61,22 +61,16 @@ func (req restoreMessagesReq) validate() error {
 
 type deleteAllMessagesReq struct {
 	token       string
-	publisherID string
-	from        float64
-	to          float64
+	pageMeta readers.PageMetadata
 }
 
 func (req deleteAllMessagesReq) validate() error {
 	if req.token == "" {
-		return api.ErrBearerToken
+		return apiutil.ErrBearerToken
 	}
 
-	if req.pageMeta.Limit > maxLimitSize {
-		return apiutil.ErrLimitSize
-	}
-
-	if req.pageMeta.Offset < 0 {
-		return apiutil.ErrOffsetSize
+	if req.pageMeta.Publisher == "" {
+		return apiutil.ErrMissingPublisherID
 	}
 
 	return nil

--- a/readers/api/requests.go
+++ b/readers/api/requests.go
@@ -60,7 +60,7 @@ func (req restoreMessagesReq) validate() error {
 }
 
 type deleteAllMessagesReq struct {
-	token       string
+	token    string
 	pageMeta readers.PageMetadata
 }
 

--- a/readers/api/requests.go
+++ b/readers/api/requests.go
@@ -59,12 +59,12 @@ func (req restoreMessagesReq) validate() error {
 	return nil
 }
 
-type deleteAllMessagesReq struct {
+type deleteMessagesReq struct {
 	token    string
 	pageMeta readers.PageMetadata
 }
 
-func (req deleteAllMessagesReq) validate() error {
+func (req deleteMessagesReq) validate() error {
 	if req.token == "" {
 		return apiutil.ErrBearerToken
 	}

--- a/readers/api/requests.go
+++ b/readers/api/requests.go
@@ -58,3 +58,26 @@ func (req restoreMessagesReq) validate() error {
 
 	return nil
 }
+
+type deleteAllMessagesReq struct {
+	token       string
+	publisherID string
+	from        float64
+	to          float64
+}
+
+func (req deleteAllMessagesReq) validate() error {
+	if req.token == "" {
+		return api.ErrBearerToken
+	}
+
+	if req.pageMeta.Limit > maxLimitSize {
+		return apiutil.ErrLimitSize
+	}
+
+	if req.pageMeta.Offset < 0 {
+		return apiutil.ErrOffsetSize
+	}
+
+	return nil
+}

--- a/readers/api/requests.go
+++ b/readers/api/requests.go
@@ -61,11 +61,12 @@ func (req restoreMessagesReq) validate() error {
 
 type deleteMessagesReq struct {
 	token    string
+	key      string
 	pageMeta readers.PageMetadata
 }
 
 func (req deleteMessagesReq) validate() error {
-	if req.token == "" {
+	if req.token == "" && req.key == "" {
 		return apiutil.ErrBearerToken
 	}
 

--- a/readers/api/responses.go
+++ b/readers/api/responses.go
@@ -62,3 +62,20 @@ func (res backupFileRes) Headers() map[string]string {
 func (res backupFileRes) Empty() bool {
 	return false
 }
+
+type deleteMessagesRes struct {
+	DeletedCount uint64 `json:"deleted_count"`
+} 
+
+func (res deleteMessagesRes) Headers() map[string]string {
+	return map[string]string{}
+}
+
+
+func (res deleteMessagesRes) Code() int {
+	return http.StatusOK
+}
+
+func (res deleteMessagesRes) Empty() bool {
+	return false
+}

--- a/readers/api/responses.go
+++ b/readers/api/responses.go
@@ -62,20 +62,3 @@ func (res backupFileRes) Headers() map[string]string {
 func (res backupFileRes) Empty() bool {
 	return false
 }
-
-type deleteMessagesRes struct {
-	DeletedCount uint64 `json:"deleted_count"`
-} 
-
-func (res deleteMessagesRes) Headers() map[string]string {
-	return map[string]string{}
-}
-
-
-func (res deleteMessagesRes) Code() int {
-	return http.StatusOK
-}
-
-func (res deleteMessagesRes) Empty() bool {
-	return false
-}

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -186,12 +186,12 @@ func decodeDeleteMessages(_ context.Context, r *http.Request) (interface{}, erro
 	fromStr := r.URL.Query().Get("from")
 	toStr := r.URL.Query().Get("to")
 
-	from, err := strconv.ParseUint(fromStr, 10, 64)
+	from, err := strconv.ParseFloat(fromStr, 64)
 	if err != nil {
 		return  nil, apiutil.ErrInvalidQueryParams
 	}
 
-	to, err := strconv.ParseUint(toStr, 10, 64)
+	to, err := strconv.ParseFloat(toStr, 64)
 	if err != nil {
 		return nil, apiutil.ErrInvalidQueryParams
 	}

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -63,8 +63,8 @@ func MakeHandler(svc readers.MessageRepository, tc protomfx.ThingsServiceClient,
 		deleteMessagesEndpoint(svc),
 		decodeDeleteMessages,
 		encodeResponse,
-		opts...,
-	))
+		opts...
+		))
 	mux.Post("/restore", kithttp.NewServer(
 		restoreEndpoint(svc),
 		decodeRestore,
@@ -198,6 +198,7 @@ func decodeDeleteMessages(_ context.Context, r *http.Request) (interface{}, erro
 
 	req := deleteMessagesReq {
 		token: apiutil.ExtractBearerToken(r),
+		key: apiutil.ExtractThingKey(r),
 		pageMeta: readers.PageMetadata{
 			Publisher: publisherID,
 			From: from,

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -65,7 +65,6 @@ func MakeHandler(svc readers.MessageRepository, tc protomfx.ThingsServiceClient,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Post("/restore", kithttp.NewServer(
 		restoreEndpoint(svc),
 		decodeRestore,

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -58,6 +58,14 @@ func MakeHandler(svc readers.MessageRepository, tc protomfx.ThingsServiceClient,
 		encodeResponse,
 		opts...,
 	))
+
+	mux.Delete("/messages/:publisherID", kithttp.NewServer(
+		deleteMessagesEndpoint(svc),
+		decodeDeleteAllMessages,
+		encodeResponse,
+		opts...,
+	))
+
 	mux.Post("/restore", kithttp.NewServer(
 		restoreEndpoint(svc),
 		decodeRestore,

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -36,6 +36,9 @@ type MessageRepository interface {
 
 	// Backup retrieves all messages from database.
 	Backup(rpm PageMetadata) (MessagesPage, error)
+
+	// Deletes messages for a specific publisher within a time range. Returns number of deleted messages.
+	DeleteMessages(ctx context.Context, publisherID string, from, to float64)
 }
 
 // Message represents any message format.

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -38,7 +38,7 @@ type MessageRepository interface {
 	Backup(rpm PageMetadata) (MessagesPage, error)
 
 	// Deletes messages for a specific publisher within a time range. Returns number of deleted messages.
-	DeleteMessages(ctx context.Context, publisherID string, from, to float64) (uint64, error)
+	DeleteMessages(ctx context.Context, rpm PageMetadata) (uint64, error)
 }
 
 // Message represents any message format.

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -37,7 +37,7 @@ type MessageRepository interface {
 	// Backup retrieves all messages from database.
 	Backup(rpm PageMetadata) (MessagesPage, error)
 
-	// Deletes messages for a specific publisher within a time range. Returns number of deleted messages.
+	// Deletes messages for a specific publisher within a time range.
 	DeleteMessages(ctx context.Context, rpm PageMetadata) error
 }
 

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -38,7 +38,7 @@ type MessageRepository interface {
 	Backup(rpm PageMetadata) (MessagesPage, error)
 
 	// Deletes messages for a specific publisher within a time range. Returns number of deleted messages.
-	DeleteMessages(ctx context.Context, publisherID string, from, to float64)
+	DeleteMessages(ctx context.Context, publisherID string, from, to float64) (uint64, error)
 }
 
 // Message represents any message format.

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -38,7 +38,7 @@ type MessageRepository interface {
 	Backup(rpm PageMetadata) (MessagesPage, error)
 
 	// Deletes messages for a specific publisher within a time range. Returns number of deleted messages.
-	DeleteMessages(ctx context.Context, rpm PageMetadata) (uint64, error)
+	DeleteMessages(ctx context.Context, rpm PageMetadata) error
 }
 
 // Message represents any message format.

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -183,9 +183,9 @@ func (repo *messageRepositoryMock) checkBoolValueFilter(senmlMsg senml.Message, 
 }
 
 func (repo *messageRepositoryMock) checkStringValueFilter(senmlMsg senml.Message, rpm readers.PageMetadata) bool {
-	return senmlMsg.StringValue != nil && *&senmlMsg.StringValue == &rpm.StringValue
+	return senmlMsg.StringValue != nil && *senmlMsg.StringValue == rpm.StringValue
 }
 
 func (repo *messageRepositoryMock) checkDataValueFilter(senmlMsg senml.Message, rpm readers.PageMetadata) bool {
-	return senmlMsg.DataValue != nil && *&senmlMsg.DataValue == &rpm.DataValue
+	return senmlMsg.DataValue != nil && *senmlMsg.DataValue == rpm.DataValue
 }

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -134,6 +134,7 @@ func (repo *messageRepositoryMock) DeleteMessages(ctx context.Context, rpm reade
 			if !shouldDelete {
 				remainingMessages = append(remainingMessages, m)
 			}
+		}
 
 		repo.messages[profileID] = remainingMessages
 	}

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -173,6 +173,8 @@ func (repo *messageRepositoryMock) checkValueFilter(senmlMsg senml.Message, quer
 		return *senmlMsg.Value >= rpm.Value
 	case readers.EqualKey:
 		return *senmlMsg.Value == rpm.Value
+	default: 
+		return *senmlMsg.Value == rpm.Value
 	}
 }
 

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -131,12 +131,9 @@ func (repo *messageRepositoryMock) DeleteMessages(ctx context.Context, rpm reade
 				}
 			}
 
-			if shouldDelete {
-				deletedCount++
-			} else {
+			if !shouldDelete {
 				remainingMessages = append(remainingMessages, m)
 			}
-		}
 
 		repo.messages[profileID] = remainingMessages
 	}

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -45,8 +45,6 @@ func (repo *messageRepositoryMock) DeleteMessages(ctx context.Context, rpm reade
 	meta, _ := json.Marshal(rpm)
 	json.Unmarshal(meta, &query)
 
-	var deletedCount uint64 = 0
-
 	for profileID, messages := range repo.messages {
 		var remainingMessages []readers.Message
 		

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -37,7 +37,7 @@ func (repo *messageRepositoryMock) ListProfileMessages(profileID string, rpm rea
 	return repo.readAll(profileID, rpm)
 }
 
-func (repo *messageRepositoryMock) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (uint64, error) {
+func (repo *messageRepositoryMock) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) error {
 	repo.mutex.Lock()
 	defer repo.mutex.Unlock()
 
@@ -143,7 +143,7 @@ func (repo *messageRepositoryMock) DeleteMessages(ctx context.Context, rpm reade
 		repo.messages[profileID] = remainingMessages
 	}
 
-	return deletedCount, nil
+	return nil
 }
 
 func (repo *messageRepositoryMock) ListAllMessages(rpm readers.PageMetadata) (readers.MessagesPage, error) {

--- a/readers/mongodb/messages.go
+++ b/readers/mongodb/messages.go
@@ -44,8 +44,8 @@ func (repo mongoRepository) Backup(rpm readers.PageMetadata) (readers.MessagesPa
 	return repo.readAll("", rpm)
 }
 
-func (repo mongoRepository) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (uint64, error) {
-	return 0, nil
+func (repo mongoRepository) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) error {
+	return nil
 }
 
 func (repo mongoRepository) Restore(ctx context.Context, messages ...senml.Message) error {

--- a/readers/mongodb/messages.go
+++ b/readers/mongodb/messages.go
@@ -44,6 +44,10 @@ func (repo mongoRepository) Backup(rpm readers.PageMetadata) (readers.MessagesPa
 	return repo.readAll("", rpm)
 }
 
+func (repo mongoRepository) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (uint64, error) {
+	return 0, nil
+}
+
 func (repo mongoRepository) Restore(ctx context.Context, messages ...senml.Message) error {
 	coll := repo.db.Collection(defCollection)
 	var dbMsgs []interface{}

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/transformers/senml"

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -25,8 +25,8 @@ const (
 var _ readers.MessageRepository = (*postgresRepository)(nil)
 
 var (
-	errInvalidMessage         = errors.New("invalid message representation")
-	errTransRollback          = errors.New("failed to rollback transaction")
+	errInvalidMessage = errors.New("invalid message representation")
+	errTransRollback  = errors.New("failed to rollback transaction")
 )
 
 type postgresRepository struct {
@@ -48,7 +48,6 @@ func (tr postgresRepository) Backup(rpm readers.PageMetadata) (readers.MessagesP
 }
 
 func (tr postgresRepository) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) error {
-
 	tx, err := tr.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(errors.ErrSaveMessage, err)
@@ -101,11 +100,6 @@ func (tr postgresRepository) DeleteMessages(ctx context.Context, rpm readers.Pag
 			}
 			return errors.Wrap(errors.ErrDeleteMessage, err)
 		}
-
-		if err != nil {
-			return errors.Wrap(errors.ErrDeleteMessage, err)
-		}
-
 	}
 
 	return nil

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -62,7 +62,7 @@ func (tr postgresRepository) DeleteMessages(ctx context.Context, rpm readers.Pag
 		}
 
 		if err = tx.Commit(); err != nil {
-			err = errors.Wrap(errors.ErrDeleteMessage, err)
+			err = errors.Wrap(errors.ErrDeleteMessages, err)
 		}
 	}()
 
@@ -91,14 +91,14 @@ func (tr postgresRepository) DeleteMessages(ctx context.Context, rpm readers.Pag
 			if ok {
 				switch pgErr.Code {
 				case pgerrcode.UndefinedTable:
-					return errors.Wrap(errors.ErrDeleteMessage, err)
+					return errors.Wrap(errors.ErrDeleteMessages, err)
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrDeleteMessage, errInvalidMessage)
+					return errors.Wrap(errors.ErrDeleteMessages, errInvalidMessage)
 				default:
-					return errors.Wrap(errors.ErrDeleteMessage, err)
+					return errors.Wrap(errors.ErrDeleteMessages, err)
 				}
 			}
-			return errors.Wrap(errors.ErrDeleteMessage, err)
+			return errors.Wrap(errors.ErrDeleteMessages, err)
 		}
 	}
 

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -274,7 +274,7 @@ func (tr postgresRepository) readAll(rpm readers.PageMetadata) (readers.Messages
 	return page, nil
 }
 
-func fmtCondition(rpm readers.PageMetadata, table ...string) string {
+func fmtCondition(rpm readers.PageMetadata, table string) string {
 	var query map[string]interface{}
 	meta, err := json.Marshal(rpm)
 	if err != nil {
@@ -286,7 +286,7 @@ func fmtCondition(rpm readers.PageMetadata, table ...string) string {
 	op := "WHERE"
 	timeColumn := "time"
 
-	if len(table) > 0 && table[0] == jsonTable {
+	if table != "" && table == jsonTable {
 		timeColumn = "created"
 	}
 

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -50,7 +50,7 @@ func (tr postgresRepository) Backup(rpm readers.PageMetadata) (readers.MessagesP
 func (tr postgresRepository) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) error {
 	tx, err := tr.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(errors.ErrSaveMessage, err)
+		return errors.Wrap(errors.ErrSaveMessages, err)
 	}
 
 	defer func() {

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -43,6 +43,10 @@ func (tr postgresRepository) ListAllMessages(rpm readers.PageMetadata) (readers.
 	return tr.readAll(rpm)
 }
 
+func (tr postgresRepository) Backup(rpm readers.PageMetadata) (readers.MessagesPage, error) {
+	return tr.readAll(rpm)
+}
+
 func (tr postgresRepository) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (uint64, error) {
 	if rpm.Publisher == "" {
 		return 0, errors.Wrap(errors.ErrDeleteMessage, errors.New("publisher ID cannot be empty"))

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -25,8 +25,8 @@ const (
 var _ readers.MessageRepository = (*postgresRepository)(nil)
 
 var (
-	errInvalidMessage = errors.New("invalid message representation")
-	errTransRollback  = errors.New("failed to rollback transaction")
+	errInvalidMessage         = errors.New("invalid message representation")
+	errTransRollback          = errors.New("failed to rollback transaction")
 )
 
 type postgresRepository struct {
@@ -92,9 +92,9 @@ func (tr postgresRepository) DeleteMessages(ctx context.Context, rpm readers.Pag
 			if ok {
 				switch pgErr.Code {
 				case pgerrcode.UndefinedTable:
-					return errors.Wrap(errors.ErrDeleteMessage, errors.New("messages table does not exist"))
+					return errors.Wrap(errors.ErrDeleteMessage, err)
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrDeleteMessage, errors.New("invalid parameter format"))
+					return errors.Wrap(errors.ErrDeleteMessage, errInvalidMessage)
 				default:
 					return errors.Wrap(errors.ErrDeleteMessage, err)
 				}
@@ -291,7 +291,7 @@ func fmtCondition(rpm readers.PageMetadata, table ...string) string {
 	condition := ""
 	op := "WHERE"
 	timeColumn := "time"
-	
+
 	if len(table) > 0 && table[0] == jsonTable {
 		timeColumn = "created"
 	}

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -48,13 +48,6 @@ func (tr postgresRepository) Backup(rpm readers.PageMetadata) (readers.MessagesP
 }
 
 func (tr postgresRepository) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) error {
-	if rpm.Publisher == "" {
-		return errors.Wrap(errors.ErrDeleteMessage, errors.New("publisher ID cannot be empty"))
-	}
-
-	if rpm.From < 0 || rpm.To < 0 || rpm.From >= rpm.To {
-		return errors.Wrap(errors.ErrDeleteMessage, errors.New("invalid time range"))
-	}
 
 	tx, err := tr.db.BeginTxx(ctx, nil)
 	if err != nil {
@@ -81,8 +74,6 @@ func (tr postgresRepository) DeleteMessages(ctx context.Context, rpm readers.Pag
 		q := fmt.Sprintf("DELETE FROM %s %s", table, condition)
 
 		params := map[string]interface{}{
-			"limit":        rpm.Limit,
-			"offset":       rpm.Offset,
 			"subtopic":     rpm.Subtopic,
 			"publisher":    rpm.Publisher,
 			"name":         rpm.Name,

--- a/readers/postgres/messages_test.go
+++ b/readers/postgres/messages_test.go
@@ -581,12 +581,12 @@ func TestDeleteMessagesSenML(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		_, _ = reader.DeleteMessages(context.Background(), readers.PageMetadata{
+		_ = reader.DeleteMessages(context.Background(), readers.PageMetadata{
 			Publisher: pubID,
 			From:      0,
 			To:        now + 1,
 		})
-		_, _ = reader.DeleteMessages(context.Background(), readers.PageMetadata{
+		_ = reader.DeleteMessages(context.Background(), readers.PageMetadata{
 			Publisher: pubID2,
 			From:      0,
 			To:        now + 1,
@@ -619,9 +619,34 @@ func TestDeleteMessagesSenML(t *testing.T) {
 			require.Nil(t, err, fmt.Sprintf("expected no error got %s\n", err))
 		}
 
-		deletedCount, err := reader.DeleteMessages(context.Background(), tc.pageMeta)
+		beforePage, err := reader.ListAllMessages(readers.PageMetadata{
+			Publisher: tc.pageMeta.Publisher,
+			Subtopic:  tc.pageMeta.Subtopic,
+			Protocol:  tc.pageMeta.Protocol,
+			From:      tc.pageMeta.From,
+			To:        tc.pageMeta.To,
+			Limit:     noLimit,
+		})
+
+		require.Nil(t, err)
+		beforeCount := beforePage.Total
+
+		err = reader.DeleteMessages(context.Background(), tc.pageMeta)
 		assert.Nil(t, err, fmt.Sprintf("%s: expected no error got %s", desc, err))
-		assert.Equal(t, tc.expectedCount, deletedCount, fmt.Sprintf("%s: %s - expected %d deleted, got %d", desc, tc.description, tc.expectedCount, deletedCount))
+
+		afterPage, err := reader.ListAllMessages(readers.PageMetadata{
+			Publisher: tc.pageMeta.Publisher,
+			Subtopic:  tc.pageMeta.Subtopic,
+			Protocol:  tc.pageMeta.Protocol,
+			From:      tc.pageMeta.From,
+			To:        tc.pageMeta.To,
+			Limit:     noLimit,
+		})
+		require.Nil(t, err)
+		afterCount := afterPage.Total
+
+		actualDeleted := beforeCount - afterCount
+		assert.Equal(t, tc.expectedCount, actualDeleted, fmt.Sprintf("%s: %s - expected %d deleted, got %d", desc, tc.description, tc.expectedCount, actualDeleted))
 	}
 }
 
@@ -754,13 +779,13 @@ func TestDeleteMessagesJSON(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		_, _ = reader.DeleteMessages(context.Background(), readers.PageMetadata{
+		_ = reader.DeleteMessages(context.Background(), readers.PageMetadata{
 			Format:    jsonFormat,
 			Publisher: id1,
 			From:      0,
 			To:        float64(created + int64(msgsNum)),
 		})
-		_, _ = reader.DeleteMessages(context.Background(), readers.PageMetadata{
+		_ = reader.DeleteMessages(context.Background(), readers.PageMetadata{
 			Format:    jsonFormat,
 			Publisher: id2,
 			From:      0,
@@ -772,9 +797,35 @@ func TestDeleteMessagesJSON(t *testing.T) {
 			require.Nil(t, err, fmt.Sprintf("expected no error got %s\n", err))
 		}
 
-		deletedCount, err := reader.DeleteMessages(context.Background(), tc.pageMeta)
+		beforePage, err := reader.ListAllMessages(readers.PageMetadata{
+			Format:    tc.pageMeta.Format,
+			Publisher: tc.pageMeta.Publisher,
+			Subtopic:  tc.pageMeta.Subtopic,
+			Protocol:  tc.pageMeta.Protocol,
+			From:      tc.pageMeta.From,
+			To:        tc.pageMeta.To,
+			Limit:     noLimit,
+		})
+		require.Nil(t, err)
+		beforeCount := beforePage.Total
+
+		err = reader.DeleteMessages(context.Background(), tc.pageMeta)
 		assert.Nil(t, err, fmt.Sprintf("%s: expected no error got %s", desc, err))
-		assert.Equal(t, tc.expectedCount, deletedCount, fmt.Sprintf("%s: %s - expected %d deleted, got %d", desc, tc.description, tc.expectedCount, deletedCount))
+
+		afterPage, err := reader.ListAllMessages(readers.PageMetadata{
+			Format:    tc.pageMeta.Format,
+			Publisher: tc.pageMeta.Publisher,
+			Subtopic:  tc.pageMeta.Subtopic,
+			Protocol:  tc.pageMeta.Protocol,
+			From:      tc.pageMeta.From,
+			To:        tc.pageMeta.To,
+			Limit:     noLimit,
+		})
+		require.Nil(t, err)
+		afterCount := afterPage.Total
+
+		actualDeleted := beforeCount - afterCount
+		assert.Equal(t, tc.expectedCount, actualDeleted, fmt.Sprintf("%s: %s - expected %d deleted, got %d", desc, tc.description, tc.expectedCount, actualDeleted))
 	}
 }
 

--- a/readers/postgres/messages_test.go
+++ b/readers/postgres/messages_test.go
@@ -18,7 +18,6 @@ import (
 	preader "github.com/MainfluxLabs/mainflux/readers/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/mongo/description"
 )
 
 const (

--- a/readers/postgres/messages_test.go
+++ b/readers/postgres/messages_test.go
@@ -601,7 +601,7 @@ func TestDeleteMessagesSenML(t *testing.T) {
 
 			deletedCount, err := reader.DeleteMessages(context.Background(), tc.pageMeta)
 			assert.Nil(t, err, fmt.Sprintf("%s: expected no error got %s", desc, err))
-			assert.Equal(t, tc.expectedCount, deletedCount, fmt.Sprint("%s: %s - expected %s deleted, got %d", desc, tc.description, tc.expectedCount, deletedCount))
+			assert.Equal(t, tc.expectedCount, deletedCount, fmt.Sprintf("%s: %s - expected %d deleted, got %d", desc, tc.description, tc.expectedCount, deletedCount))
 			
 
 			// cleanup
@@ -716,7 +716,7 @@ func TestDeleteMessagesJSON(t *testing.T) {
 
 			// cleanup
 			_, err = reader.DeleteMessages(context.Background(), readers.PageMetadata{Format: jsonFormat, Limit: noLimit})
-			require.Nil(t, err, fmt.Sprintf("cleanup failed: %s, err"))
+			require.Nil(t, err, fmt.Sprintf("cleanup failed: %s", err))
 		})
 	}
 }

--- a/readers/postgres/messages_test.go
+++ b/readers/postgres/messages_test.go
@@ -635,7 +635,8 @@ func TestDeleteMessagesJSON(t *testing.T) {
 	m := protomfx.Message{
 		Publisher:   id1,
 		Subtopic:    subtopic,
-		Protocol:    payload,
+		Protocol:    udpProt,
+		Payload: 	payload,
 		ContentType: jsonCT,
 	}
 

--- a/readers/timescale/messages.go
+++ b/readers/timescale/messages.go
@@ -45,6 +45,10 @@ func (tr timescaleRepository) ListAllMessages(rpm readers.PageMetadata) (readers
 	return tr.readAll(rpm)
 }
 
+func (tr timescaleRepository) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (uint64, error) {
+	return 0, nil
+}
+
 func (tr timescaleRepository) Backup(rpm readers.PageMetadata) (readers.MessagesPage, error) {
 	return tr.readAll(rpm)
 }

--- a/readers/timescale/messages.go
+++ b/readers/timescale/messages.go
@@ -45,8 +45,8 @@ func (tr timescaleRepository) ListAllMessages(rpm readers.PageMetadata) (readers
 	return tr.readAll(rpm)
 }
 
-func (tr timescaleRepository) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) (uint64, error) {
-	return 0, nil
+func (tr timescaleRepository) DeleteMessages(ctx context.Context, rpm readers.PageMetadata) error {
+	return nil
 }
 
 func (tr timescaleRepository) Backup(rpm readers.PageMetadata) (readers.MessagesPage, error) {


### PR DESCRIPTION
This PR adds a delete endpoint for messages. The endpoint deletes all messages (both SenML and JSON) from a given publisher within a time range. 

Resolves #648 