### PR TITLE
NOISSUE - Rename save message error type for consistancy 

### DIFF
--- a/consumers/writers/mongodb/consumer.go
+++ b/consumers/writers/mongodb/consumer.go
@@ -54,7 +54,7 @@ func (repo *mongoRepo) saveSenML(msgs []protomfx.Message) error {
 	for _, msg := range msgs {
 		mapped, err := messaging.ToSenMLMessage(msg)
 		if err != nil {
-			return errors.Wrap(errors.ErrSaveMessage, err)
+			return errors.Wrap(errors.ErrSaveMessages, err)
 		}
 
 		dbMsgs = append(dbMsgs, mapped)
@@ -62,7 +62,7 @@ func (repo *mongoRepo) saveSenML(msgs []protomfx.Message) error {
 
 	_, err := coll.InsertMany(context.Background(), dbMsgs)
 	if err != nil {
-		return errors.Wrap(errors.ErrSaveMessage, err)
+		return errors.Wrap(errors.ErrSaveMessages, err)
 	}
 
 	return nil
@@ -79,7 +79,7 @@ func (repo *mongoRepo) saveJSON(msgs []protomfx.Message) error {
 
 	_, err := coll.InsertMany(context.Background(), m)
 	if err != nil {
-		return errors.Wrap(errors.ErrSaveMessage, err)
+		return errors.Wrap(errors.ErrSaveMessages, err)
 	}
 
 	return nil

--- a/consumers/writers/postgres/consumer.go
+++ b/consumers/writers/postgres/consumer.go
@@ -59,7 +59,7 @@ func (pr postgresRepo) saveSenML(msgs []protomfx.Message) (err error) {
 
 	tx, err := pr.db.BeginTxx(context.Background(), nil)
 	if err != nil {
-		return errors.Wrap(errors.ErrSaveMessage, err)
+		return errors.Wrap(errors.ErrSaveMessages, err)
 	}
 	defer func() {
 		if err != nil {
@@ -70,14 +70,14 @@ func (pr postgresRepo) saveSenML(msgs []protomfx.Message) (err error) {
 		}
 
 		if err = tx.Commit(); err != nil {
-			err = errors.Wrap(errors.ErrSaveMessage, err)
+			err = errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}()
 
 	for _, msg := range msgs {
 		dbmsg, err := messaging.ToSenMLMessage(msg)
 		if err != nil {
-			return errors.Wrap(errors.ErrSaveMessage, err)
+			return errors.Wrap(errors.ErrSaveMessages, err)
 		}
 
 		if _, err := tx.NamedExec(q, dbmsg); err != nil {
@@ -85,11 +85,11 @@ func (pr postgresRepo) saveSenML(msgs []protomfx.Message) (err error) {
 			if ok {
 				switch pgErr.Code {
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrSaveMessage, errInvalidMessage)
+					return errors.Wrap(errors.ErrSaveMessages, errInvalidMessage)
 				}
 			}
 
-			return errors.Wrap(errors.ErrSaveMessage, err)
+			return errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}
 
@@ -102,7 +102,7 @@ func (pr postgresRepo) saveJSON(msgs []protomfx.Message) error {
 
 	tx, err := pr.db.BeginTxx(context.Background(), nil)
 	if err != nil {
-		return errors.Wrap(errors.ErrSaveMessage, err)
+		return errors.Wrap(errors.ErrSaveMessages, err)
 	}
 	defer func() {
 		if err != nil {
@@ -113,7 +113,7 @@ func (pr postgresRepo) saveJSON(msgs []protomfx.Message) error {
 		}
 
 		if err = tx.Commit(); err != nil {
-			err = errors.Wrap(errors.ErrSaveMessage, err)
+			err = errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}()
 
@@ -125,11 +125,11 @@ func (pr postgresRepo) saveJSON(msgs []protomfx.Message) error {
 			if ok {
 				switch pgErr.Code {
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrSaveMessage, errInvalidMessage)
+					return errors.Wrap(errors.ErrSaveMessages, errInvalidMessage)
 				}
 			}
 
-			return errors.Wrap(errors.ErrSaveMessage, err)
+			return errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}
 

--- a/consumers/writers/timescale/consumer.go
+++ b/consumers/writers/timescale/consumer.go
@@ -59,7 +59,7 @@ func (tr timescaleRepo) saveSenML(msgs []protomfx.Message) (err error) {
 
 	tx, err := tr.db.BeginTxx(context.Background(), nil)
 	if err != nil {
-		return errors.Wrap(errors.ErrSaveMessage, err)
+		return errors.Wrap(errors.ErrSaveMessages, err)
 	}
 	defer func() {
 		if err != nil {
@@ -70,14 +70,14 @@ func (tr timescaleRepo) saveSenML(msgs []protomfx.Message) (err error) {
 		}
 
 		if err = tx.Commit(); err != nil {
-			err = errors.Wrap(errors.ErrSaveMessage, err)
+			err = errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}()
 
 	for _, msg := range msgs {
 		dbmsg, err := messaging.ToSenMLMessage(msg)
 		if err != nil {
-			return errors.Wrap(errors.ErrSaveMessage, err)
+			return errors.Wrap(errors.ErrSaveMessages, err)
 		}
 
 		if _, err := tx.NamedExec(q, dbmsg); err != nil {
@@ -85,11 +85,11 @@ func (tr timescaleRepo) saveSenML(msgs []protomfx.Message) (err error) {
 			if ok {
 				switch pgErr.Code {
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrSaveMessage, errInvalidMessage)
+					return errors.Wrap(errors.ErrSaveMessages, errInvalidMessage)
 				}
 			}
 
-			return errors.Wrap(errors.ErrSaveMessage, err)
+			return errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}
 
@@ -102,7 +102,7 @@ func (tr timescaleRepo) saveJSON(msgs []protomfx.Message) error {
 
 	tx, err := tr.db.BeginTxx(context.Background(), nil)
 	if err != nil {
-		return errors.Wrap(errors.ErrSaveMessage, err)
+		return errors.Wrap(errors.ErrSaveMessages, err)
 	}
 	defer func() {
 		if err != nil {
@@ -113,7 +113,7 @@ func (tr timescaleRepo) saveJSON(msgs []protomfx.Message) error {
 		}
 
 		if err = tx.Commit(); err != nil {
-			err = errors.Wrap(errors.ErrSaveMessage, err)
+			err = errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}()
 
@@ -125,11 +125,11 @@ func (tr timescaleRepo) saveJSON(msgs []protomfx.Message) error {
 			if ok {
 				switch pgErr.Code {
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrSaveMessage, errInvalidMessage)
+					return errors.Wrap(errors.ErrSaveMessages, errInvalidMessage)
 				}
 			}
 
-			return errors.Wrap(errors.ErrSaveMessage, err)
+			return errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}
 

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -34,8 +34,8 @@ var (
 	// ErrScanMetadata indicates problem with metadata in db.
 	ErrScanMetadata = New("failed to scan metadata in db")
 
-	// ErrSaveMessage indicates failure occurred while saving message to database.
-	ErrSaveMessage = New("failed to save message to database")
+	// ErrSaveMessages indicates failure occurred while saving messages to database.
+	ErrSaveMessages = New("failed to save messages to database")
 
 	// ErrMessage indicates an error converting a message to Mainflux message.
 	ErrMessage = New("failed to convert to Mainflux message")

--- a/readers/mongodb/messages.go
+++ b/readers/mongodb/messages.go
@@ -53,7 +53,7 @@ func (repo mongoRepository) Restore(ctx context.Context, messages ...senml.Messa
 
 	_, err := coll.InsertMany(context.Background(), dbMsgs)
 	if err != nil {
-		return errors.Wrap(errors.ErrSaveMessage, err)
+		return errors.Wrap(errors.ErrSaveMessages, err)
 	}
 
 	return nil

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -57,7 +57,7 @@ func (tr postgresRepository) Restore(ctx context.Context, messages ...senml.Mess
 
 	tx, err := tr.db.BeginTxx(context.Background(), nil)
 	if err != nil {
-		return errors.Wrap(errors.ErrSaveMessage, err)
+		return errors.Wrap(errors.ErrSaveMessages, err)
 	}
 
 	defer func() {
@@ -69,7 +69,7 @@ func (tr postgresRepository) Restore(ctx context.Context, messages ...senml.Mess
 		}
 
 		if err = tx.Commit(); err != nil {
-			err = errors.Wrap(errors.ErrSaveMessage, err)
+			err = errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}()
 
@@ -78,9 +78,9 @@ func (tr postgresRepository) Restore(ctx context.Context, messages ...senml.Mess
 		if _, err := tx.NamedExec(q, m); err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok && pgErr.Code == pgerrcode.InvalidTextRepresentation {
-				return errors.Wrap(errors.ErrSaveMessage, errInvalidMessage)
+				return errors.Wrap(errors.ErrSaveMessages, errInvalidMessage)
 			}
-			return errors.Wrap(errors.ErrSaveMessage, err)
+			return errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}
 

--- a/readers/timescale/messages.go
+++ b/readers/timescale/messages.go
@@ -59,7 +59,7 @@ func (tr timescaleRepository) Restore(ctx context.Context, messages ...senml.Mes
 
 	tx, err := tr.db.BeginTxx(context.Background(), nil)
 	if err != nil {
-		return errors.Wrap(errors.ErrSaveMessage, err)
+		return errors.Wrap(errors.ErrSaveMessages, err)
 	}
 
 	defer func() {
@@ -71,7 +71,7 @@ func (tr timescaleRepository) Restore(ctx context.Context, messages ...senml.Mes
 		}
 
 		if err = tx.Commit(); err != nil {
-			err = errors.Wrap(errors.ErrSaveMessage, err)
+			err = errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}()
 
@@ -82,11 +82,11 @@ func (tr timescaleRepository) Restore(ctx context.Context, messages ...senml.Mes
 			if ok {
 				switch pgErr.Code {
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrSaveMessage, errInvalidMessage)
+					return errors.Wrap(errors.ErrSaveMessages, errInvalidMessage)
 				}
 			}
 
-			return errors.Wrap(errors.ErrSaveMessage, err)
+			return errors.Wrap(errors.ErrSaveMessages, err)
 		}
 	}
 


### PR DESCRIPTION
This PR renames `ErrSaveMessage` to `ErrSaveMessages` for consistency with the existing naming conventions in the codebase, as referenced in #653