### PR TITLE
MF-688 - Fix CLI 'provision test' subcommand

### DIFF
--- a/cli/orgs.go
+++ b/cli/orgs.go
@@ -30,7 +30,7 @@ var cmdOrgs = []cobra.Command{
 				return
 			}
 
-			err := sdk.CreateOrg(org, args[1])
+			_, err := sdk.CreateOrg(org, args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/provision.go
+++ b/cli/provision.go
@@ -135,7 +135,7 @@ var cmdProvision = []cobra.Command{
 
 			// Create profiles
 			for i := 0; i < numProfs; i++ {
-				n := fmt.Sprintf("c%d", i)
+				n := fmt.Sprintf("p%d", i)
 
 				c := mfxsdk.Profile{
 					Name:    n,

--- a/cli/provision.go
+++ b/cli/provision.go
@@ -111,7 +111,7 @@ var cmdProvision = []cobra.Command{
 			}
 
 			// Create test Organization
-			orgId, err := sdk.CreateOrg(mfxsdk.Org{Name: namesgenerator.GetRandomName(0)}, ut)
+			orgID, err := sdk.CreateOrg(mfxsdk.Org{Name: namesgenerator.GetRandomName(0)}, ut)
 			if err != nil {
 				logError(err)
 				return
@@ -121,7 +121,7 @@ var cmdProvision = []cobra.Command{
 				Name: "gr",
 			}
 
-			grID, err := sdk.CreateGroup(g, orgId, ut)
+			grID, err := sdk.CreateGroup(g, orgID, ut)
 			if err != nil {
 				logError(err)
 				return

--- a/pkg/sdk/go/orgs.go
+++ b/pkg/sdk/go/orgs.go
@@ -11,36 +11,37 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 )
 
 const orgsEndpoint = "orgs"
 
-func (sdk mfSDK) CreateOrg(o Org, token string) error {
+func (sdk mfSDK) CreateOrg(o Org, token string) (string, error) {
 	data, err := json.Marshal(o)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	url := fmt.Sprintf("%s/%s", sdk.authURL, orgsEndpoint)
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	resp, err := sdk.sendRequest(req, token, string(CTJSON))
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return errors.Wrap(ErrFailedCreation, errors.New(resp.Status))
+		return "", errors.Wrap(ErrFailedCreation, errors.New(resp.Status))
 	}
 
-	return nil
+	return strings.TrimPrefix(resp.Header.Get("Location"), fmt.Sprintf("/%s/", orgsEndpoint)), nil
 }
 
 func (sdk mfSDK) Org(id, token string) (Org, error) {

--- a/pkg/sdk/go/orgs.go
+++ b/pkg/sdk/go/orgs.go
@@ -41,7 +41,8 @@ func (sdk mfSDK) CreateOrg(o Org, token string) (string, error) {
 		return "", errors.Wrap(ErrFailedCreation, errors.New(resp.Status))
 	}
 
-	return strings.TrimPrefix(resp.Header.Get("Location"), fmt.Sprintf("/%s/", orgsEndpoint)), nil
+	id := strings.TrimPrefix(resp.Header.Get("Location"), fmt.Sprintf("/%s/", orgsEndpoint))
+	return id, nil
 }
 
 func (sdk mfSDK) Org(id, token string) (Org, error) {

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -291,8 +291,8 @@ type SDK interface {
 	// ListGroupMembers lists members that are specified for a certain group.
 	ListGroupMembers(groupID, token string, offset, limit uint64) (GroupMembersPage, error)
 
-	// CreateOrg registers new org.
-	CreateOrg(org Org, token string) error
+	// CreateOrg registers a new Org and returns its ID.
+	CreateOrg(org Org, token string) (string, error)
 
 	// Org returns org data by id.
 	Org(id, token string) (Org, error)


### PR DESCRIPTION
This PR closes #688 by first provisioning a new Org before other resources: Groups, Profiles, and Things.

It also enhances the `SDK.CreateOrg()` method to return the ID of the newly created Org.