### PR TITLE
MF-675 - CLI: Implement ability to list Groups by Org

### DIFF
--- a/cli/groups.go
+++ b/cli/groups.go
@@ -78,7 +78,7 @@ var cmdGroups = []cobra.Command{
 					return
 				}
 
-				res, err := sdk.GroupsByOrg(
+				res, err := sdk.ListGroupsByOrg(
 					mfxsdk.PageMetadata{Offset: uint64(Offset), Limit: uint64(Limit)},
 					args[1],
 					args[2],

--- a/pkg/sdk/go/orgs.go
+++ b/pkg/sdk/go/orgs.go
@@ -309,3 +309,35 @@ func (sdk mfSDK) ListMembersByOrg(orgID, token string, offset, limit uint64) (Me
 
 	return mp, nil
 }
+
+func (sdk mfSDK) GroupsByOrg(meta PageMetadata, orgID, token string) (GroupsPage, error) {
+	apiUrl := fmt.Sprintf("%s/%s/%s/groups?offset=%d&limit=%d", sdk.thingsURL, orgsEndpoint, orgID, meta.Offset, meta.Limit)
+
+	req, err := http.NewRequest(http.MethodGet, apiUrl, nil)
+	if err != nil {
+		return GroupsPage{}, err
+	}
+
+	resp, err := sdk.sendRequest(req, token, string(CTJSON))
+	if err != nil {
+		return GroupsPage{}, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return GroupsPage{}, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return GroupsPage{}, errors.Wrap(ErrFailedFetch, errors.New(resp.Status))
+	}
+
+	var gp GroupsPage
+	if err := json.Unmarshal(body, &gp); err != nil {
+		return GroupsPage{}, err
+	}
+
+	return gp, nil
+}

--- a/pkg/sdk/go/orgs.go
+++ b/pkg/sdk/go/orgs.go
@@ -310,7 +310,7 @@ func (sdk mfSDK) ListMembersByOrg(orgID, token string, offset, limit uint64) (Me
 	return mp, nil
 }
 
-func (sdk mfSDK) GroupsByOrg(meta PageMetadata, orgID, token string) (GroupsPage, error) {
+func (sdk mfSDK) ListGroupsByOrg(meta PageMetadata, orgID, token string) (GroupsPage, error) {
 	apiUrl := fmt.Sprintf("%s/%s/%s/groups?offset=%d&limit=%d", sdk.thingsURL, orgsEndpoint, orgID, meta.Offset, meta.Limit)
 
 	req, err := http.NewRequest(http.MethodGet, apiUrl, nil)

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -234,6 +234,9 @@ type SDK interface {
 	// Groups returns page of groups.
 	Groups(meta PageMetadata, token string) (GroupsPage, error)
 
+	// GroupsByOrg returns a page of all Groups belonging to the spcified Org.
+	GroupsByOrg(meta PageMetadata, orgID string, token string) (GroupsPage, error)
+
 	// Group returns users group object by id.
 	Group(id, token string) (Group, error)
 

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -234,8 +234,8 @@ type SDK interface {
 	// Groups returns page of groups.
 	Groups(meta PageMetadata, token string) (GroupsPage, error)
 
-	// GroupsByOrg returns a page of all Groups belonging to the spcified Org.
-	GroupsByOrg(meta PageMetadata, orgID string, token string) (GroupsPage, error)
+	// ListGroupsByOrg returns a page of all Groups belonging to the spcified Org.
+	ListGroupsByOrg(meta PageMetadata, orgID string, token string) (GroupsPage, error)
 
 	// Group returns users group object by id.
 	Group(id, token string) (Group, error)


### PR DESCRIPTION
This PR implements a new SDK method: `ListGroupsByOrg`, and uses it to extend the CLI's `groups` subcommand with the ability to list Groups belonging to a specific Org.

Usage is as follows:

```sh
$ mainfluxlabs-cli groups get by-org <org-id> <user-token>
```

Resolves #675 