### PR TITLE
MF-670 - Improve API response when attempting to remove Profile assigned to at least one Thing

### DIFF
--- a/things/api/http/profiles/transport.go
+++ b/things/api/http/profiles/transport.go
@@ -244,6 +244,8 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)
+	case err == things.ErrProfileInUse:
+		w.WriteHeader(http.StatusConflict)
 	default:
 		apiutil.EncodeError(err, w)
 	}

--- a/things/api/http/profiles/transport.go
+++ b/things/api/http/profiles/transport.go
@@ -244,7 +244,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)
-	case errors.Contains(err, things.ErrProfileInUse):
+	case errors.Contains(err, things.ErrProfileAssigned):
 		w.WriteHeader(http.StatusConflict)
 	default:
 		apiutil.EncodeError(err, w)

--- a/things/api/http/profiles/transport.go
+++ b/things/api/http/profiles/transport.go
@@ -244,7 +244,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)
-	case err == things.ErrProfileInUse:
+	case errors.Contains(err, things.ErrProfileInUse):
 		w.WriteHeader(http.StatusConflict)
 	default:
 		apiutil.EncodeError(err, w)

--- a/things/postgres/profiles.go
+++ b/things/postgres/profiles.go
@@ -203,7 +203,7 @@ func (cr profileRepository) Remove(ctx context.Context, ids ...string) error {
 		if err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {
-				if pgErr.Code == pgerrcode.ForeignKeyViolation && pgErr.ConstraintName == "fk_things_profile_id" {
+				if pgErr.Code == pgerrcode.ForeignKeyViolation {
 					return errors.Wrap(things.ErrProfileAssigned, err)
 				}
 			}

--- a/things/postgres/profiles.go
+++ b/things/postgres/profiles.go
@@ -201,6 +201,13 @@ func (cr profileRepository) Remove(ctx context.Context, ids ...string) error {
 		q := `DELETE FROM profiles WHERE id = :id`
 		_, err := cr.db.NamedExecContext(ctx, q, dbpr)
 		if err != nil {
+			pgErr, ok := err.(*pgconn.PgError)
+			if ok {
+				if pgErr.Code == pgerrcode.ForeignKeyViolation && pgErr.ConstraintName == "fk_things_profile_id" {
+					return errors.Wrap(things.ErrProfileInUse, err)
+				}
+			}
+
 			return errors.Wrap(errors.ErrRemoveEntity, err)
 		}
 	}

--- a/things/postgres/profiles.go
+++ b/things/postgres/profiles.go
@@ -204,7 +204,7 @@ func (cr profileRepository) Remove(ctx context.Context, ids ...string) error {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {
 				if pgErr.Code == pgerrcode.ForeignKeyViolation && pgErr.ConstraintName == "fk_things_profile_id" {
-					return errors.Wrap(things.ErrProfileInUse, err)
+					return errors.Wrap(things.ErrProfileAssigned, err)
 				}
 			}
 

--- a/things/postgres/profiles_test.go
+++ b/things/postgres/profiles_test.go
@@ -430,7 +430,7 @@ func TestRemoveProfile(t *testing.T) {
 		},
 		"remove assigned profile": {
 			prID: prID2,
-			err:  things.ErrProfileInUse,
+			err:  things.ErrProfileAssigned,
 		},
 	}
 

--- a/things/postgres/profiles_test.go
+++ b/things/postgres/profiles_test.go
@@ -430,7 +430,7 @@ func TestRemoveProfile(t *testing.T) {
 		},
 		"remove assigned profile": {
 			prID: prID2,
-			err:  errors.ErrRemoveEntity,
+			err:  things.ErrProfileInUse,
 		},
 	}
 

--- a/things/service.go
+++ b/things/service.go
@@ -583,18 +583,6 @@ func (ts *thingsService) RemoveProfiles(ctx context.Context, token string, ids .
 			return err
 		}
 
-		// Check whether Profile is currently tied to at least one Thing
-		thingsWithProfile, err := ts.things.RetrieveByProfile(ctx, id, apiutil.PageMetadata{Offset: 0, Limit: 1, Dir: "id"})
-
-		if err != nil {
-			return err
-		}
-
-		// Profile currently assigned to at least one thing
-		if thingsWithProfile.Total != 0 {
-			return ErrProfileInUse
-		}
-
 		if err := ts.profileCache.RemoveGroup(ctx, id); err != nil {
 			return err
 		}

--- a/things/service.go
+++ b/things/service.go
@@ -21,6 +21,10 @@ const (
 	Owner  = "owner"
 )
 
+var (
+	ErrProfileInUse = errors.New("profile currently assigned to thing(s)")
+)
+
 // Service specifies an API that must be fullfiled by the domain service
 // implementation, and all of its decorators (e.g. logging & metrics).
 type Service interface {
@@ -574,8 +578,21 @@ func (ts *thingsService) RemoveProfiles(ctx context.Context, token string, ids .
 			ID:     id,
 			Action: Editor,
 		}
+
 		if err := ts.CanUserAccessProfile(ctx, ar); err != nil {
 			return err
+		}
+
+		// Check whether Profile is currently tied to at least one Thing
+		thingsWithProfile, err := ts.things.RetrieveByProfile(ctx, id, apiutil.PageMetadata{Offset: 0, Limit: 1, Dir: "id"})
+
+		if err != nil {
+			return err
+		}
+
+		// Profile currently assigned to at least one thing
+		if thingsWithProfile.Total != 0 {
+			return ErrProfileInUse
 		}
 
 		if err := ts.profileCache.RemoveGroup(ctx, id); err != nil {

--- a/things/service.go
+++ b/things/service.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	ErrProfileInUse = errors.New("profile currently assigned to thing(s)")
+	ErrProfileAssigned = errors.New("profile currently assigned to thing(s)")
 )
 
 // Service specifies an API that must be fullfiled by the domain service


### PR DESCRIPTION
This PR resolves #670:

- `profileRepository.Remove()` now checks for a foreign key validation error after attempting to remove the profile(s), returning a `things.ErrProfileInUse` as appropriate
- The API endpoint for removing profiles (`DELETE /profiles/:id`) now responds in a more descriptive, user-friendly manner by:
    - Returning `409 Conflict` as the HTTP status code
    - The following JSON error in the body:
    ```
    {"error":"profile currently assigned to thing(s)"}
    ```

Questions:

* Is `409 Conflict` an appropriate status code to respond with in a case such as this one?