### PR TITLE
MF-657 - CLI: Explicitly set URLs for every service when initializing the SDK

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -17,11 +17,11 @@ const defURL string = "http://localhost"
 func main() {
 	msgContentType := string(sdk.CTJSONSenML)
 	sdkConf := sdk.Config{
-		AuthURL:         defURL,
-		ThingsURL:       defURL,
+		AuthURL:         fmt.Sprintf("%s/svcauth", defURL),
+		ThingsURL:       fmt.Sprintf("%s/svcthings", defURL),
 		WebhooksURL:     fmt.Sprintf("%s/svcwebhooks", defURL),
-		UsersURL:        defURL,
-		ReaderURL:       defURL,
+		UsersURL:        fmt.Sprintf("%s/svcthings", defURL),
+		ReaderURL:       fmt.Sprintf("%s/reader", defURL),
 		HTTPAdapterURL:  fmt.Sprintf("%s/http", defURL),
 		BootstrapURL:    defURL,
 		CertsURL:        defURL,

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -20,7 +20,7 @@ func main() {
 		AuthURL:         fmt.Sprintf("%s/svcauth", defURL),
 		ThingsURL:       fmt.Sprintf("%s/svcthings", defURL),
 		WebhooksURL:     fmt.Sprintf("%s/svcwebhooks", defURL),
-		UsersURL:        fmt.Sprintf("%s/svcthings", defURL),
+		UsersURL:        fmt.Sprintf("%s/svcusers", defURL),
 		ReaderURL:       fmt.Sprintf("%s/reader", defURL),
 		HTTPAdapterURL:  fmt.Sprintf("%s/http", defURL),
 		BootstrapURL:    defURL,


### PR DESCRIPTION
This PR fixes #657 and other possible CLI issues by explicitly initializing the URL for each service in the SDK config.