### PR TITLE
MF-661 - Update HTTP API endpoint for creating Things to not require a Group ID

### DIFF
--- a/cli/provision.go
+++ b/cli/provision.go
@@ -24,7 +24,7 @@ const csvExt = ".csv"
 
 var cmdProvision = []cobra.Command{
 	{
-		Use:   "things <things_file> <group_id> <user_token>",
+		Use:   "things <things_file> <user_token>",
 		Short: "Provision things",
 		Long:  `Bulk create things`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -44,7 +44,7 @@ var cmdProvision = []cobra.Command{
 				return
 			}
 
-			things, err = sdk.CreateThings(things, args[1], args[2])
+			things, err = sdk.CreateThings(things, args[1])
 			if err != nil {
 				logError(err)
 				return
@@ -162,7 +162,7 @@ var cmdProvision = []cobra.Command{
 
 				things = append(things, t)
 			}
-			things, err = sdk.CreateThings(things, grID, ut)
+			things, err = sdk.CreateThings(things, ut)
 			if err != nil {
 				logError(err)
 				return

--- a/cli/provision.go
+++ b/cli/provision.go
@@ -24,11 +24,11 @@ const csvExt = ".csv"
 
 var cmdProvision = []cobra.Command{
 	{
-		Use:   "things <things_file> <user_token>",
+		Use:   "things <things_file> <profile_id> <user_token>",
 		Short: "Provision things",
 		Long:  `Bulk create things`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 2 {
+			if len(args) != 3 {
 				logUsage(cmd.Use)
 				return
 			}
@@ -44,7 +44,7 @@ var cmdProvision = []cobra.Command{
 				return
 			}
 
-			things, err = sdk.CreateThings(things, args[1])
+			things, err = sdk.CreateThings(things, args[1], args[2])
 			if err != nil {
 				logError(err)
 				return
@@ -155,14 +155,12 @@ var cmdProvision = []cobra.Command{
 				n := fmt.Sprintf("d%d", i)
 
 				t := mfxsdk.Thing{
-					Name:      n,
-					GroupID:   grID,
-					ProfileID: profiles[0].ID,
+					Name: n,
 				}
 
 				things = append(things, t)
 			}
-			things, err = sdk.CreateThings(things, ut)
+			things, err = sdk.CreateThings(things, profiles[0].ID, ut)
 			if err != nil {
 				logError(err)
 				return

--- a/cli/things.go
+++ b/cli/things.go
@@ -27,7 +27,7 @@ var cmdThings = []cobra.Command{
 				return
 			}
 
-			id, err := sdk.CreateThing(thing, args[1], args[1])
+			id, err := sdk.CreateThing(thing, args[1], args[2])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/things.go
+++ b/cli/things.go
@@ -12,11 +12,11 @@ import (
 
 var cmdThings = []cobra.Command{
 	{
-		Use:   "create <JSON_thing> <user_token>",
+		Use:   "create <JSON_thing> <profile_id> <user_token>",
 		Short: "Create thing",
 		Long:  `Create new thing, generate its UUID and store it`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 2 {
+			if len(args) != 3 {
 				logUsage(cmd.Use)
 				return
 			}
@@ -27,7 +27,7 @@ var cmdThings = []cobra.Command{
 				return
 			}
 
-			id, err := sdk.CreateThing(thing, thing.ProfileID, args[1])
+			id, err := sdk.CreateThing(thing, args[1], args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/things.go
+++ b/cli/things.go
@@ -12,11 +12,11 @@ import (
 
 var cmdThings = []cobra.Command{
 	{
-		Use:   "create <JSON_thing> <group_id> <user_token>",
+		Use:   "create <JSON_thing> <user_token>",
 		Short: "Create thing",
-		Long:  `Create new thing, generate his UUID and store it`,
+		Long:  `Create new thing, generate its UUID and store it`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 3 {
+			if len(args) != 2 {
 				logUsage(cmd.Use)
 				return
 			}
@@ -27,7 +27,7 @@ var cmdThings = []cobra.Command{
 				return
 			}
 
-			id, err := sdk.CreateThing(thing, args[1], args[2])
+			id, err := sdk.CreateThing(thing, args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/cli/things.go
+++ b/cli/things.go
@@ -27,7 +27,7 @@ var cmdThings = []cobra.Command{
 				return
 			}
 
-			id, err := sdk.CreateThing(thing, args[1])
+			id, err := sdk.CreateThing(thing, thing.ProfileID, args[1])
 			if err != nil {
 				logError(err)
 				return

--- a/pkg/sdk/go/profiles_test.go
+++ b/pkg/sdk/go/profiles_test.go
@@ -352,7 +352,7 @@ func TestViewProfileByThing(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	th := sdk.Thing{Name: name, ProfileID: pid}
-	tid, err := mainfluxSDK.CreateThing(th, token)
+	tid, err := mainfluxSDK.CreateThing(th, pid, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	resProfile := sdk.Profile{

--- a/pkg/sdk/go/profiles_test.go
+++ b/pkg/sdk/go/profiles_test.go
@@ -352,7 +352,7 @@ func TestViewProfileByThing(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	th := sdk.Thing{Name: name, ProfileID: pid}
-	tid, err := mainfluxSDK.CreateThing(th, grID, token)
+	tid, err := mainfluxSDK.CreateThing(th, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	resProfile := sdk.Profile{

--- a/pkg/sdk/go/profiles_test.go
+++ b/pkg/sdk/go/profiles_test.go
@@ -348,15 +348,15 @@ func TestViewProfileByThing(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	pr := sdk.Profile{Name: name}
-	pid, err := mainfluxSDK.CreateProfile(pr, grID, token)
+	prID, err := mainfluxSDK.CreateProfile(pr, grID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
-	th := sdk.Thing{Name: name, ProfileID: pid}
-	tid, err := mainfluxSDK.CreateThing(th, pid, token)
+	th := sdk.Thing{Name: name, ProfileID: prID}
+	thID, err := mainfluxSDK.CreateThing(th, prID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	resProfile := sdk.Profile{
-		ID:      pid,
+		ID:      prID,
 		GroupID: grID,
 		Name:    name,
 	}
@@ -370,21 +370,21 @@ func TestViewProfileByThing(t *testing.T) {
 	}{
 		{
 			desc:     "view profile by thing",
-			thing:    tid,
+			thing:    thID,
 			token:    token,
 			err:      nil,
 			response: resProfile,
 		},
 		{
 			desc:     "view profile by thing with invalid token",
-			thing:    tid,
+			thing:    thID,
 			token:    wrongValue,
 			err:      createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response: sdk.Profile{},
 		},
 		{
 			desc:     "view profile by thing with empty token",
-			thing:    tid,
+			thing:    thID,
 			token:    emptyValue,
 			err:      createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response: sdk.Profile{},

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -193,10 +193,10 @@ type SDK interface {
 	UpdatePassword(oldPass, newPass, token string) error
 
 	// CreateThing registers new thing and returns its id.
-	CreateThing(thing Thing, profileId, token string) (string, error)
+	CreateThing(thing Thing, profileID, token string) (string, error)
 
 	// CreateThings registers new things and returns their ids.
-	CreateThings(things []Thing, profileId, token string) ([]Thing, error)
+	CreateThings(things []Thing, profileID, token string) ([]Thing, error)
 
 	// Things returns page of things.
 	Things(token string, pm PageMetadata) (ThingsPage, error)

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -193,10 +193,10 @@ type SDK interface {
 	UpdatePassword(oldPass, newPass, token string) error
 
 	// CreateThing registers new thing and returns its id.
-	CreateThing(thing Thing, groupID, token string) (string, error)
+	CreateThing(thing Thing, token string) (string, error)
 
 	// CreateThings registers new things and returns their ids.
-	CreateThings(things []Thing, groupID, token string) ([]Thing, error)
+	CreateThings(things []Thing, token string) ([]Thing, error)
 
 	// Things returns page of things.
 	Things(token string, pm PageMetadata) (ThingsPage, error)

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -193,10 +193,10 @@ type SDK interface {
 	UpdatePassword(oldPass, newPass, token string) error
 
 	// CreateThing registers new thing and returns its id.
-	CreateThing(thing Thing, token string) (string, error)
+	CreateThing(thing Thing, profileId, token string) (string, error)
 
 	// CreateThings registers new things and returns their ids.
-	CreateThings(things []Thing, token string) ([]Thing, error)
+	CreateThings(things []Thing, profileId, token string) ([]Thing, error)
 
 	// Things returns page of things.
 	Things(token string, pm PageMetadata) (ThingsPage, error)

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -26,8 +26,8 @@ type identifyThingResp struct {
 	ID string `json:"id,omitempty"`
 }
 
-func (sdk mfSDK) CreateThing(t Thing, profileId, token string) (string, error) {
-	things, err := sdk.CreateThings([]Thing{t}, profileId, token)
+func (sdk mfSDK) CreateThing(t Thing, profileID, token string) (string, error) {
+	things, err := sdk.CreateThings([]Thing{t}, profileID, token)
 	if err != nil {
 		return "", err
 	}
@@ -39,13 +39,13 @@ func (sdk mfSDK) CreateThing(t Thing, profileId, token string) (string, error) {
 	return things[0].ID, nil
 }
 
-func (sdk mfSDK) CreateThings(things []Thing, profileId, token string) ([]Thing, error) {
+func (sdk mfSDK) CreateThings(things []Thing, profileID, token string) ([]Thing, error) {
 	data, err := json.Marshal(things)
 	if err != nil {
 		return []Thing{}, err
 	}
 
-	url := fmt.Sprintf("%s/%s/%s/things", sdk.thingsURL, profilesEndpoint, profileId)
+	url := fmt.Sprintf("%s/%s/%s/things", sdk.thingsURL, profilesEndpoint, profileID)
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -45,7 +45,7 @@ func (sdk mfSDK) CreateThings(things []Thing, groupID, token string) ([]Thing, e
 		return []Thing{}, err
 	}
 
-	url := fmt.Sprintf("%s/groups/%s/%s", sdk.thingsURL, groupID, thingsEndpoint)
+	url := fmt.Sprintf("%s/%s", sdk.thingsURL, thingsEndpoint)
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -26,8 +26,8 @@ type identifyThingResp struct {
 	ID string `json:"id,omitempty"`
 }
 
-func (sdk mfSDK) CreateThing(t Thing, groupID, token string) (string, error) {
-	things, err := sdk.CreateThings([]Thing{t}, groupID, token)
+func (sdk mfSDK) CreateThing(t Thing, token string) (string, error) {
+	things, err := sdk.CreateThings([]Thing{t}, token)
 	if err != nil {
 		return "", err
 	}
@@ -39,7 +39,7 @@ func (sdk mfSDK) CreateThing(t Thing, groupID, token string) (string, error) {
 	return things[0].ID, nil
 }
 
-func (sdk mfSDK) CreateThings(things []Thing, groupID, token string) ([]Thing, error) {
+func (sdk mfSDK) CreateThings(things []Thing, token string) ([]Thing, error) {
 	data, err := json.Marshal(things)
 	if err != nil {
 		return []Thing{}, err

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -26,8 +26,8 @@ type identifyThingResp struct {
 	ID string `json:"id,omitempty"`
 }
 
-func (sdk mfSDK) CreateThing(t Thing, token string) (string, error) {
-	things, err := sdk.CreateThings([]Thing{t}, token)
+func (sdk mfSDK) CreateThing(t Thing, profileId, token string) (string, error) {
+	things, err := sdk.CreateThings([]Thing{t}, profileId, token)
 	if err != nil {
 		return "", err
 	}
@@ -39,13 +39,13 @@ func (sdk mfSDK) CreateThing(t Thing, token string) (string, error) {
 	return things[0].ID, nil
 }
 
-func (sdk mfSDK) CreateThings(things []Thing, token string) ([]Thing, error) {
+func (sdk mfSDK) CreateThings(things []Thing, profileId, token string) ([]Thing, error) {
 	data, err := json.Marshal(things)
 	if err != nil {
 		return []Thing{}, err
 	}
 
-	url := fmt.Sprintf("%s/%s", sdk.thingsURL, thingsEndpoint)
+	url := fmt.Sprintf("%s/%s/%s/things", sdk.thingsURL, profilesEndpoint, profileId)
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -124,7 +124,7 @@ func TestCreateThing(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		loc, err := mainfluxSDK.CreateThing(tc.thing, tc.token)
+		loc, err := mainfluxSDK.CreateThing(tc.thing, prID, tc.token)
 
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.location, loc, fmt.Sprintf("%s: expected location %s got %s", tc.desc, tc.location, loc))
@@ -217,7 +217,7 @@ func TestCreateThings(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		res, err := mainfluxSDK.CreateThings(tc.things, tc.token)
+		res, err := mainfluxSDK.CreateThings(tc.things, prID, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 
 		for idx := range tc.res {
@@ -248,7 +248,7 @@ func TestThing(t *testing.T) {
 	th1.ProfileID = prID
 	th1.Key = fmt.Sprintf("%s%012d", uuid.Prefix, 2)
 	th1.GroupID = grID
-	id, err := mainfluxSDK.CreateThing(th1, token)
+	id, err := mainfluxSDK.CreateThing(th1, prID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	cases := []struct {
@@ -309,7 +309,7 @@ func TestMetadataByKey(t *testing.T) {
 	th1.ProfileID = prID
 	th1.GroupID = grID
 	th1.Key = fmt.Sprintf("%s%012d", uuid.Prefix, 1)
-	_, err = mainfluxSDK.CreateThing(th1, token)
+	_, err = mainfluxSDK.CreateThing(th1, prID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	otherKey := fmt.Sprintf("%s%012d", uuid.Prefix, 2)
@@ -374,7 +374,7 @@ func TestThings(t *testing.T) {
 		name := fmt.Sprintf("test-%d", i)
 		key := fmt.Sprintf("%s%012d", uuid.Prefix, i)
 		th := sdk.Thing{GroupID: grID, ID: id, ProfileID: prID, Name: name, Key: key, Metadata: metadata}
-		_, err := mainfluxSDK.CreateThing(th, token)
+		_, err := mainfluxSDK.CreateThing(th, prID, token)
 		require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 		things = append(things, th)
@@ -494,7 +494,7 @@ func TestThingsByProfile(t *testing.T) {
 			Metadata:  metadata,
 			Key:       fmt.Sprintf("%s%012d", uuid.Prefix, 2*i+1),
 		}
-		_, err := mainfluxSDK.CreateThing(th, token)
+		_, err := mainfluxSDK.CreateThing(th, prID, token)
 		require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 		ths = append(ths, th)
@@ -609,7 +609,7 @@ func TestUpdateThing(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	th1.ProfileID = prID
-	id, err := mainfluxSDK.CreateThing(th1, token)
+	id, err := mainfluxSDK.CreateThing(th1, prID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	th1.Name = "test2"
 
@@ -701,7 +701,7 @@ func TestDeleteThing(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	th1.ProfileID = prID
-	id, err := mainfluxSDK.CreateThing(th1, token)
+	id, err := mainfluxSDK.CreateThing(th1, prID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	cases := []struct {
@@ -773,7 +773,7 @@ func TestDeleteThings(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	th1.ProfileID = prID
-	id1, err := mainfluxSDK.CreateThing(th1, token)
+	id1, err := mainfluxSDK.CreateThing(th1, prID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	thIDs := []string{id1}
 
@@ -855,7 +855,7 @@ func TestIdentifyThing(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	th.ProfileID = prID
-	id, err := mainfluxSDK.CreateThing(th, token)
+	id, err := mainfluxSDK.CreateThing(th, prID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	thing, err := mainfluxSDK.Thing(th.ID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -124,7 +124,7 @@ func TestCreateThing(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		loc, err := mainfluxSDK.CreateThing(tc.thing, tc.groupID, tc.token)
+		loc, err := mainfluxSDK.CreateThing(tc.thing, tc.token)
 
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.location, loc, fmt.Sprintf("%s: expected location %s got %s", tc.desc, tc.location, loc))
@@ -217,7 +217,7 @@ func TestCreateThings(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		res, err := mainfluxSDK.CreateThings(tc.things, grID, tc.token)
+		res, err := mainfluxSDK.CreateThings(tc.things, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 
 		for idx := range tc.res {
@@ -248,7 +248,7 @@ func TestThing(t *testing.T) {
 	th1.ProfileID = prID
 	th1.Key = fmt.Sprintf("%s%012d", uuid.Prefix, 2)
 	th1.GroupID = grID
-	id, err := mainfluxSDK.CreateThing(th1, grID, token)
+	id, err := mainfluxSDK.CreateThing(th1, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	cases := []struct {
@@ -309,7 +309,7 @@ func TestMetadataByKey(t *testing.T) {
 	th1.ProfileID = prID
 	th1.GroupID = grID
 	th1.Key = fmt.Sprintf("%s%012d", uuid.Prefix, 1)
-	_, err = mainfluxSDK.CreateThing(th1, grID, token)
+	_, err = mainfluxSDK.CreateThing(th1, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	otherKey := fmt.Sprintf("%s%012d", uuid.Prefix, 2)
@@ -374,7 +374,7 @@ func TestThings(t *testing.T) {
 		name := fmt.Sprintf("test-%d", i)
 		key := fmt.Sprintf("%s%012d", uuid.Prefix, i)
 		th := sdk.Thing{GroupID: grID, ID: id, ProfileID: prID, Name: name, Key: key, Metadata: metadata}
-		_, err := mainfluxSDK.CreateThing(th, th.GroupID, token)
+		_, err := mainfluxSDK.CreateThing(th, token)
 		require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 		things = append(things, th)
@@ -494,7 +494,7 @@ func TestThingsByProfile(t *testing.T) {
 			Metadata:  metadata,
 			Key:       fmt.Sprintf("%s%012d", uuid.Prefix, 2*i+1),
 		}
-		_, err := mainfluxSDK.CreateThing(th, th.GroupID, token)
+		_, err := mainfluxSDK.CreateThing(th, token)
 		require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 		ths = append(ths, th)
@@ -609,7 +609,7 @@ func TestUpdateThing(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	th1.ProfileID = prID
-	id, err := mainfluxSDK.CreateThing(th1, grID, token)
+	id, err := mainfluxSDK.CreateThing(th1, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	th1.Name = "test2"
 
@@ -701,7 +701,7 @@ func TestDeleteThing(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	th1.ProfileID = prID
-	id, err := mainfluxSDK.CreateThing(th1, grID, token)
+	id, err := mainfluxSDK.CreateThing(th1, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	cases := []struct {
@@ -773,7 +773,7 @@ func TestDeleteThings(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	th1.ProfileID = prID
-	id1, err := mainfluxSDK.CreateThing(th1, grID, token)
+	id1, err := mainfluxSDK.CreateThing(th1, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	thIDs := []string{id1}
 
@@ -855,7 +855,7 @@ func TestIdentifyThing(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	th.ProfileID = prID
-	id, err := mainfluxSDK.CreateThing(th, grID, token)
+	id, err := mainfluxSDK.CreateThing(th, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	thing, err := mainfluxSDK.Thing(th.ID, token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))

--- a/things/api/http/things/endpoint.go
+++ b/things/api/http/things/endpoint.go
@@ -20,9 +20,15 @@ func createThingsEndpoint(svc things.Service) endpoint.Endpoint {
 
 		ths := []things.Thing{}
 		for _, t := range req.Things {
+			// Obtain the new Thing's Group ID based on the assigned Profile's belonging Group
+			groupId, err := svc.GetGroupIDByProfileID(ctx, t.ProfileID)
+			if err != nil {
+				return nil, err
+			}
+
 			th := things.Thing{
 				ID:        t.ID,
-				GroupID:   req.groupID,
+				GroupID:   groupId,
 				ProfileID: t.ProfileID,
 				Name:      t.Name,
 				Key:       t.Key,

--- a/things/api/http/things/endpoint.go
+++ b/things/api/http/things/endpoint.go
@@ -19,7 +19,7 @@ func createThingsEndpoint(svc things.Service) endpoint.Endpoint {
 		}
 
 		// Obtain the new Things' Group ID based on the Profile ID from the request
-		groupId, err := svc.GetGroupIDByProfileID(ctx, req.profileID)
+		groupID, err := svc.GetGroupIDByProfileID(ctx, req.profileID)
 		if err != nil {
 			return nil, err
 		}
@@ -29,7 +29,7 @@ func createThingsEndpoint(svc things.Service) endpoint.Endpoint {
 
 			th := things.Thing{
 				ID:        t.ID,
-				GroupID:   groupId,
+				GroupID:   groupID,
 				ProfileID: req.profileID,
 				Name:      t.Name,
 				Key:       t.Key,

--- a/things/api/http/things/endpoint.go
+++ b/things/api/http/things/endpoint.go
@@ -18,18 +18,19 @@ func createThingsEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
+		// Obtain the new Things' Group ID based on the Profile ID from the request
+		groupId, err := svc.GetGroupIDByProfileID(ctx, req.profileId)
+		if err != nil {
+			return nil, err
+		}
+
 		ths := []things.Thing{}
 		for _, t := range req.Things {
-			// Obtain the new Thing's Group ID based on the assigned Profile's belonging Group
-			groupId, err := svc.GetGroupIDByProfileID(ctx, t.ProfileID)
-			if err != nil {
-				return nil, err
-			}
 
 			th := things.Thing{
 				ID:        t.ID,
 				GroupID:   groupId,
-				ProfileID: t.ProfileID,
+				ProfileID: req.profileId,
 				Name:      t.Name,
 				Key:       t.Key,
 				Metadata:  t.Metadata,

--- a/things/api/http/things/endpoint.go
+++ b/things/api/http/things/endpoint.go
@@ -25,7 +25,6 @@ func createThingsEndpoint(svc things.Service) endpoint.Endpoint {
 
 		ths := []things.Thing{}
 		for _, t := range req.Things {
-
 			th := things.Thing{
 				ID:        t.ID,
 				GroupID:   groupID,

--- a/things/api/http/things/endpoint.go
+++ b/things/api/http/things/endpoint.go
@@ -18,7 +18,6 @@ func createThingsEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		// Obtain the new Things' Group ID based on the Profile ID from the request
 		groupID, err := svc.GetGroupIDByProfileID(ctx, req.profileID)
 		if err != nil {
 			return nil, err

--- a/things/api/http/things/endpoint.go
+++ b/things/api/http/things/endpoint.go
@@ -19,7 +19,7 @@ func createThingsEndpoint(svc things.Service) endpoint.Endpoint {
 		}
 
 		// Obtain the new Things' Group ID based on the Profile ID from the request
-		groupId, err := svc.GetGroupIDByProfileID(ctx, req.profileId)
+		groupId, err := svc.GetGroupIDByProfileID(ctx, req.profileID)
 		if err != nil {
 			return nil, err
 		}
@@ -30,7 +30,7 @@ func createThingsEndpoint(svc things.Service) endpoint.Endpoint {
 			th := things.Thing{
 				ID:        t.ID,
 				GroupID:   groupId,
-				ProfileID: req.profileId,
+				ProfileID: req.profileID,
 				Name:      t.Name,
 				Key:       t.Key,
 				Metadata:  t.Metadata,

--- a/things/api/http/things/endpoint_test.go
+++ b/things/api/http/things/endpoint_test.go
@@ -145,7 +145,6 @@ func TestCreateThings(t *testing.T) {
 
 	data := fmt.Sprintf(`[{"name": "1", "key": "1","profile_id":"%s"}, {"name": "2", "key": "2","profile_id":"%s"}]`, prID, prID)
 	invalidNameData := fmt.Sprintf(`[{"name": "%s", "key": "10","profile_id":"%s"}]`, invalidName, prID)
-	invalidProfileData := `[{"name": "test", "key": "1"}]`
 
 	cases := []struct {
 		desc        string
@@ -182,14 +181,6 @@ func TestCreateThings(t *testing.T) {
 		{
 			desc:        "create thing with invalid name",
 			data:        invalidNameData,
-			contentType: contentType,
-			auth:        token,
-			status:      http.StatusBadRequest,
-			response:    emptyValue,
-		},
-		{
-			desc:        "create thing without profile id",
-			data:        invalidProfileData,
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusBadRequest,
@@ -241,7 +232,7 @@ func TestCreateThings(t *testing.T) {
 		req := testRequest{
 			client:      ts.Client(),
 			method:      http.MethodPost,
-			url:         fmt.Sprintf("%s/things", ts.URL),
+			url:         fmt.Sprintf("%s/profiles/%s/things", ts.URL, prID),
 			contentType: tc.contentType,
 			token:       tc.auth,
 			body:        strings.NewReader(tc.data),

--- a/things/api/http/things/endpoint_test.go
+++ b/things/api/http/things/endpoint_test.go
@@ -141,12 +141,11 @@ func TestCreateThings(t *testing.T) {
 	profile1.GroupID = grID1
 	prs, err := svc.CreateProfiles(context.Background(), token, profile, profile1)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
-	prID, prID1 := prs[0].ID, prs[1].ID
+	prID := prs[0].ID
 
 	data := fmt.Sprintf(`[{"name": "1", "key": "1","profile_id":"%s"}, {"name": "2", "key": "2","profile_id":"%s"}]`, prID, prID)
 	invalidNameData := fmt.Sprintf(`[{"name": "%s", "key": "10","profile_id":"%s"}]`, invalidName, prID)
 	invalidProfileData := `[{"name": "test", "key": "1"}]`
-	invalidGroupData := fmt.Sprintf(`[{"name": "test", "key": "10","profile_id":"%s"}]`, prID1)
 
 	cases := []struct {
 		desc        string
@@ -194,14 +193,6 @@ func TestCreateThings(t *testing.T) {
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusBadRequest,
-			response:    emptyValue,
-		},
-		{
-			desc:        "create thing with profile from different group",
-			data:        invalidGroupData,
-			contentType: contentType,
-			auth:        token,
-			status:      http.StatusForbidden,
 			response:    emptyValue,
 		},
 		{
@@ -278,7 +269,7 @@ func TestUpdateThing(t *testing.T) {
 	profile.GroupID = grID
 	prs, err := svc.CreateProfiles(context.Background(), token, profile, profile1)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
-	prID, prID1 := prs[0].ID, prs[1].ID
+	prID := prs[0].ID
 
 	thing.GroupID = grID
 	thing.ProfileID = prID
@@ -289,7 +280,6 @@ func TestUpdateThing(t *testing.T) {
 	data := fmt.Sprintf(`{"name":"test","profile_id":"%s"}`, prID)
 	invalidNameData := fmt.Sprintf(`{"name": "%s","profile_id":"%s"}`, invalidName, prID)
 	invalidProfileData := `{"name": "test"}`
-	invalidGroupData := fmt.Sprintf(`{"name":"test","profile_id":"%s"}`, prID1)
 
 	cases := []struct {
 		desc        string
@@ -385,14 +375,6 @@ func TestUpdateThing(t *testing.T) {
 			contentType: contentType,
 			auth:        token,
 			status:      http.StatusBadRequest,
-		},
-		{
-			desc:        "update thing with profile from different group",
-			req:         invalidGroupData,
-			id:          th.ID,
-			contentType: contentType,
-			auth:        token,
-			status:      http.StatusForbidden,
 		},
 	}
 

--- a/things/api/http/things/endpoint_test.go
+++ b/things/api/http/things/endpoint_test.go
@@ -241,7 +241,7 @@ func TestCreateThings(t *testing.T) {
 		req := testRequest{
 			client:      ts.Client(),
 			method:      http.MethodPost,
-			url:         fmt.Sprintf("%s/groups/%s/things", ts.URL, grID),
+			url:         fmt.Sprintf("%s/things", ts.URL),
 			contentType: tc.contentType,
 			token:       tc.auth,
 			body:        strings.NewReader(tc.data),

--- a/things/api/http/things/requests.go
+++ b/things/api/http/things/requests.go
@@ -21,7 +21,7 @@ type createThingReq struct {
 
 type createThingsReq struct {
 	token     string
-	profileId string
+	profileID string
 	Things    []createThingReq
 }
 
@@ -30,7 +30,7 @@ func (req createThingsReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	if req.profileId == "" {
+	if req.profileID == "" {
 		return apiutil.ErrMissingProfileID
 	}
 

--- a/things/api/http/things/requests.go
+++ b/things/api/http/things/requests.go
@@ -21,18 +21,13 @@ type createThingReq struct {
 }
 
 type createThingsReq struct {
-	token   string
-	groupID string
-	Things  []createThingReq
+	token  string
+	Things []createThingReq
 }
 
 func (req createThingsReq) validate() error {
 	if req.token == "" {
 		return apiutil.ErrBearerToken
-	}
-
-	if req.groupID == "" {
-		return apiutil.ErrMissingGroupID
 	}
 
 	if len(req.Things) <= 0 {

--- a/things/api/http/things/requests.go
+++ b/things/api/http/things/requests.go
@@ -13,16 +13,16 @@ const (
 )
 
 type createThingReq struct {
-	ProfileID string                 `json:"profile_id"`
-	Name      string                 `json:"name,omitempty"`
-	Key       string                 `json:"key,omitempty"`
-	ID        string                 `json:"id,omitempty"`
-	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+	Name     string                 `json:"name,omitempty"`
+	Key      string                 `json:"key,omitempty"`
+	ID       string                 `json:"id,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 type createThingsReq struct {
-	token  string
-	Things []createThingReq
+	token     string
+	profileId string
+	Things    []createThingReq
 }
 
 func (req createThingsReq) validate() error {
@@ -30,14 +30,15 @@ func (req createThingsReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
+	if req.profileId == "" {
+		return apiutil.ErrMissingProfileID
+	}
+
 	if len(req.Things) <= 0 {
 		return apiutil.ErrEmptyList
 	}
 
 	for _, thing := range req.Things {
-		if thing.ProfileID == "" {
-			return apiutil.ErrMissingProfileID
-		}
 		if thing.ID != "" {
 			if err := apiutil.ValidateUUID(thing.ID); err != nil {
 				return err

--- a/things/api/http/things/transport.go
+++ b/things/api/http/things/transport.go
@@ -35,14 +35,6 @@ func MakeHandler(svc things.Service, mux *bone.Mux, tracer opentracing.Tracer, l
 		opts...,
 	))
 
-	// TODO: will eventually become obsolete, remove
-	mux.Post("/groups/:id/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_things")(createThingsEndpoint(svc)),
-		decodeCreateThings,
-		encodeResponse,
-		opts...,
-	))
-
 	mux.Get("/things/:id", kithttp.NewServer(
 		kitot.TraceServer(tracer, "view_thing")(viewThingEndpoint(svc)),
 		decodeRequest,

--- a/things/api/http/things/transport.go
+++ b/things/api/http/things/transport.go
@@ -28,6 +28,13 @@ func MakeHandler(svc things.Service, mux *bone.Mux, tracer opentracing.Tracer, l
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
 	}
 
+	mux.Post("/profiles/:id/things", kithttp.NewServer(
+		kitot.TraceServer(tracer, "create_things")(createThingsEndpoint(svc)),
+		decodeCreateThings,
+		encodeResponse,
+		opts...,
+	))
+
 	mux.Get("/things/:id", kithttp.NewServer(
 		kitot.TraceServer(tracer, "view_thing")(viewThingEndpoint(svc)),
 		decodeRequest,
@@ -52,13 +59,6 @@ func MakeHandler(svc things.Service, mux *bone.Mux, tracer opentracing.Tracer, l
 	mux.Get("/profiles/:id/things", kithttp.NewServer(
 		kitot.TraceServer(tracer, "list_things_by_profile")(listThingsByProfileEndpoint(svc)),
 		decodeListByProfile,
-		encodeResponse,
-		opts...,
-	))
-
-	mux.Post("/profiles/:id/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_things")(createThingsEndpoint(svc)),
-		decodeCreateThings,
 		encodeResponse,
 		opts...,
 	))

--- a/things/api/http/things/transport.go
+++ b/things/api/http/things/transport.go
@@ -153,7 +153,7 @@ func decodeCreateThings(_ context.Context, r *http.Request) (interface{}, error)
 
 	req := createThingsReq{
 		token:     apiutil.ExtractBearerToken(r),
-		profileId: bone.GetValue(r, apiutil.IDKey),
+		profileID: bone.GetValue(r, apiutil.IDKey),
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req.Things); err != nil {

--- a/tools/provision/provision.go
+++ b/tools/provision/provision.go
@@ -138,22 +138,22 @@ func Provision(conf Config) {
 		gID = profiles[i].GroupID
 	}
 
-	things, err = s.CreateThings(things, token)
-	if err != nil {
-		log.Fatalf("Failed to create the things: %s", err.Error())
-	}
-
 	profiles, err = s.CreateProfiles(profiles, gID, token)
 	if err != nil {
 		log.Fatalf("Failed to create the chennels: %s", err.Error())
 	}
 
-	for _, t := range things {
-		tIDs = append(tIDs, t.ID)
-	}
-
 	for _, c := range profiles {
 		cIDs = append(cIDs, c.ID)
+	}
+
+	things, err = s.CreateThings(things, cIDs[0], token)
+	if err != nil {
+		log.Fatalf("Failed to create the things: %s", err.Error())
+	}
+
+	for _, t := range things {
+		tIDs = append(tIDs, t.ID)
 	}
 
 	for i := 0; i < conf.Num; i++ {

--- a/tools/provision/provision.go
+++ b/tools/provision/provision.go
@@ -140,7 +140,7 @@ func Provision(conf Config) {
 
 	profiles, err = s.CreateProfiles(profiles, gID, token)
 	if err != nil {
-		log.Fatalf("Failed to create the chennels: %s", err.Error())
+		log.Fatalf("Failed to create the profiles: %s", err.Error())
 	}
 
 	for _, c := range profiles {

--- a/tools/provision/provision.go
+++ b/tools/provision/provision.go
@@ -138,7 +138,7 @@ func Provision(conf Config) {
 		gID = profiles[i].GroupID
 	}
 
-	things, err = s.CreateThings(things, gID, token)
+	things, err = s.CreateThings(things, token)
 	if err != nil {
 		log.Fatalf("Failed to create the things: %s", err.Error())
 	}


### PR DESCRIPTION
This PR modifies the HTTP API endpoint for creating new Things to address concerns from issue #661.

> Previously, creating new Things required one to supply both a Profile ID (to which the new Thing would belong) and a Group Id. However, as Profiles themselves already belong to Groups, and as providing a Group ID that differs to that of the Profile's belonging Group's ID would result in an error, it seemed unnecessary to require both.

| Endpoint - OLD                                     | Endpoint - **NEW**                  |
|----------------------------------------------------|---------------------------------|
| ```POST /svcthings/groups/<group-id>/things```     | ```POST /svcthings/things``` |

The Thing's belonging Group is now derived from that of the assigned Profile during creation, and the structure of the JSON body for requests at this endpoint _remains the same_. This has the benefit of allowing the API consumer to create multiple Things belonging to Profiles from different Groups in one call.

Additionally, the related methods of SDK and the CLI have been updated to follow this change.

#### TODO:

- [x] Update API and CLI documentation to reflect these changes
    - MainfluxLabs/docs PR [here](https://github.com/MainfluxLabs/docs/pull/36)
