### PR TITLE
MF-674 - Standardize SDK method signatures

### DIFF
--- a/certs/service.go
+++ b/certs/service.go
@@ -111,7 +111,7 @@ func (cs *certsService) IssueCert(ctx context.Context, token, thingID string, tt
 		return Cert{}, err
 	}
 
-	thing, err := cs.sdk.Thing(thingID, token)
+	thing, err := cs.sdk.GetThing(thingID, token)
 	if err != nil {
 		return Cert{}, errors.Wrap(ErrFailedCertCreation, err)
 	}
@@ -143,7 +143,7 @@ func (cs *certsService) RevokeCert(ctx context.Context, token, thingID string) (
 	if err != nil {
 		return revoke, err
 	}
-	thing, err := cs.sdk.Thing(thingID, token)
+	thing, err := cs.sdk.GetThing(thingID, token)
 	if err != nil {
 		return revoke, errors.Wrap(ErrFailedCertRevocation, err)
 	}

--- a/cli/group_members.go
+++ b/cli/group_members.go
@@ -39,7 +39,13 @@ var cmdGroupMembers = []cobra.Command{
 				logUsage(cmd.Use)
 				return
 			}
-			up, err := sdk.ListGroupMembers(args[0], args[1], uint64(Offset), uint64(Limit))
+
+			meta := mfxsdk.PageMetadata{
+				Offset: uint64(Offset),
+				Limit:  uint64(Limit),
+			}
+
+			up, err := sdk.GetGroupMembers(args[0], meta, args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/group_members.go
+++ b/cli/group_members.go
@@ -45,7 +45,7 @@ var cmdGroupMembers = []cobra.Command{
 				Limit:  uint64(Limit),
 			}
 
-			up, err := sdk.GetGroupMembers(args[0], meta, args[1])
+			up, err := sdk.ListGroupMembers(args[0], meta, args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/groups.go
+++ b/cli/groups.go
@@ -59,7 +59,7 @@ var cmdGroups = []cobra.Command{
 					Offset: uint64(Offset),
 					Limit:  uint64(Limit),
 				}
-				gp, err := sdk.GetGroups(meta, args[1])
+				gp, err := sdk.ListGroups(meta, args[1])
 				if err != nil {
 					logError(err)
 					return
@@ -78,7 +78,7 @@ var cmdGroups = []cobra.Command{
 					return
 				}
 
-				res, err := sdk.GetGroupsByOrg(
+				res, err := sdk.ListGroupsByOrg(
 					args[1],
 					mfxsdk.PageMetadata{Offset: uint64(Offset), Limit: uint64(Limit)},
 					args[2],
@@ -146,7 +146,7 @@ var cmdGroups = []cobra.Command{
 				Limit:  uint64(Limit),
 			}
 
-			up, err := sdk.GetThingsByGroup(args[0], meta, args[1])
+			up, err := sdk.ListThingsByGroup(args[0], meta, args[1])
 			if err != nil {
 				logError(err)
 				return
@@ -186,7 +186,7 @@ var cmdGroups = []cobra.Command{
 				Limit:  uint64(Limit),
 			}
 
-			up, err := sdk.GetProfilesByGroup(args[0], meta, args[1])
+			up, err := sdk.ListProfilesByGroup(args[0], meta, args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/groups.go
+++ b/cli/groups.go
@@ -59,14 +59,14 @@ var cmdGroups = []cobra.Command{
 					Offset: uint64(Offset),
 					Limit:  uint64(Limit),
 				}
-				gp, err := sdk.Groups(meta, args[1])
+				gp, err := sdk.GetGroups(meta, args[1])
 				if err != nil {
 					logError(err)
 					return
 				}
 				logJSON(gp)
 			case "group-id":
-				g, err := sdk.Group(args[1], args[2])
+				g, err := sdk.GetGroup(args[1], args[2])
 				if err != nil {
 					logError(err)
 					return
@@ -78,9 +78,9 @@ var cmdGroups = []cobra.Command{
 					return
 				}
 
-				res, err := sdk.ListGroupsByOrg(
-					mfxsdk.PageMetadata{Offset: uint64(Offset), Limit: uint64(Limit)},
+				res, err := sdk.GetGroupsByOrg(
 					args[1],
+					mfxsdk.PageMetadata{Offset: uint64(Offset), Limit: uint64(Limit)},
 					args[2],
 				)
 
@@ -140,7 +140,13 @@ var cmdGroups = []cobra.Command{
 				logUsage(cmd.Use)
 				return
 			}
-			up, err := sdk.ListThingsByGroup(args[0], args[1], uint64(Offset), uint64(Limit))
+
+			meta := mfxsdk.PageMetadata{
+				Offset: uint64(Offset),
+				Limit:  uint64(Limit),
+			}
+
+			up, err := sdk.GetThingsByGroup(args[0], meta, args[1])
 			if err != nil {
 				logError(err)
 				return
@@ -157,7 +163,7 @@ var cmdGroups = []cobra.Command{
 				logUsage(cmd.Use)
 				return
 			}
-			up, err := sdk.ViewGroupByThing(args[0], args[1])
+			up, err := sdk.GetGroupByThing(args[0], args[1])
 			if err != nil {
 				logError(err)
 				return
@@ -174,7 +180,13 @@ var cmdGroups = []cobra.Command{
 				logUsage(cmd.Use)
 				return
 			}
-			up, err := sdk.ListProfilesByGroup(args[0], args[1], uint64(Offset), uint64(Limit))
+
+			meta := mfxsdk.PageMetadata{
+				Offset: uint64(Offset),
+				Limit:  uint64(Limit),
+			}
+
+			up, err := sdk.GetProfilesByGroup(args[0], meta, args[1])
 			if err != nil {
 				logError(err)
 				return
@@ -191,7 +203,7 @@ var cmdGroups = []cobra.Command{
 				logUsage(cmd.Use)
 				return
 			}
-			up, err := sdk.ViewGroupByProfile(args[0], args[1])
+			up, err := sdk.GetGroupByProfile(args[0], args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/keys.go
+++ b/cli/keys.go
@@ -26,7 +26,7 @@ var cmdAPIKeys = []cobra.Command{
 				return
 			}
 
-			resp, err := sdk.Issue(args[1], d)
+			resp, err := sdk.Issue(d, args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/message.go
+++ b/cli/message.go
@@ -46,7 +46,7 @@ var cmdMessages = []cobra.Command{
 			}
 			switch len(args) {
 			case 1:
-				m, err := sdk.ReadMessages(pm, false, args[0])
+				m, err := sdk.ReadMessages(false, pm, args[0])
 				if err != nil {
 					logError(err)
 					return
@@ -54,7 +54,7 @@ var cmdMessages = []cobra.Command{
 
 				logJSON(m)
 			case 2:
-				m, err := sdk.ReadMessages(pm, true, args[1])
+				m, err := sdk.ReadMessages(true, pm, args[1])
 				if err != nil {
 					logError(err)
 					return

--- a/cli/org_members.go
+++ b/cli/org_members.go
@@ -44,8 +44,13 @@ var cmdOrgMembers = []cobra.Command{
 				return
 			}
 
+			meta := mfxsdk.PageMetadata{
+				Offset: uint64(Offset),
+				Limit:  uint64(Limit),
+			}
+
 			if args[0] == "all" {
-				mbs, err := sdk.ListMembersByOrg(args[1], args[2], uint64(Offset), uint64(Limit))
+				mbs, err := sdk.GetMembersByOrg(args[1], meta, args[2])
 				if err != nil {
 					logError(err)
 					return
@@ -54,7 +59,7 @@ var cmdOrgMembers = []cobra.Command{
 				return
 			}
 
-			mb, err := sdk.ViewMember(args[0], args[1], args[2])
+			mb, err := sdk.GetMember(args[0], args[1], args[2])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/org_members.go
+++ b/cli/org_members.go
@@ -50,7 +50,7 @@ var cmdOrgMembers = []cobra.Command{
 			}
 
 			if args[0] == "all" {
-				mbs, err := sdk.GetMembersByOrg(args[1], meta, args[2])
+				mbs, err := sdk.ListMembersByOrg(args[1], meta, args[2])
 				if err != nil {
 					logError(err)
 					return

--- a/cli/orgs.go
+++ b/cli/orgs.go
@@ -58,7 +58,7 @@ var cmdOrgs = []cobra.Command{
 					Offset: uint64(Offset),
 					Limit:  uint64(Limit),
 				}
-				l, err := sdk.Orgs(meta, args[1])
+				l, err := sdk.GetOrgs(meta, args[1])
 				if err != nil {
 					logError(err)
 					return
@@ -70,7 +70,7 @@ var cmdOrgs = []cobra.Command{
 				logUsage(cmd.Use)
 				return
 			}
-			t, err := sdk.Org(args[0], args[1])
+			t, err := sdk.GetOrg(args[0], args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/orgs.go
+++ b/cli/orgs.go
@@ -58,7 +58,7 @@ var cmdOrgs = []cobra.Command{
 					Offset: uint64(Offset),
 					Limit:  uint64(Limit),
 				}
-				l, err := sdk.GetOrgs(meta, args[1])
+				l, err := sdk.ListOrgs(meta, args[1])
 				if err != nil {
 					logError(err)
 					return

--- a/cli/profiles.go
+++ b/cli/profiles.go
@@ -63,7 +63,7 @@ var cmdProfiles = []cobra.Command{
 
 			switch args[0] {
 			case "all":
-				l, err := sdk.GetProfiles(pageMetadata, args[1])
+				l, err := sdk.ListProfiles(pageMetadata, args[1])
 				if err != nil {
 					logError(err)
 					return

--- a/cli/profiles.go
+++ b/cli/profiles.go
@@ -63,7 +63,7 @@ var cmdProfiles = []cobra.Command{
 
 			switch args[0] {
 			case "all":
-				l, err := sdk.Profiles(args[1], pageMetadata)
+				l, err := sdk.GetProfiles(pageMetadata, args[1])
 				if err != nil {
 					logError(err)
 					return
@@ -72,7 +72,7 @@ var cmdProfiles = []cobra.Command{
 				logJSON(l)
 				return
 			case "by-thing":
-				pbt, err := sdk.ViewProfileByThing(args[1], args[2])
+				pbt, err := sdk.GetProfileByThing(args[1], args[2])
 				if err != nil {
 					logError(err)
 					return
@@ -81,7 +81,7 @@ var cmdProfiles = []cobra.Command{
 				logJSON(pbt)
 				return
 			case "by-id":
-				c, err := sdk.Profile(args[1], args[2])
+				c, err := sdk.GetProfile(args[1], args[2])
 				if err != nil {
 					logError(err)
 					return

--- a/cli/provision.go
+++ b/cli/provision.go
@@ -122,7 +122,7 @@ var cmdProvision = []cobra.Command{
 				return
 			}
 
-			gr, err := sdk.Group(grID, ut)
+			gr, err := sdk.GetGroup(grID, ut)
 			if err != nil {
 				logError(err)
 				return

--- a/cli/things.go
+++ b/cli/things.go
@@ -62,7 +62,7 @@ var cmdThings = []cobra.Command{
 
 			switch args[0] {
 			case "all":
-				l, err := sdk.GetThings(pageMetadata, args[1])
+				l, err := sdk.ListThings(pageMetadata, args[1])
 				if err != nil {
 					logError(err)
 					return
@@ -71,7 +71,7 @@ var cmdThings = []cobra.Command{
 				logJSON(l)
 				return
 			case "by-profile":
-				tip, err := sdk.GetThingsByProfile(args[1], pageMetadata, args[2])
+				tip, err := sdk.ListThingsByProfile(args[1], pageMetadata, args[2])
 				if err != nil {
 					logError(err)
 					return

--- a/cli/things.go
+++ b/cli/things.go
@@ -62,7 +62,7 @@ var cmdThings = []cobra.Command{
 
 			switch args[0] {
 			case "all":
-				l, err := sdk.Things(args[1], pageMetadata)
+				l, err := sdk.GetThings(pageMetadata, args[1])
 				if err != nil {
 					logError(err)
 					return
@@ -71,7 +71,7 @@ var cmdThings = []cobra.Command{
 				logJSON(l)
 				return
 			case "by-profile":
-				tip, err := sdk.ThingsByProfile(args[1], args[2], pageMetadata)
+				tip, err := sdk.GetThingsByProfile(args[1], pageMetadata, args[2])
 				if err != nil {
 					logError(err)
 					return
@@ -80,7 +80,7 @@ var cmdThings = []cobra.Command{
 				logJSON(tip)
 				return
 			case "by-id":
-				t, err := sdk.Thing(args[1], args[2])
+				t, err := sdk.GetThing(args[1], args[2])
 				if err != nil {
 					logError(err)
 					return
@@ -104,7 +104,7 @@ var cmdThings = []cobra.Command{
 				return
 			}
 
-			meta, err := sdk.MetadataByKey(args[0])
+			meta, err := sdk.GetThingMetadataByKey(args[0])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/users.go
+++ b/cli/users.go
@@ -60,7 +60,7 @@ var cmdUsers = []cobra.Command{
 				Metadata: metadata,
 			}
 			if args[0] == "all" {
-				l, err := sdk.GetUsers(pageMetadata, args[1])
+				l, err := sdk.ListUsers(pageMetadata, args[1])
 				if err != nil {
 					logError(err)
 					return

--- a/cli/users.go
+++ b/cli/users.go
@@ -28,7 +28,7 @@ var cmdUsers = []cobra.Command{
 				Email:    args[0],
 				Password: args[1],
 			}
-			id, err := sdk.CreateUser(args[2], user)
+			id, err := sdk.CreateUser(user, args[2])
 			if err != nil {
 				logError(err)
 				return
@@ -60,7 +60,7 @@ var cmdUsers = []cobra.Command{
 				Metadata: metadata,
 			}
 			if args[0] == "all" {
-				l, err := sdk.Users(args[1], pageMetadata)
+				l, err := sdk.GetUsers(pageMetadata, args[1])
 				if err != nil {
 					logError(err)
 					return
@@ -68,7 +68,7 @@ var cmdUsers = []cobra.Command{
 				logJSON(l)
 				return
 			}
-			u, err := sdk.User(args[0], args[1])
+			u, err := sdk.GetUser(args[0], args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/webhooks.go
+++ b/cli/webhooks.go
@@ -44,21 +44,21 @@ var cmdWebhooks = []cobra.Command{
 
 			switch args[0] {
 			case "by-group":
-				l, err := sdk.ListWebhooksByGroup(args[1], args[2])
+				l, err := sdk.GetWebhooksByGroup(args[1], args[2])
 				if err != nil {
 					logError(err)
 					return
 				}
 				logJSON(l)
 			case "by-thing":
-				l, err := sdk.ListWebhooksByThing(args[1], args[2])
+				l, err := sdk.GetWebhooksByThing(args[1], args[2])
 				if err != nil {
 					logError(err)
 					return
 				}
 				logJSON(l)
 			case "by-id":
-				w, err := sdk.Webhook(args[1], args[2])
+				w, err := sdk.GetWebhook(args[1], args[2])
 				if err != nil {
 					logError(err)
 					return

--- a/cli/webhooks.go
+++ b/cli/webhooks.go
@@ -44,14 +44,14 @@ var cmdWebhooks = []cobra.Command{
 
 			switch args[0] {
 			case "by-group":
-				l, err := sdk.GetWebhooksByGroup(args[1], args[2])
+				l, err := sdk.ListWebhooksByGroup(args[1], args[2])
 				if err != nil {
 					logError(err)
 					return
 				}
 				logJSON(l)
 			case "by-thing":
-				l, err := sdk.GetWebhooksByThing(args[1], args[2])
+				l, err := sdk.ListWebhooksByThing(args[1], args[2])
 				if err != nil {
 					logError(err)
 					return

--- a/pkg/sdk/go/groups.go
+++ b/pkg/sdk/go/groups.go
@@ -111,8 +111,8 @@ func (sdk mfSDK) DeleteGroups(ids []string, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) ListThingsByGroup(groupID, token string, offset, limit uint64) (ThingsPage, error) {
-	url := fmt.Sprintf("%s/%s/%s/things?offset=%d&limit=%d", sdk.thingsURL, groupsEndpoint, groupID, offset, limit)
+func (sdk mfSDK) GetThingsByGroup(groupID string, pm PageMetadata, token string) (ThingsPage, error) {
+	url := fmt.Sprintf("%s/%s/%s/things?offset=%d&limit=%d", sdk.thingsURL, groupsEndpoint, groupID, pm.Offset, pm.Limit)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return ThingsPage{}, err
@@ -141,8 +141,8 @@ func (sdk mfSDK) ListThingsByGroup(groupID, token string, offset, limit uint64) 
 	return gtp, nil
 }
 
-func (sdk mfSDK) ListProfilesByGroup(groupID, token string, offset, limit uint64) (ProfilesPage, error) {
-	url := fmt.Sprintf("%s/%s/%s/profiles?offset=%d&limit=%d", sdk.thingsURL, groupsEndpoint, groupID, offset, limit)
+func (sdk mfSDK) GetProfilesByGroup(groupID string, meta PageMetadata, token string) (ProfilesPage, error) {
+	url := fmt.Sprintf("%s/%s/%s/profiles?offset=%d&limit=%d", sdk.thingsURL, groupsEndpoint, groupID, meta.Offset, meta.Limit)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return ProfilesPage{}, err
@@ -171,7 +171,7 @@ func (sdk mfSDK) ListProfilesByGroup(groupID, token string, offset, limit uint64
 	return gcp, nil
 }
 
-func (sdk mfSDK) Groups(meta PageMetadata, token string) (GroupsPage, error) {
+func (sdk mfSDK) GetGroups(meta PageMetadata, token string) (GroupsPage, error) {
 	u, err := url.Parse(sdk.thingsURL)
 	if err != nil {
 		return GroupsPage{}, err
@@ -217,7 +217,7 @@ func (sdk mfSDK) getGroups(token, url string) (GroupsPage, error) {
 	return tp, nil
 }
 
-func (sdk mfSDK) Group(id, token string) (Group, error) {
+func (sdk mfSDK) GetGroup(id, token string) (Group, error) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.thingsURL, groupsEndpoint, id)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -271,7 +271,7 @@ func (sdk mfSDK) UpdateGroup(g Group, groupID, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) ViewGroupByThing(thingID, token string) (Group, error) {
+func (sdk mfSDK) GetGroupByThing(thingID, token string) (Group, error) {
 	url := fmt.Sprintf("%s/%s/%s/%s", sdk.thingsURL, thingsEndpoint, thingID, groupsEndpoint)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -301,7 +301,7 @@ func (sdk mfSDK) ViewGroupByThing(thingID, token string) (Group, error) {
 	return g, nil
 }
 
-func (sdk mfSDK) ViewGroupByProfile(profileID, token string) (Group, error) {
+func (sdk mfSDK) GetGroupByProfile(profileID, token string) (Group, error) {
 	url := fmt.Sprintf("%s/%s/%s/%s", sdk.thingsURL, profilesEndpoint, profileID, groupsEndpoint)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -407,8 +407,8 @@ func (sdk mfSDK) RemoveGroupMembers(ids []string, groupID, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) ListGroupMembers(groupID, token string, offset, limit uint64) (GroupMembersPage, error) {
-	url := fmt.Sprintf("%s/%s/%s/members?offset=%d&limit=%d", sdk.thingsURL, groupsEndpoint, groupID, offset, limit)
+func (sdk mfSDK) GetGroupMembers(groupID string, pm PageMetadata, token string) (GroupMembersPage, error) {
+	url := fmt.Sprintf("%s/%s/%s/members?offset=%d&limit=%d", sdk.thingsURL, groupsEndpoint, groupID, pm.Offset, pm.Limit)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return GroupMembersPage{}, err

--- a/pkg/sdk/go/groups.go
+++ b/pkg/sdk/go/groups.go
@@ -407,7 +407,7 @@ func (sdk mfSDK) RemoveGroupMembers(ids []string, groupID, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) GetGroupMembers(groupID string, pm PageMetadata, token string) (GroupMembersPage, error) {
+func (sdk mfSDK) ListGroupMembers(groupID string, pm PageMetadata, token string) (GroupMembersPage, error) {
 	url := fmt.Sprintf("%s/%s/%s/members?offset=%d&limit=%d", sdk.thingsURL, groupsEndpoint, groupID, pm.Offset, pm.Limit)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/sdk/go/groups.go
+++ b/pkg/sdk/go/groups.go
@@ -111,7 +111,7 @@ func (sdk mfSDK) DeleteGroups(ids []string, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) GetThingsByGroup(groupID string, pm PageMetadata, token string) (ThingsPage, error) {
+func (sdk mfSDK) ListThingsByGroup(groupID string, pm PageMetadata, token string) (ThingsPage, error) {
 	url := fmt.Sprintf("%s/%s/%s/things?offset=%d&limit=%d", sdk.thingsURL, groupsEndpoint, groupID, pm.Offset, pm.Limit)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -141,7 +141,7 @@ func (sdk mfSDK) GetThingsByGroup(groupID string, pm PageMetadata, token string)
 	return gtp, nil
 }
 
-func (sdk mfSDK) GetProfilesByGroup(groupID string, meta PageMetadata, token string) (ProfilesPage, error) {
+func (sdk mfSDK) ListProfilesByGroup(groupID string, meta PageMetadata, token string) (ProfilesPage, error) {
 	url := fmt.Sprintf("%s/%s/%s/profiles?offset=%d&limit=%d", sdk.thingsURL, groupsEndpoint, groupID, meta.Offset, meta.Limit)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -171,7 +171,7 @@ func (sdk mfSDK) GetProfilesByGroup(groupID string, meta PageMetadata, token str
 	return gcp, nil
 }
 
-func (sdk mfSDK) GetGroups(meta PageMetadata, token string) (GroupsPage, error) {
+func (sdk mfSDK) ListGroups(meta PageMetadata, token string) (GroupsPage, error) {
 	u, err := url.Parse(sdk.thingsURL)
 	if err != nil {
 		return GroupsPage{}, err

--- a/pkg/sdk/go/keys.go
+++ b/pkg/sdk/go/keys.go
@@ -27,7 +27,7 @@ const (
 	APIKey
 )
 
-func (sdk mfSDK) Issue(token string, d time.Duration) (KeyRes, error) {
+func (sdk mfSDK) Issue(d time.Duration, token string) (KeyRes, error) {
 	datareq := keyReq{Type: APIKey, Duration: d}
 	data, err := json.Marshal(datareq)
 	if err != nil {
@@ -83,7 +83,7 @@ func (sdk mfSDK) Revoke(id, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) RetrieveKey(id, token string) (retrieveKeyRes, error) {
+func (sdk mfSDK) RetrieveKey(token, id string) (retrieveKeyRes, error) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.authURL, keysEndpoint, id)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/sdk/go/keys.go
+++ b/pkg/sdk/go/keys.go
@@ -83,7 +83,7 @@ func (sdk mfSDK) Revoke(id, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) RetrieveKey(token, id string) (retrieveKeyRes, error) {
+func (sdk mfSDK) RetrieveKey(id, token string) (retrieveKeyRes, error) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.authURL, keysEndpoint, id)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/sdk/go/message.go
+++ b/pkg/sdk/go/message.go
@@ -36,7 +36,7 @@ func (sdk mfSDK) SendMessage(subtopic, msg, key string) error {
 	return nil
 }
 
-func (sdk mfSDK) ReadMessages(pm PageMetadata, isAdmin bool, token string) (map[string]interface{}, error) {
+func (sdk mfSDK) ReadMessages(isAdmin bool, pm PageMetadata, token string) (map[string]interface{}, error) {
 	url, err := sdk.withQueryParams(sdk.readerURL, messagesEndpoint, pm)
 	if err != nil {
 		return nil, err

--- a/pkg/sdk/go/orgs.go
+++ b/pkg/sdk/go/orgs.go
@@ -43,7 +43,7 @@ func (sdk mfSDK) CreateOrg(o Org, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) Org(id, token string) (Org, error) {
+func (sdk mfSDK) GetOrg(id, token string) (Org, error) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.authURL, orgsEndpoint, id)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -116,7 +116,7 @@ func (sdk mfSDK) DeleteOrg(id, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) Orgs(meta PageMetadata, token string) (OrgsPage, error) {
+func (sdk mfSDK) GetOrgs(meta PageMetadata, token string) (OrgsPage, error) {
 	u, err := url.Parse(sdk.authURL)
 	if err != nil {
 		return OrgsPage{}, err
@@ -163,7 +163,7 @@ func (sdk mfSDK) getOrgs(token, url string) (OrgsPage, error) {
 	return op, nil
 }
 
-func (sdk mfSDK) ViewMember(memberID, orgID, token string) (Member, error) {
+func (sdk mfSDK) GetMember(memberID, orgID, token string) (Member, error) {
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", sdk.authURL, orgsEndpoint, orgID, membersEndpoint, memberID)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -280,8 +280,8 @@ func (sdk mfSDK) UpdateMembers(oms []OrgMember, orgID, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) ListMembersByOrg(orgID, token string, offset, limit uint64) (MembersPage, error) {
-	url := fmt.Sprintf("%s/%s/%s/members?offset=%d&limit=%d", sdk.authURL, orgsEndpoint, orgID, offset, limit)
+func (sdk mfSDK) GetMembersByOrg(orgID string, pm PageMetadata, token string) (MembersPage, error) {
+	url := fmt.Sprintf("%s/%s/%s/members?offset=%d&limit=%d", sdk.authURL, orgsEndpoint, orgID, pm.Offset, pm.Limit)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return MembersPage{}, err
@@ -310,7 +310,7 @@ func (sdk mfSDK) ListMembersByOrg(orgID, token string, offset, limit uint64) (Me
 	return mp, nil
 }
 
-func (sdk mfSDK) ListGroupsByOrg(meta PageMetadata, orgID, token string) (GroupsPage, error) {
+func (sdk mfSDK) GetGroupsByOrg(orgID string, meta PageMetadata, token string) (GroupsPage, error) {
 	apiUrl := fmt.Sprintf("%s/%s/%s/groups?offset=%d&limit=%d", sdk.thingsURL, orgsEndpoint, orgID, meta.Offset, meta.Limit)
 
 	req, err := http.NewRequest(http.MethodGet, apiUrl, nil)

--- a/pkg/sdk/go/orgs.go
+++ b/pkg/sdk/go/orgs.go
@@ -116,7 +116,7 @@ func (sdk mfSDK) DeleteOrg(id, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) GetOrgs(meta PageMetadata, token string) (OrgsPage, error) {
+func (sdk mfSDK) ListOrgs(meta PageMetadata, token string) (OrgsPage, error) {
 	u, err := url.Parse(sdk.authURL)
 	if err != nil {
 		return OrgsPage{}, err
@@ -280,7 +280,7 @@ func (sdk mfSDK) UpdateMembers(oms []OrgMember, orgID, token string) error {
 	return nil
 }
 
-func (sdk mfSDK) GetMembersByOrg(orgID string, pm PageMetadata, token string) (MembersPage, error) {
+func (sdk mfSDK) ListMembersByOrg(orgID string, pm PageMetadata, token string) (MembersPage, error) {
 	url := fmt.Sprintf("%s/%s/%s/members?offset=%d&limit=%d", sdk.authURL, orgsEndpoint, orgID, pm.Offset, pm.Limit)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -310,7 +310,7 @@ func (sdk mfSDK) GetMembersByOrg(orgID string, pm PageMetadata, token string) (M
 	return mp, nil
 }
 
-func (sdk mfSDK) GetGroupsByOrg(orgID string, meta PageMetadata, token string) (GroupsPage, error) {
+func (sdk mfSDK) ListGroupsByOrg(orgID string, meta PageMetadata, token string) (GroupsPage, error) {
 	apiUrl := fmt.Sprintf("%s/%s/%s/groups?offset=%d&limit=%d", sdk.thingsURL, orgsEndpoint, orgID, meta.Offset, meta.Limit)
 
 	req, err := http.NewRequest(http.MethodGet, apiUrl, nil)

--- a/pkg/sdk/go/profiles.go
+++ b/pkg/sdk/go/profiles.go
@@ -63,7 +63,7 @@ func (sdk mfSDK) CreateProfiles(prs []Profile, groupID, token string) ([]Profile
 	return ccr.Profiles, nil
 }
 
-func (sdk mfSDK) GetProfiles(pm PageMetadata, token string) (ProfilesPage, error) {
+func (sdk mfSDK) ListProfiles(pm PageMetadata, token string) (ProfilesPage, error) {
 	url, err := sdk.withQueryParams(sdk.thingsURL, profilesEndpoint, pm)
 	if err != nil {
 		return ProfilesPage{}, err

--- a/pkg/sdk/go/profiles.go
+++ b/pkg/sdk/go/profiles.go
@@ -63,7 +63,7 @@ func (sdk mfSDK) CreateProfiles(prs []Profile, groupID, token string) ([]Profile
 	return ccr.Profiles, nil
 }
 
-func (sdk mfSDK) Profiles(token string, pm PageMetadata) (ProfilesPage, error) {
+func (sdk mfSDK) GetProfiles(pm PageMetadata, token string) (ProfilesPage, error) {
 	url, err := sdk.withQueryParams(sdk.thingsURL, profilesEndpoint, pm)
 	if err != nil {
 		return ProfilesPage{}, err
@@ -96,7 +96,7 @@ func (sdk mfSDK) Profiles(token string, pm PageMetadata) (ProfilesPage, error) {
 	return cp, nil
 }
 
-func (sdk mfSDK) ViewProfileByThing(thingID, token string) (Profile, error) {
+func (sdk mfSDK) GetProfileByThing(thingID, token string) (Profile, error) {
 	url := fmt.Sprintf("%s/things/%s/profiles", sdk.thingsURL, thingID)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -126,7 +126,7 @@ func (sdk mfSDK) ViewProfileByThing(thingID, token string) (Profile, error) {
 	return pr, nil
 }
 
-func (sdk mfSDK) Profile(id, token string) (Profile, error) {
+func (sdk mfSDK) GetProfile(id, token string) (Profile, error) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.thingsURL, profilesEndpoint, id)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/sdk/go/profiles_test.go
+++ b/pkg/sdk/go/profiles_test.go
@@ -327,7 +327,7 @@ func TestProfiles(t *testing.T) {
 			Metadata: tc.metadata,
 		}
 
-		page, err := mainfluxSDK.GetProfiles(filter, tc.token)
+		page, err := mainfluxSDK.ListProfiles(filter, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Profiles, fmt.Sprintf("%s: expected response profile %s, got %s", tc.desc, tc.response, page.Profiles))
 	}

--- a/pkg/sdk/go/profiles_test.go
+++ b/pkg/sdk/go/profiles_test.go
@@ -219,7 +219,7 @@ func TestProfile(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		respPr, err := mainfluxSDK.Profile(tc.profileID, tc.token)
+		respPr, err := mainfluxSDK.GetProfile(tc.profileID, tc.token)
 
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, respPr, fmt.Sprintf("%s: expected response profile %s, got %s", tc.desc, tc.response, respPr))
@@ -327,7 +327,7 @@ func TestProfiles(t *testing.T) {
 			Metadata: tc.metadata,
 		}
 
-		page, err := mainfluxSDK.Profiles(tc.token, filter)
+		page, err := mainfluxSDK.GetProfiles(filter, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Profiles, fmt.Sprintf("%s: expected response profile %s, got %s", tc.desc, tc.response, page.Profiles))
 	}
@@ -406,7 +406,7 @@ func TestViewProfileByThing(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		pr, err := mainfluxSDK.ViewProfileByThing(tc.thing, tc.token)
+		pr, err := mainfluxSDK.GetProfileByThing(tc.thing, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, pr, fmt.Sprintf("%s: expected response profile %s, got %s", tc.desc, tc.response, pr))
 	}

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -172,13 +172,13 @@ type Metadata map[string]interface{}
 // SDK contains Mainflux API.
 type SDK interface {
 	// CreateUser creates mainflux user.
-	CreateUser(token string, user User) (string, error)
+	CreateUser(user User, token string) (string, error)
 
-	// User returns user object by id.
-	User(token, id string) (User, error)
+	// GetUser returns user object by id.
+	GetUser(id, token string) (User, error)
 
-	// Users returns list of users.
-	Users(token string, pm PageMetadata) (UsersPage, error)
+	// GetUsers returns list of users.
+	GetUsers(pm PageMetadata, token string) (UsersPage, error)
 
 	// CreateToken receives credentials and returns user token.
 	CreateToken(user User) (string, error)
@@ -198,17 +198,17 @@ type SDK interface {
 	// CreateThings registers new things and returns their ids.
 	CreateThings(things []Thing, groupID, token string) ([]Thing, error)
 
-	// Things returns page of things.
-	Things(token string, pm PageMetadata) (ThingsPage, error)
+	// GetThings returns page of things.
+	GetThings(pm PageMetadata, token string) (ThingsPage, error)
 
-	// ThingsByProfile returns page of things assigned to the specified profile.
-	ThingsByProfile(profileID, token string, pm PageMetadata) (ThingsPage, error)
+	// GetThingsByProfile returns page of things assigned to the specified profile.
+	GetThingsByProfile(profileID string, pm PageMetadata, token string) (ThingsPage, error)
 
-	// Thing returns thing object by id.
-	Thing(id, token string) (Thing, error)
+	// GetThing returns thing object by id.
+	GetThing(id, token string) (Thing, error)
 
-	// MetadataByKey retrieves metadata about the thing identified by the given key.
-	MetadataByKey(thingKey string) (Metadata, error)
+	// GetThingMetadataByKey retrieves metadata about the thing identified by the given key.
+	GetThingMetadataByKey(thingKey string) (Metadata, error)
 
 	// UpdateThing updates existing thing.
 	UpdateThing(thing Thing, thingID, token string) error
@@ -231,20 +231,20 @@ type SDK interface {
 	// DeleteGroups delete users groups.
 	DeleteGroups(ids []string, token string) error
 
-	// Groups returns page of groups.
-	Groups(meta PageMetadata, token string) (GroupsPage, error)
+	// GetGroups returns page of groups.
+	GetGroups(meta PageMetadata, token string) (GroupsPage, error)
 
-	// ListGroupsByOrg returns a page of all Groups belonging to the spcified Org.
-	ListGroupsByOrg(meta PageMetadata, orgID string, token string) (GroupsPage, error)
+	// GetGroupsByOrg returns a page of all Groups belonging to the spcified Org.
+	GetGroupsByOrg(orgID string, meta PageMetadata, token string) (GroupsPage, error)
 
-	// Group returns users group object by id.
-	Group(id, token string) (Group, error)
+	// GetGroup returns users group object by id.
+	GetGroup(id, token string) (Group, error)
 
-	// ListThingsByGroup lists things that are members of specified group.
-	ListThingsByGroup(groupID, token string, offset, limit uint64) (ThingsPage, error)
+	// GetThingsByGroup lists things that are members of specified group.
+	GetThingsByGroup(groupID string, meta PageMetadata, token string) (ThingsPage, error)
 
-	// ViewGroupByThing retrieves a group that the specified thing is a member of.
-	ViewGroupByThing(thingID, token string) (Group, error)
+	// GetGroupByThing retrieves a group that the specified thing is a member of.
+	GetGroupByThing(thingID, token string) (Group, error)
 
 	// UpdateGroup updates existing group.
 	UpdateGroup(group Group, groupID, token string) error
@@ -255,14 +255,14 @@ type SDK interface {
 	// CreateProfiles registers new profiles and returns their ids.
 	CreateProfiles(profiles []Profile, groupID, token string) ([]Profile, error)
 
-	// Profiles returns page of profiles.
-	Profiles(token string, pm PageMetadata) (ProfilesPage, error)
+	// GetProfiles returns page of profiles.
+	GetProfiles(pm PageMetadata, token string) (ProfilesPage, error)
 
-	// ViewProfileByThing returns profile that are assigned to specified thing.
-	ViewProfileByThing(thingID, token string) (Profile, error)
+	// GetProfileByThing returns profile that are assigned to specified thing.
+	GetProfileByThing(thingID, token string) (Profile, error)
 
-	// Profile returns profile data by id.
-	Profile(id, token string) (Profile, error)
+	// GetProfile returns profile data by id.
+	GetProfile(id, token string) (Profile, error)
 
 	// UpdateProfile updates existing profile.
 	UpdateProfile(profile Profile, profileID, token string) error
@@ -273,11 +273,11 @@ type SDK interface {
 	// DeleteProfiles removes existing profile.
 	DeleteProfiles(ids []string, token string) error
 
-	// ListProfilesByGroup lists profiles that are members of specified group.
-	ListProfilesByGroup(groupID, token string, offset, limit uint64) (ProfilesPage, error)
+	// GetProfilesByGroup lists profiles that are members of specified group.
+	GetProfilesByGroup(groupID string, pm PageMetadata, token string) (ProfilesPage, error)
 
-	// ViewGroupByProfile retrieves a group that the specified profile is a member of.
-	ViewGroupByProfile(profileID, token string) (Group, error)
+	// GetGroupByProfile retrieves a group that the specified profile is a member of.
+	GetGroupByProfile(profileID, token string) (Group, error)
 
 	// CreateGroupMembers creates group members.
 	CreateGroupMembers(members []GroupMember, groupID, token string) error
@@ -288,14 +288,14 @@ type SDK interface {
 	// RemoveGroupMembers removes existing group members.
 	RemoveGroupMembers(ids []string, groupID, token string) error
 
-	// ListGroupMembers lists members that are specified for a certain group.
-	ListGroupMembers(groupID, token string, offset, limit uint64) (GroupMembersPage, error)
+	// GetGroupMembers lists members that are specified for a certain group.
+	GetGroupMembers(groupID string, pm PageMetadata, token string) (GroupMembersPage, error)
 
 	// CreateOrg registers new org.
 	CreateOrg(org Org, token string) error
 
-	// Org returns org data by id.
-	Org(id, token string) (Org, error)
+	// GetOrg returns org data by id.
+	GetOrg(id, token string) (Org, error)
 
 	// UpdateOrg updates existing org.
 	UpdateOrg(o Org, orgID, token string) error
@@ -303,11 +303,11 @@ type SDK interface {
 	// DeleteOrg removes existing org.
 	DeleteOrg(id, token string) error
 
-	// Orgs returns page of orgs.
-	Orgs(meta PageMetadata, token string) (OrgsPage, error)
+	// GetOrgs returns page of orgs.
+	GetOrgs(meta PageMetadata, token string) (OrgsPage, error)
 
-	// ViewMember retrieves a member belonging to the specified org.
-	ViewMember(memberID, orgID, token string) (Member, error)
+	// GetMember retrieves a member belonging to the specified org.
+	GetMember(memberID, orgID, token string) (Member, error)
 
 	// AssignMembers assigns a members to the specified org.
 	AssignMembers(om []OrgMember, orgID, token string) error
@@ -318,20 +318,20 @@ type SDK interface {
 	// UpdateMembers updates existing member.
 	UpdateMembers(members []OrgMember, orgID, token string) error
 
-	// ListMembersByOrg lists members who belong to a specified org.
-	ListMembersByOrg(orgID, token string, offset, limit uint64) (MembersPage, error)
+	// GetMembersByOrg lists members who belong to a specified org.
+	GetMembersByOrg(orgID string, meta PageMetadata, token string) (MembersPage, error)
 
 	// CreateWebhooks creates new webhooks.
 	CreateWebhooks(whs []Webhook, groupID, token string) ([]Webhook, error)
 
-	// ListWebhooksByGroup lists webhooks who belong to a specified group.
-	ListWebhooksByGroup(groupID, token string) (Webhooks, error)
+	// GetWebhooksByGroup lists webhooks who belong to a specified group.
+	GetWebhooksByGroup(groupID, token string) (Webhooks, error)
 
-	// ListWebhooksByThing lists webhooks who belong to a specified tthing.
-	ListWebhooksByThing(thingID, token string) (Webhooks, error)
+	// GetWebhooksByThing lists webhooks who belong to a specified tthing.
+	GetWebhooksByThing(thingID, token string) (Webhooks, error)
 
-	// Webhook returns webhook data by id.
-	Webhook(webhookID, token string) (Webhook, error)
+	// GetWebhook returns webhook data by id.
+	GetWebhook(webhookID, token string) (Webhook, error)
 
 	// UpdateWebhook updates existing webhook.
 	UpdateWebhook(wh Webhook, webhookID, token string) error
@@ -343,7 +343,7 @@ type SDK interface {
 	SendMessage(subtopic, msg, token string) error
 
 	// ReadMessages read messages.
-	ReadMessages(pm PageMetadata, isAdmin bool, token string) (map[string]interface{}, error)
+	ReadMessages(isAdmin bool, pm PageMetadata, token string) (map[string]interface{}, error)
 
 	// ValidateContentType sets message content type.
 	ValidateContentType(ct ContentType) error
@@ -361,13 +361,13 @@ type SDK interface {
 	RevokeCert(thingID, certID, token string) error
 
 	// Issue issues a new key, returning its token value alongside.
-	Issue(token string, duration time.Duration) (KeyRes, error)
+	Issue(duration time.Duration, token string) (KeyRes, error)
 
 	// Revoke removes the key with the provided ID that is issued by the user identified by the provided key.
-	Revoke(token, id string) error
+	Revoke(id, token string) error
 
 	// RetrieveKey retrieves data for the key identified by the provided ID, that is issued by the user identified by the provided key.
-	RetrieveKey(token, id string) (retrieveKeyRes, error)
+	RetrieveKey(id, token string) (retrieveKeyRes, error)
 }
 
 type mfSDK struct {

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -288,8 +288,8 @@ type SDK interface {
 	// RemoveGroupMembers removes existing group members.
 	RemoveGroupMembers(ids []string, groupID, token string) error
 
-	// GetGroupMembers lists members that are specified for a certain group.
-	GetGroupMembers(groupID string, pm PageMetadata, token string) (GroupMembersPage, error)
+	// ListGroupMembers lists members that are specified for a certain group.
+	ListGroupMembers(groupID string, pm PageMetadata, token string) (GroupMembersPage, error)
 
 	// CreateOrg registers new org.
 	CreateOrg(org Org, token string) error

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -177,8 +177,8 @@ type SDK interface {
 	// GetUser returns user object by id.
 	GetUser(id, token string) (User, error)
 
-	// GetUsers returns list of users.
-	GetUsers(pm PageMetadata, token string) (UsersPage, error)
+	// ListUsers returns list of users.
+	ListUsers(pm PageMetadata, token string) (UsersPage, error)
 
 	// CreateToken receives credentials and returns user token.
 	CreateToken(user User) (string, error)
@@ -198,11 +198,11 @@ type SDK interface {
 	// CreateThings registers new things and returns their ids.
 	CreateThings(things []Thing, groupID, token string) ([]Thing, error)
 
-	// GetThings returns page of things.
-	GetThings(pm PageMetadata, token string) (ThingsPage, error)
+	// ListThings returns page of things.
+	ListThings(pm PageMetadata, token string) (ThingsPage, error)
 
-	// GetThingsByProfile returns page of things assigned to the specified profile.
-	GetThingsByProfile(profileID string, pm PageMetadata, token string) (ThingsPage, error)
+	// ListThingsByProfile returns page of things assigned to the specified profile.
+	ListThingsByProfile(profileID string, pm PageMetadata, token string) (ThingsPage, error)
 
 	// GetThing returns thing object by id.
 	GetThing(id, token string) (Thing, error)
@@ -231,17 +231,17 @@ type SDK interface {
 	// DeleteGroups delete users groups.
 	DeleteGroups(ids []string, token string) error
 
-	// GetGroups returns page of groups.
-	GetGroups(meta PageMetadata, token string) (GroupsPage, error)
+	// ListGroups returns page of groups.
+	ListGroups(meta PageMetadata, token string) (GroupsPage, error)
 
-	// GetGroupsByOrg returns a page of all Groups belonging to the spcified Org.
-	GetGroupsByOrg(orgID string, meta PageMetadata, token string) (GroupsPage, error)
+	// ListGroupsByOrg returns a page of all Groups belonging to the spcified Org.
+	ListGroupsByOrg(orgID string, meta PageMetadata, token string) (GroupsPage, error)
 
 	// GetGroup returns users group object by id.
 	GetGroup(id, token string) (Group, error)
 
-	// GetThingsByGroup lists things that are members of specified group.
-	GetThingsByGroup(groupID string, meta PageMetadata, token string) (ThingsPage, error)
+	// ListThingsByGroup lists things that are members of specified group.
+	ListThingsByGroup(groupID string, meta PageMetadata, token string) (ThingsPage, error)
 
 	// GetGroupByThing retrieves a group that the specified thing is a member of.
 	GetGroupByThing(thingID, token string) (Group, error)
@@ -255,8 +255,8 @@ type SDK interface {
 	// CreateProfiles registers new profiles and returns their ids.
 	CreateProfiles(profiles []Profile, groupID, token string) ([]Profile, error)
 
-	// GetProfiles returns page of profiles.
-	GetProfiles(pm PageMetadata, token string) (ProfilesPage, error)
+	// ListProfiles returns page of profiles.
+	ListProfiles(pm PageMetadata, token string) (ProfilesPage, error)
 
 	// GetProfileByThing returns profile that are assigned to specified thing.
 	GetProfileByThing(thingID, token string) (Profile, error)
@@ -273,8 +273,8 @@ type SDK interface {
 	// DeleteProfiles removes existing profile.
 	DeleteProfiles(ids []string, token string) error
 
-	// GetProfilesByGroup lists profiles that are members of specified group.
-	GetProfilesByGroup(groupID string, pm PageMetadata, token string) (ProfilesPage, error)
+	// ListProfilesByGroup lists profiles that are members of specified group.
+	ListProfilesByGroup(groupID string, pm PageMetadata, token string) (ProfilesPage, error)
 
 	// GetGroupByProfile retrieves a group that the specified profile is a member of.
 	GetGroupByProfile(profileID, token string) (Group, error)
@@ -303,8 +303,8 @@ type SDK interface {
 	// DeleteOrg removes existing org.
 	DeleteOrg(id, token string) error
 
-	// GetOrgs returns page of orgs.
-	GetOrgs(meta PageMetadata, token string) (OrgsPage, error)
+	// ListOrgs returns page of orgs.
+	ListOrgs(meta PageMetadata, token string) (OrgsPage, error)
 
 	// GetMember retrieves a member belonging to the specified org.
 	GetMember(memberID, orgID, token string) (Member, error)
@@ -318,17 +318,17 @@ type SDK interface {
 	// UpdateMembers updates existing member.
 	UpdateMembers(members []OrgMember, orgID, token string) error
 
-	// GetMembersByOrg lists members who belong to a specified org.
-	GetMembersByOrg(orgID string, meta PageMetadata, token string) (MembersPage, error)
+	// ListMembersByOrg lists members who belong to a specified org.
+	ListMembersByOrg(orgID string, meta PageMetadata, token string) (MembersPage, error)
 
 	// CreateWebhooks creates new webhooks.
 	CreateWebhooks(whs []Webhook, groupID, token string) ([]Webhook, error)
 
-	// GetWebhooksByGroup lists webhooks who belong to a specified group.
-	GetWebhooksByGroup(groupID, token string) (Webhooks, error)
+	// ListWebhooksByGroup lists webhooks who belong to a specified group.
+	ListWebhooksByGroup(groupID, token string) (Webhooks, error)
 
-	// GetWebhooksByThing lists webhooks who belong to a specified tthing.
-	GetWebhooksByThing(thingID, token string) (Webhooks, error)
+	// ListWebhooksByThing lists webhooks who belong to a specified tthing.
+	ListWebhooksByThing(thingID, token string) (Webhooks, error)
 
 	// GetWebhook returns webhook data by id.
 	GetWebhook(webhookID, token string) (Webhook, error)

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -75,7 +75,7 @@ func (sdk mfSDK) CreateThings(things []Thing, groupID, token string) ([]Thing, e
 	return ctr.Things, nil
 }
 
-func (sdk mfSDK) GetThings(pm PageMetadata, token string) (ThingsPage, error) {
+func (sdk mfSDK) ListThings(pm PageMetadata, token string) (ThingsPage, error) {
 	url, err := sdk.withQueryParams(sdk.thingsURL, thingsEndpoint, pm)
 	if err != nil {
 		return ThingsPage{}, err
@@ -109,7 +109,7 @@ func (sdk mfSDK) GetThings(pm PageMetadata, token string) (ThingsPage, error) {
 	return tp, nil
 }
 
-func (sdk mfSDK) GetThingsByProfile(prID string, pm PageMetadata, token string) (ThingsPage, error) {
+func (sdk mfSDK) ListThingsByProfile(prID string, pm PageMetadata, token string) (ThingsPage, error) {
 	url := fmt.Sprintf("%s/profiles/%s/things?offset=%d&limit=%d&dir=%s", sdk.thingsURL, prID, pm.Offset, pm.Limit, pm.Dir)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -75,7 +75,7 @@ func (sdk mfSDK) CreateThings(things []Thing, groupID, token string) ([]Thing, e
 	return ctr.Things, nil
 }
 
-func (sdk mfSDK) Things(token string, pm PageMetadata) (ThingsPage, error) {
+func (sdk mfSDK) GetThings(pm PageMetadata, token string) (ThingsPage, error) {
 	url, err := sdk.withQueryParams(sdk.thingsURL, thingsEndpoint, pm)
 	if err != nil {
 		return ThingsPage{}, err
@@ -109,7 +109,7 @@ func (sdk mfSDK) Things(token string, pm PageMetadata) (ThingsPage, error) {
 	return tp, nil
 }
 
-func (sdk mfSDK) ThingsByProfile(prID, token string, pm PageMetadata) (ThingsPage, error) {
+func (sdk mfSDK) GetThingsByProfile(prID string, pm PageMetadata, token string) (ThingsPage, error) {
 	url := fmt.Sprintf("%s/profiles/%s/things?offset=%d&limit=%d&dir=%s", sdk.thingsURL, prID, pm.Offset, pm.Limit, pm.Dir)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -139,7 +139,7 @@ func (sdk mfSDK) ThingsByProfile(prID, token string, pm PageMetadata) (ThingsPag
 	return tp, nil
 }
 
-func (sdk mfSDK) Thing(id, token string) (Thing, error) {
+func (sdk mfSDK) GetThing(id, token string) (Thing, error) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.thingsURL, thingsEndpoint, id)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -170,7 +170,7 @@ func (sdk mfSDK) Thing(id, token string) (Thing, error) {
 	return t, nil
 }
 
-func (sdk mfSDK) MetadataByKey(thingKey string) (Metadata, error) {
+func (sdk mfSDK) GetThingMetadataByKey(thingKey string) (Metadata, error) {
 	url := fmt.Sprintf("%s/metadata", sdk.thingsURL)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -456,7 +456,7 @@ func TestThings(t *testing.T) {
 			Dir:      tc.dir,
 			Metadata: tc.metadata,
 		}
-		page, err := mainfluxSDK.GetThings(filter, tc.token)
+		page, err := mainfluxSDK.ListThings(filter, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Things, fmt.Sprintf("%s: expected response profile %s, got %s", tc.desc, tc.response, page.Things))
 	}
@@ -584,7 +584,7 @@ func TestThingsByProfile(t *testing.T) {
 			Limit:  tc.limit,
 			Dir:    tc.dir,
 		}
-		page, err := mainfluxSDK.GetThingsByProfile(tc.profile, filter, tc.token)
+		page, err := mainfluxSDK.ListThingsByProfile(tc.profile, filter, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Things, fmt.Sprintf("%s: expected response profile %s, got %s", tc.desc, tc.response, page.Things))
 	}

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -282,7 +282,7 @@ func TestThing(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		respTh, err := mainfluxSDK.Thing(tc.thID, tc.token)
+		respTh, err := mainfluxSDK.GetThing(tc.thID, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, respTh, fmt.Sprintf("%s: expected response thing %s, got %s", tc.desc, tc.response, respTh))
 	}
@@ -345,7 +345,7 @@ func TestMetadataByKey(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		resMeta, err := mainfluxSDK.MetadataByKey(tc.key)
+		resMeta, err := mainfluxSDK.GetThingMetadataByKey(tc.key)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, resMeta, fmt.Sprintf("%s: expected response thing %s, got %s", tc.desc, tc.response, resMeta))
 	}
@@ -456,7 +456,7 @@ func TestThings(t *testing.T) {
 			Dir:      tc.dir,
 			Metadata: tc.metadata,
 		}
-		page, err := mainfluxSDK.Things(tc.token, filter)
+		page, err := mainfluxSDK.GetThings(filter, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Things, fmt.Sprintf("%s: expected response profile %s, got %s", tc.desc, tc.response, page.Things))
 	}
@@ -584,7 +584,7 @@ func TestThingsByProfile(t *testing.T) {
 			Limit:  tc.limit,
 			Dir:    tc.dir,
 		}
-		page, err := mainfluxSDK.ThingsByProfile(tc.profile, tc.token, filter)
+		page, err := mainfluxSDK.GetThingsByProfile(tc.profile, filter, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Things, fmt.Sprintf("%s: expected response profile %s, got %s", tc.desc, tc.response, page.Things))
 	}
@@ -857,7 +857,7 @@ func TestIdentifyThing(t *testing.T) {
 	th.ProfileID = prID
 	id, err := mainfluxSDK.CreateThing(th, grID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
-	thing, err := mainfluxSDK.Thing(th.ID, token)
+	thing, err := mainfluxSDK.GetThing(th.ID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	cases := []struct {

--- a/pkg/sdk/go/users.go
+++ b/pkg/sdk/go/users.go
@@ -102,7 +102,7 @@ func (sdk mfSDK) GetUser(userID, token string) (User, error) {
 	return u, nil
 }
 
-func (sdk mfSDK) GetUsers(pm PageMetadata, token string) (UsersPage, error) {
+func (sdk mfSDK) ListUsers(pm PageMetadata, token string) (UsersPage, error) {
 	url, err := sdk.withQueryParams(sdk.usersURL, usersEndpoint, pm)
 	if err != nil {
 		return UsersPage{}, err

--- a/pkg/sdk/go/users.go
+++ b/pkg/sdk/go/users.go
@@ -22,7 +22,7 @@ const (
 	membersEndpoint      = "members"
 )
 
-func (sdk mfSDK) CreateUser(token string, u User) (string, error) {
+func (sdk mfSDK) CreateUser(u User, token string) (string, error) {
 	data, err := json.Marshal(u)
 	if err != nil {
 		return "", err
@@ -72,7 +72,7 @@ func (sdk mfSDK) RegisterUser(u User) (string, error) {
 	return id, nil
 }
 
-func (sdk mfSDK) User(userID, token string) (User, error) {
+func (sdk mfSDK) GetUser(userID, token string) (User, error) {
 	url := fmt.Sprintf("%s/%s", sdk.usersURL, usersEndpoint)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -102,7 +102,7 @@ func (sdk mfSDK) User(userID, token string) (User, error) {
 	return u, nil
 }
 
-func (sdk mfSDK) Users(token string, pm PageMetadata) (UsersPage, error) {
+func (sdk mfSDK) GetUsers(pm PageMetadata, token string) (UsersPage, error) {
 	url, err := sdk.withQueryParams(sdk.usersURL, usersEndpoint, pm)
 	if err != nil {
 		return UsersPage{}, err

--- a/pkg/sdk/go/webhooks.go
+++ b/pkg/sdk/go/webhooks.go
@@ -47,7 +47,7 @@ func (sdk mfSDK) CreateWebhooks(whs []Webhook, thingID, token string) ([]Webhook
 	return ws.Webhooks, nil
 }
 
-func (sdk mfSDK) GetWebhooksByGroup(groupID, token string) (Webhooks, error) {
+func (sdk mfSDK) ListWebhooksByGroup(groupID, token string) (Webhooks, error) {
 	url := fmt.Sprintf("%s/groups/%s/%s", sdk.webhooksURL, groupID, webhooksEndpoint)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -77,7 +77,7 @@ func (sdk mfSDK) GetWebhooksByGroup(groupID, token string) (Webhooks, error) {
 	return ws, nil
 }
 
-func (sdk mfSDK) GetWebhooksByThing(thingID, token string) (Webhooks, error) {
+func (sdk mfSDK) ListWebhooksByThing(thingID, token string) (Webhooks, error) {
 	url := fmt.Sprintf("%s/things/%s/%s", sdk.webhooksURL, thingID, webhooksEndpoint)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/sdk/go/webhooks.go
+++ b/pkg/sdk/go/webhooks.go
@@ -47,7 +47,7 @@ func (sdk mfSDK) CreateWebhooks(whs []Webhook, thingID, token string) ([]Webhook
 	return ws.Webhooks, nil
 }
 
-func (sdk mfSDK) ListWebhooksByGroup(groupID, token string) (Webhooks, error) {
+func (sdk mfSDK) GetWebhooksByGroup(groupID, token string) (Webhooks, error) {
 	url := fmt.Sprintf("%s/groups/%s/%s", sdk.webhooksURL, groupID, webhooksEndpoint)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -77,7 +77,7 @@ func (sdk mfSDK) ListWebhooksByGroup(groupID, token string) (Webhooks, error) {
 	return ws, nil
 }
 
-func (sdk mfSDK) ListWebhooksByThing(thingID, token string) (Webhooks, error) {
+func (sdk mfSDK) GetWebhooksByThing(thingID, token string) (Webhooks, error) {
 	url := fmt.Sprintf("%s/things/%s/%s", sdk.webhooksURL, thingID, webhooksEndpoint)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -107,7 +107,7 @@ func (sdk mfSDK) ListWebhooksByThing(thingID, token string) (Webhooks, error) {
 	return ws, nil
 }
 
-func (sdk mfSDK) Webhook(webhookID, token string) (Webhook, error) {
+func (sdk mfSDK) GetWebhook(webhookID, token string) (Webhook, error) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.webhooksURL, webhooksEndpoint, webhookID)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/tools/provision/provision.go
+++ b/tools/provision/provision.go
@@ -83,7 +83,7 @@ func Provision(conf Config) {
 	}
 
 	// Create new user
-	if _, err := s.CreateUser("", user); err != nil {
+	if _, err := s.CreateUser(user, ""); err != nil {
 		log.Fatalf("Unable to create new user: %s", err.Error())
 		return
 


### PR DESCRIPTION
This PR standardizes SDK method names, their arguments and argument orders:

- Methods that *retrieve* a single resource now always begin with a `Get` prefix
    - Example: `GetThing()`
- Methods that *retrieve* multiple resources now always begin with a `List` prefix
    - Example: `ListThings()`
- In general methods now begin with a verb describing the operation (i.e. `Create`, `Update`, `Delete`, etc..), followed by the resource name
- Methods that accept an authentication `token` now always receive it as the last argument
- Methods that accept pagination metadata now always do so via the use of a `PageMetadata` type, that comes as the second-to-last argument (before the above mentioned token)

Resolves #674 