### PR TITLE
MF-659 - Validate user password in User.Validate

### DIFF
--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -165,7 +165,7 @@ func main() {
 	svc := newService(db, dbTracer, auth, cfg, logger)
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(svc, usersHttpTracer, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(svc, usersHttpTracer, logger, cfg.passRegex), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {

--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -290,7 +290,7 @@ func newService(db *sqlx.DB, tracer opentracing.Tracer, ac protomfx.AuthServiceC
 
 	idProvider := uuid.New()
 
-	svc := users.New(userRepo, hasher, ac, emailer, idProvider, c.passRegex)
+	svc := users.New(userRepo, hasher, ac, emailer, idProvider)
 	svc = httpapi.LoggingMiddleware(svc, logger)
 	svc = httpapi.MetricsMiddleware(
 		svc,

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -49,7 +49,7 @@ func newUserService() users.Service {
 	auth := mocks.NewAuthService(admin.ID, usersList, orgsList)
 	emailer := usmocks.NewEmailer()
 
-	return users.New(usersRepo, hasher, auth, emailer, idProvider, passRegex)
+	return users.New(usersRepo, hasher, auth, emailer, idProvider)
 }
 
 func newUserServer(svc users.Service) *httptest.Server {

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -54,7 +54,7 @@ func newUserService() users.Service {
 
 func newUserServer(svc users.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger, passRegex)
 	return httptest.NewServer(mux)
 }
 

--- a/users/api/http/endpoint_test.go
+++ b/users/api/http/endpoint_test.go
@@ -91,7 +91,7 @@ func newService() users.Service {
 	hasher := usmocks.NewHasher()
 	auth := mocks.NewAuthService(admin.ID, usersList, nil)
 	email := usmocks.NewEmailer()
-	return users.New(usersRepo, hasher, auth, email, idProvider, passRegex)
+	return users.New(usersRepo, hasher, auth, email, idProvider)
 }
 
 func newServer(svc users.Service) *httptest.Server {

--- a/users/api/http/endpoint_test.go
+++ b/users/api/http/endpoint_test.go
@@ -95,7 +95,7 @@ func newService() users.Service {
 }
 
 func newServer(svc users.Service) *httptest.Server {
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger.NewMock())
+	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger.NewMock(), passRegex)
 	return httptest.NewServer(mux)
 }
 

--- a/users/api/http/requests.go
+++ b/users/api/http/requests.go
@@ -4,6 +4,8 @@
 package http
 
 import (
+	"regexp"
+
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/users"
@@ -13,6 +15,8 @@ const (
 	maxLimitSize = 100
 	maxEmailSize = 1024
 )
+
+var userPasswordRegex *regexp.Regexp
 
 type userReq struct {
 	user users.User

--- a/users/api/http/requests.go
+++ b/users/api/http/requests.go
@@ -19,7 +19,7 @@ type userReq struct {
 }
 
 func (req userReq) validate() error {
-	return req.user.Validate()
+	return req.user.Validate(userPasswordRegex)
 }
 
 type selfRegisterUserReq struct {
@@ -27,7 +27,7 @@ type selfRegisterUserReq struct {
 }
 
 func (req selfRegisterUserReq) validate() error {
-	return req.user.Validate()
+	return req.user.Validate(userPasswordRegex)
 }
 
 type registerUserReq struct {
@@ -39,7 +39,7 @@ func (req registerUserReq) validate() error {
 	if req.token == "" {
 		return errors.ErrAuthorization
 	}
-	return req.user.Validate()
+	return req.user.Validate(userPasswordRegex)
 }
 
 type viewUserReq struct {

--- a/users/api/http/requests.go
+++ b/users/api/http/requests.go
@@ -124,6 +124,10 @@ func (req resetTokenReq) validate() error {
 		return apiutil.ErrMissingPass
 	}
 
+	if !userPasswordRegex.MatchString(req.Password) {
+		return users.ErrPasswordFormat
+	}
+
 	if req.ConfPass == "" {
 		return apiutil.ErrMissingConfPass
 	}
@@ -153,6 +157,11 @@ func (req passwChangeReq) validate() error {
 	if req.Email == "" && req.OldPassword == "" {
 		return apiutil.ErrMissingPass
 	}
+
+	if !userPasswordRegex.MatchString(req.Password) {
+		return users.ErrPasswordFormat
+	}
+
 	return nil
 }
 

--- a/users/api/http/transport.go
+++ b/users/api/http/transport.go
@@ -28,8 +28,6 @@ const (
 	statusKey = "status"
 )
 
-var userPasswordRegex *regexp.Regexp
-
 // MakeHandler returns a HTTP handler for API endpoints.
 func MakeHandler(svc users.Service, tracer opentracing.Tracer, logger logger.Logger, passwordRegex *regexp.Regexp) http.Handler {
 	userPasswordRegex = passwordRegex

--- a/users/api/http/transport.go
+++ b/users/api/http/transport.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/MainfluxLabs/mainflux"
@@ -27,8 +28,12 @@ const (
 	statusKey = "status"
 )
 
+var userPasswordRegex *regexp.Regexp
+
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc users.Service, tracer opentracing.Tracer, logger logger.Logger) http.Handler {
+func MakeHandler(svc users.Service, tracer opentracing.Tracer, logger logger.Logger, userPasswordRegexTemplate *regexp.Regexp) http.Handler {
+	userPasswordRegex = userPasswordRegexTemplate
+
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
 	}

--- a/users/api/http/transport.go
+++ b/users/api/http/transport.go
@@ -31,8 +31,8 @@ const (
 var userPasswordRegex *regexp.Regexp
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc users.Service, tracer opentracing.Tracer, logger logger.Logger, userPasswordRegexTemplate *regexp.Regexp) http.Handler {
-	userPasswordRegex = userPasswordRegexTemplate
+func MakeHandler(svc users.Service, tracer opentracing.Tracer, logger logger.Logger, passwordRegex *regexp.Regexp) http.Handler {
+	userPasswordRegex = passwordRegex
 
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),

--- a/users/service.go
+++ b/users/service.go
@@ -143,10 +143,6 @@ func New(users UserRepository, hasher Hasher, auth protomfx.AuthServiceClient, e
 }
 
 func (svc usersService) SelfRegister(ctx context.Context, user User) (string, error) {
-	if !svc.passRegex.MatchString(user.Password) {
-		return "", ErrPasswordFormat
-	}
-
 	uid, err := svc.idProvider.ID()
 	if err != nil {
 		return "", err
@@ -192,10 +188,6 @@ func (svc usersService) RegisterAdmin(ctx context.Context, user User) error {
 		return nil
 	}
 
-	if !svc.passRegex.MatchString(user.Password) {
-		return ErrPasswordFormat
-	}
-
 	uid, err := svc.idProvider.ID()
 	if err != nil {
 		return err
@@ -229,10 +221,6 @@ func (svc usersService) RegisterAdmin(ctx context.Context, user User) error {
 func (svc usersService) Register(ctx context.Context, token string, user User) (string, error) {
 	if err := svc.isAdmin(ctx, token); err != nil {
 		return "", err
-	}
-
-	if !svc.passRegex.MatchString(user.Password) {
-		return "", ErrPasswordFormat
 	}
 
 	uid, err := svc.idProvider.ID()
@@ -436,9 +424,7 @@ func (svc usersService) ResetPassword(ctx context.Context, resetToken, password 
 	if u.Email == "" {
 		return errors.ErrNotFound
 	}
-	if !svc.passRegex.MatchString(password) {
-		return ErrPasswordFormat
-	}
+
 	password, err = svc.hasher.Hash(password)
 	if err != nil {
 		return err
@@ -447,9 +433,6 @@ func (svc usersService) ResetPassword(ctx context.Context, resetToken, password 
 }
 
 func (svc usersService) ChangePassword(ctx context.Context, token, email, password, oldPassword string) error {
-	if !svc.passRegex.MatchString(password) {
-		return ErrPasswordFormat
-	}
 	ir, err := svc.identify(ctx, token)
 	if err != nil {
 		return errors.Wrap(errors.ErrAuthentication, err)

--- a/users/service.go
+++ b/users/service.go
@@ -5,7 +5,6 @@ package users
 
 import (
 	"context"
-	"regexp"
 
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
@@ -127,18 +126,16 @@ type usersService struct {
 	email      Emailer
 	auth       protomfx.AuthServiceClient
 	idProvider uuid.IDProvider
-	passRegex  *regexp.Regexp
 }
 
 // New instantiates the users service implementation
-func New(users UserRepository, hasher Hasher, auth protomfx.AuthServiceClient, e Emailer, idp uuid.IDProvider, passRegex *regexp.Regexp) Service {
+func New(users UserRepository, hasher Hasher, auth protomfx.AuthServiceClient, e Emailer, idp uuid.IDProvider) Service {
 	return &usersService{
 		users:      users,
 		hasher:     hasher,
 		auth:       auth,
 		email:      e,
 		idProvider: idp,
-		passRegex:  passRegex,
 	}
 }
 

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -78,15 +78,6 @@ func TestSelfRegister(t *testing.T) {
 			token: admin.Email,
 			err:   errors.ErrConflict,
 		},
-		{
-			desc: "register new user with weak password",
-			user: users.User{
-				Email:    registerUser.Email,
-				Password: "weak",
-			},
-			token: admin.Email,
-			err:   users.ErrPasswordFormat,
-		},
 	}
 
 	for _, tc := range cases {

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -44,7 +44,7 @@ func newService() users.Service {
 	authSvc := mocks.NewAuthService(admin.ID, usersList, nil)
 	e := usmocks.NewEmailer()
 
-	return users.New(userRepo, hasher, authSvc, e, idProvider, passRegex)
+	return users.New(userRepo, hasher, authSvc, e, idProvider)
 }
 
 func TestSelfRegister(t *testing.T) {

--- a/users/users.go
+++ b/users/users.go
@@ -5,6 +5,7 @@ package users
 
 import (
 	"context"
+	"regexp"
 
 	"github.com/MainfluxLabs/mainflux/pkg/email"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
@@ -26,12 +27,12 @@ type User struct {
 }
 
 // Validate returns an error if user representation is invalid.
-func (u User) Validate() error {
+func (u User) Validate(passRegex *regexp.Regexp) error {
 	if !email.IsEmail(u.Email) {
 		return errors.ErrMalformedEntity
 	}
 
-	if u.Password == "" {
+	if !passRegex.MatchString(u.Password) {
 		return errors.ErrMalformedEntity
 	}
 

--- a/users/users.go
+++ b/users/users.go
@@ -33,7 +33,7 @@ func (u User) Validate(passRegex *regexp.Regexp) error {
 	}
 
 	if !passRegex.MatchString(u.Password) {
-		return errors.ErrMalformedEntity
+		return ErrPasswordFormat
 	}
 
 	return nil

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -138,7 +138,7 @@ func TestValidate(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		err := tc.user.Validate()
+		err := tc.user.Validate(passRegex)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 	}
 }


### PR DESCRIPTION
This PR currently:

- ~~Sets and exports the default user password validation regex string in one place~~
    - ~~Previously the same constant was repeated in about 4 different places~~
- Validates the user's password against the regex in `users.User.Validate()`
- ~~Adds a couple password-related tests to the `users` package~~

---

However, it is currently broken as `users.User.Validate()` doesn't accept the regex as an argument, but instead always checks against the default one (this is problematic because users can set the regex at runtime using the `MF_USERS_PASS_REGEX` env. variable). Making it accept a regex is trivial, but as `User.Validate()` is currently called [when HTTP request data is validated in the handlers](https://github.com/MainfluxLabs/mainflux/blob/309db4fa142607721132ae8573306639fac6d670/users/api/http/requests.go#L30), and as those methods have no way to inspect the password regex being used at runtime, some refactoring would need to be done. 

There are a couple options:

- Remove calls to `Users.Validate()` from the HTTP handler layer ([requests.go](https://github.com/MainfluxLabs/mainflux/blob/master/users/api/http/requests.go)) and move them to the users service layer methods (`users.Service.Register()`, `users.Service.SelfRegister()`, etc...)
    - Methods in the users service implementation already perform password checks
    - Would require some work to match the current behavior mandated by endpoint and service tests
    - Would leave some struct `.validate` methods in [requests.go](https://github.com/MainfluxLabs/mainflux/blob/master/users/api/http/requests.go) empty - kinda weird but maybe OK?
- Keep `Users.Validate()` calls in the HTTP handler layer (in [requests.go](https://github.com/MainfluxLabs/mainflux/blob/master/users/api/http/requests.go), as it currently is), but refactor the structure such that they are able to be passed the password regex from the `users.Service` implementation
    - Probably unnecessarily complicated
- Abandon this entirely, keep password checks in users service methods without the use of `User.Validate()`
    - This leaves the `User.Validate()` somewhat pointless as it only checks for validity of the e-mail