### PR TITLE
MF-652 - Fix users password regex

### DIFF
--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -67,7 +67,7 @@ const (
 	defEmailTemplate    = "email.tmpl"
 	defAdminEmail       = ""
 	defAdminPassword    = ""
-	defPassRegex        = "^.{8,}$"
+	defPassRegex        = `^\S{8,}$`
 
 	defTokenResetEndpoint = "/reset-request" // URL where user lands after click on the reset link from email
 

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	passRegex = regexp.MustCompile("^.{8,}$")
+	passRegex = regexp.MustCompile(`^\S{8,}$`)
 	user      = users.User{Email: userEmail, ID: "574106f7-030e-4881-8ab0-151195c29f94", Password: validPass, Role: auth.Owner}
 	otherUser = users.User{Email: otherEmail, ID: "371106m2-131g-5286-2mc1-540295c29f96", Password: validPass, Role: auth.Editor}
 	admin     = users.User{Email: adminEmail, ID: "371106m2-131g-5286-2mc1-540295c29f95", Password: validPass, Role: auth.RootSub}

--- a/users/api/http/endpoint_test.go
+++ b/users/api/http/endpoint_test.go
@@ -58,7 +58,7 @@ var (
 	missingPassRes     = toJSON(apiutil.ErrorRes{Err: apiutil.ErrMissingPass.Error()})
 	invalidRestPassRes = toJSON(apiutil.ErrorRes{Err: apiutil.ErrInvalidResetPass.Error()})
 	idProvider         = uuid.New()
-	passRegex          = regexp.MustCompile("^.{8,}$")
+	passRegex          = regexp.MustCompile(`^\S{8,}$`)
 )
 
 type testRequest struct {

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -35,7 +35,7 @@ var (
 	host            = "example.com"
 
 	idProvider = uuid.New()
-	passRegex  = regexp.MustCompile("^.{8,}$")
+	passRegex  = regexp.MustCompile(`^\S{8,}$`)
 )
 
 func newService() users.Service {


### PR DESCRIPTION
This PR modifies the default user password validation regex to disallow any whitespace characters. 

Fixes #652