### PR TITLE
NOISSUE - Document schemas of Postgres databases

### DIFF
--- a/auth/postgres/README.md
+++ b/auth/postgres/README.md
@@ -1,0 +1,55 @@
+# Auth - DB Schema
+
+```sql
+CREATE TABLE public.keys (
+    id character varying(254) NOT NULL,
+    type smallint,
+    subject character varying(254) NOT NULL,
+    issuer_id uuid NOT NULL,
+    issued_at timestamp without time zone NOT NULL,
+    expires_at timestamp without time zone
+);
+
+CREATE TABLE public.member_relations (
+    member_id uuid NOT NULL,
+    org_id uuid NOT NULL,
+    role character varying(10) NOT NULL,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone
+);
+
+CREATE TABLE public.orgs (
+    id uuid NOT NULL,
+    owner_id uuid NOT NULL,
+    name character varying(254) NOT NULL,
+    description character varying(1024),
+    metadata jsonb,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone
+);
+
+CREATE TABLE public.users_roles (
+    role character varying(12),
+    user_id uuid NOT NULL,
+    CONSTRAINT users_roles_role_check CHECK (((role)::text = ANY ((ARRAY['root'::character varying, 'admin'::character varying])::text[])))
+);
+
+ALTER TABLE ONLY public.keys
+    ADD CONSTRAINT keys_pkey PRIMARY KEY (id, issuer_id);
+
+ALTER TABLE ONLY public.member_relations
+    ADD CONSTRAINT member_relations_pkey PRIMARY KEY (member_id, org_id);
+
+ALTER TABLE ONLY public.orgs
+    ADD CONSTRAINT orgs_id_key UNIQUE (id);
+
+ALTER TABLE ONLY public.orgs
+    ADD CONSTRAINT orgs_pkey PRIMARY KEY (id, owner_id);
+
+ALTER TABLE ONLY public.users_roles
+    ADD CONSTRAINT users_roles_pkey PRIMARY KEY (user_id);
+
+ALTER TABLE ONLY public.member_relations
+    ADD CONSTRAINT member_relations_org_id_fkey FOREIGN KEY (org_id) REFERENCES public.orgs(id) ON DELETE CASCADE;
+
+```

--- a/auth/postgres/README.md
+++ b/auth/postgres/README.md
@@ -1,55 +1,41 @@
 # Auth - DB Schema
 
 ```sql
-CREATE TABLE public.keys (
+CREATE TABLE keys (
     id character varying(254) NOT NULL,
     type smallint,
     subject character varying(254) NOT NULL,
     issuer_id uuid NOT NULL,
     issued_at timestamp without time zone NOT NULL,
-    expires_at timestamp without time zone
+    expires_at timestamp without time zone,
+    CONSTRAINT keys_pkey PRIMARY KEY (id, issuer_id)
 );
 
-CREATE TABLE public.member_relations (
+CREATE TABLE member_relations (
     member_id uuid NOT NULL,
     org_id uuid NOT NULL,
     role character varying(10) NOT NULL,
     created_at timestamp with time zone,
-    updated_at timestamp with time zone
+    updated_at timestamp with time zone,
+    CONSTRAINT member_relations_pkey PRIMARY KEY (member_id, org_id),
+    CONSTRAINT member_relations_org_id_fkey FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE
 );
 
-CREATE TABLE public.orgs (
+CREATE TABLE orgs (
     id uuid NOT NULL,
     owner_id uuid NOT NULL,
     name character varying(254) NOT NULL,
     description character varying(1024),
     metadata jsonb,
     created_at timestamp with time zone,
-    updated_at timestamp with time zone
+    updated_at timestamp with time zone,
+    CONSTRAINT orgs_id_key UNIQUE (id),
+    CONSTRAINT orgs_pkey PRIMARY KEY (id, owner_id)
 );
 
-CREATE TABLE public.users_roles (
-    role character varying(12),
+CREATE TABLE users_roles (
+    role character varying(12) CHECK (role IN ('root', 'admin')),
     user_id uuid NOT NULL,
-    CONSTRAINT users_roles_role_check CHECK (((role)::text = ANY ((ARRAY['root'::character varying, 'admin'::character varying])::text[])))
+    CONSTRAINT users_roles_pkey PRIMARY KEY (user_id),
 );
-
-ALTER TABLE ONLY public.keys
-    ADD CONSTRAINT keys_pkey PRIMARY KEY (id, issuer_id);
-
-ALTER TABLE ONLY public.member_relations
-    ADD CONSTRAINT member_relations_pkey PRIMARY KEY (member_id, org_id);
-
-ALTER TABLE ONLY public.orgs
-    ADD CONSTRAINT orgs_id_key UNIQUE (id);
-
-ALTER TABLE ONLY public.orgs
-    ADD CONSTRAINT orgs_pkey PRIMARY KEY (id, owner_id);
-
-ALTER TABLE ONLY public.users_roles
-    ADD CONSTRAINT users_roles_pkey PRIMARY KEY (user_id);
-
-ALTER TABLE ONLY public.member_relations
-    ADD CONSTRAINT member_relations_org_id_fkey FOREIGN KEY (org_id) REFERENCES public.orgs(id) ON DELETE CASCADE;
-
 ```

--- a/consumers/alarms/postgres/README.md
+++ b/consumers/alarms/postgres/README.md
@@ -1,0 +1,14 @@
+# Consumers - Alarms - DB Schema
+
+
+```sql
+CREATE TABLE IF NOT EXISTS alarms (
+    id          UUID PRIMARY KEY,
+    thing_id    UUID NOT NULL,
+    group_id    UUID NOT NULL,
+    subtopic    VARCHAR(254),
+    protocol    TEXT,
+    payload     JSONB,
+    created     BIGINT
+)
+```

--- a/consumers/notifiers/postgres/README.md
+++ b/consumers/notifiers/postgres/README.md
@@ -1,0 +1,12 @@
+# Consumers - Notifiers - DB Schema
+    
+```sql
+CREATE TABLE IF NOT EXISTS notifiers (
+    id          UUID PRIMARY KEY,
+    group_id    UUID NOT NULL,
+    name        VARCHAR(254) NOT NULL,						
+    contacts    VARCHAR(512) NOT NULL,
+    metadata    JSONB,
+    CONSTRAINT  unique_group_name UNIQUE (group_id, name)
+)
+```

--- a/consumers/writers/postgres/README.md
+++ b/consumers/writers/postgres/README.md
@@ -1,3 +1,30 @@
+# Consumers - Writers - DB Schema
+
+```sql
+CREATE TABLE public."json" (
+    created bigint,
+    subtopic character varying(254),
+    publisher character varying(254),
+    protocol text,
+    payload jsonb
+);
+
+CREATE TABLE public.messages (
+    subtopic character varying(254) NOT NULL,
+    publisher uuid NOT NULL,
+    protocol text,
+    name text NOT NULL,
+    unit text,
+    value double precision,
+    string_value text,
+    bool_value boolean,
+    data_value bytea,
+    sum double precision,
+    "time" double precision NOT NULL,
+    update_time double precision
+);
+```
+
 # Postgres writer
 
 Postgres writer provides message repository implementation for Postgres.

--- a/consumers/writers/postgres/README.md
+++ b/consumers/writers/postgres/README.md
@@ -1,7 +1,7 @@
 # Consumers - Writers - DB Schema
 
 ```sql
-CREATE TABLE public."json" (
+CREATE TABLE json (
     created bigint,
     subtopic character varying(254),
     publisher character varying(254),
@@ -9,7 +9,7 @@ CREATE TABLE public."json" (
     payload jsonb
 );
 
-CREATE TABLE public.messages (
+CREATE TABLE messages (
     subtopic character varying(254) NOT NULL,
     publisher uuid NOT NULL,
     protocol text,
@@ -20,7 +20,7 @@ CREATE TABLE public.messages (
     bool_value boolean,
     data_value bytea,
     sum double precision,
-    "time" double precision NOT NULL,
+    time double precision NOT NULL,
     update_time double precision
 );
 ```

--- a/mqtt/postgres/README.md
+++ b/mqtt/postgres/README.md
@@ -1,4 +1,4 @@
-MQTT - DB Schema
+# MQTT - DB Schema
 
 ```sql
 CREATE TABLE IF NOT EXISTS subscriptions (

--- a/mqtt/postgres/README.md
+++ b/mqtt/postgres/README.md
@@ -1,0 +1,13 @@
+MQTT - DB Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS subscriptions (
+    subtopic    VARCHAR(1024),
+    group_id  	UUID,
+    thing_id    UUID,
+    client_id   VARCHAR(256),
+    status      VARCHAR(128),
+    created_at  FLOAT,
+    PRIMARY KEY (client_id, subtopic, group_id, thing_id)
+);
+```

--- a/readers/postgres/README.md
+++ b/readers/postgres/README.md
@@ -5,7 +5,7 @@ Postgres reader provides message repository implementation for Postgres.
 ## Readers - DB Schema
 
 ```sql
-CREATE TABLE public."json" (
+CREATE TABLE json (
     created bigint,
     subtopic character varying(254),
     publisher character varying(254),
@@ -13,7 +13,7 @@ CREATE TABLE public."json" (
     payload jsonb
 );
 
-CREATE TABLE public.messages (
+CREATE TABLE messages (
     subtopic character varying(254) NOT NULL,
     publisher uuid NOT NULL,
     protocol text,
@@ -24,7 +24,7 @@ CREATE TABLE public.messages (
     bool_value boolean,
     data_value text,
     sum double precision,
-    "time" double precision NOT NULL,
+    time double precision NOT NULL,
     update_time double precision
 );
 ```

--- a/readers/postgres/README.md
+++ b/readers/postgres/README.md
@@ -2,6 +2,33 @@
 
 Postgres reader provides message repository implementation for Postgres.
 
+## Readers - DB Schema
+
+```sql
+CREATE TABLE public."json" (
+    created bigint,
+    subtopic character varying(254),
+    publisher character varying(254),
+    protocol text,
+    payload jsonb
+);
+
+CREATE TABLE public.messages (
+    subtopic character varying(254) NOT NULL,
+    publisher uuid NOT NULL,
+    protocol text,
+    name text NOT NULL,
+    unit text,
+    value double precision,
+    string_value text,
+    bool_value boolean,
+    data_value text,
+    sum double precision,
+    "time" double precision NOT NULL,
+    update_time double precision
+);
+```
+
 ## Configuration
 
 The service is configured using the environment variables presented in the

--- a/rules/postgres/README.md
+++ b/rules/postgres/README.md
@@ -1,0 +1,13 @@
+# Rules - DB Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS rules (
+    id          UUID PRIMARY KEY,
+    profile_id  UUID NOT NULL,
+    group_id    UUID NOT NULL, 
+    name        VARCHAR(254) NOT NULL,
+    description VARCHAR(1024),
+    condition   JSONB NOT NULL,
+    actions     JSONB NOT NULL
+);
+```

--- a/things/postgres/README.md
+++ b/things/postgres/README.md
@@ -1,16 +1,16 @@
 # Things - DB Schema
 
 ```sql
-CREATE TABLE public.group_roles (
+CREATE TABLE group_roles (
     group_id uuid NOT NULL,
     member_id uuid NOT NULL,
     role character varying(15),
 
     CONSTRAINT group_policies_pkey PRIMARY KEY (group_id, member_id),
-    CONSTRAINT group_policies_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON DELETE CASCADE
+    CONSTRAINT group_policies_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE
 );
 
-CREATE TABLE public.groups (
+CREATE TABLE groups (
     id uuid UNIQUE NOT NULL,
     org_id uuid NOT NULL,
     name character varying(254) NOT NULL,
@@ -23,7 +23,7 @@ CREATE TABLE public.groups (
     CONSTRAINT org_name UNIQUE (org_id, name)
 );
 
-CREATE TABLE public.profiles (
+CREATE TABLE profiles (
     id uuid UNIQUE NOT NULL,
     group_id uuid NOT NULL,
     name character varying(1024) NOT NULL,
@@ -32,10 +32,10 @@ CREATE TABLE public.profiles (
 
     CONSTRAINT group_name_prs UNIQUE (group_id, name),
     CONSTRAINT profiles_pkey PRIMARY KEY (id),
-    CONSTRAINT channels_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE
+    CONSTRAINT channels_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE public.things (
+CREATE TABLE things (
     id uuid UNIQUE NOT NULL,
     group_id uuid NOT NULL,
     key character varying(4096) UNIQUE NOT NULL,
@@ -45,7 +45,7 @@ CREATE TABLE public.things (
 
     CONSTRAINT group_name_ths UNIQUE (group_id, name),
     CONSTRAINT things_pkey PRIMARY KEY (id),
-    CONSTRAINT fk_things_profile_id FOREIGN KEY (profile_id) REFERENCES public.profiles(id) ON UPDATE CASCADE ON DELETE RESTRICT,
-    CONSTRAINT things_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE
+    CONSTRAINT fk_things_profile_id FOREIGN KEY (profile_id) REFERENCES profiles(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT things_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
 ```

--- a/things/postgres/README.md
+++ b/things/postgres/README.md
@@ -4,81 +4,48 @@
 CREATE TABLE public.group_roles (
     group_id uuid NOT NULL,
     member_id uuid NOT NULL,
-    role character varying(15)
+    role character varying(15),
+
+    CONSTRAINT group_policies_pkey PRIMARY KEY (group_id, member_id),
+    CONSTRAINT group_policies_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON DELETE CASCADE
 );
 
 CREATE TABLE public.groups (
-    id uuid NOT NULL,
+    id uuid UNIQUE NOT NULL,
     org_id uuid NOT NULL,
     name character varying(254) NOT NULL,
     description character varying(1024),
     metadata jsonb,
     created_at timestamp with time zone,
-    updated_at timestamp with time zone
+    updated_at timestamp with time zone,
+
+    CONSTRAINT groups_pkey PRIMARY KEY (id),
+    CONSTRAINT org_name UNIQUE (org_id, name)
 );
 
 CREATE TABLE public.profiles (
-    id uuid NOT NULL,
+    id uuid UNIQUE NOT NULL,
     group_id uuid NOT NULL,
     name character varying(1024) NOT NULL,
     config jsonb,
-    metadata jsonb
+    metadata jsonb,
+
+    CONSTRAINT group_name_prs UNIQUE (group_id, name),
+    CONSTRAINT profiles_pkey PRIMARY KEY (id),
+    CONSTRAINT channels_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
 
 CREATE TABLE public.things (
-    id uuid NOT NULL,
+    id uuid UNIQUE NOT NULL,
     group_id uuid NOT NULL,
-    key character varying(4096) NOT NULL,
+    key character varying(4096) UNIQUE NOT NULL,
     name character varying(1024) NOT NULL,
     metadata jsonb,
-    profile_id uuid NOT NULL
+    profile_id uuid NOT NULL,
+
+    CONSTRAINT group_name_ths UNIQUE (group_id, name),
+    CONSTRAINT things_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_things_profile_id FOREIGN KEY (profile_id) REFERENCES public.profiles(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT things_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
-
-ALTER TABLE ONLY public.profiles
-    ADD CONSTRAINT channels_id_key UNIQUE (id);
-
-ALTER TABLE ONLY public.gorp_migrations
-    ADD CONSTRAINT gorp_migrations_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY public.profiles
-    ADD CONSTRAINT group_name_prs UNIQUE (group_id, name);
-
-ALTER TABLE ONLY public.things
-    ADD CONSTRAINT group_name_ths UNIQUE (group_id, name);
-
-ALTER TABLE ONLY public.group_roles
-    ADD CONSTRAINT group_policies_pkey PRIMARY KEY (group_id, member_id);
-
-ALTER TABLE ONLY public.groups
-    ADD CONSTRAINT groups_id_key UNIQUE (id);
-
-ALTER TABLE ONLY public.groups
-    ADD CONSTRAINT groups_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY public.groups
-    ADD CONSTRAINT org_name UNIQUE (org_id, name);
-
-ALTER TABLE ONLY public.profiles
-    ADD CONSTRAINT profiles_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY public.things
-    ADD CONSTRAINT things_id_key UNIQUE (id);
-
-ALTER TABLE ONLY public.things
-    ADD CONSTRAINT things_key_key UNIQUE (key);
-
-ALTER TABLE ONLY public.things
-    ADD CONSTRAINT things_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY public.profiles
-    ADD CONSTRAINT channels_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-ALTER TABLE ONLY public.things
-    ADD CONSTRAINT fk_things_profile_id FOREIGN KEY (profile_id) REFERENCES public.profiles(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-ALTER TABLE ONLY public.group_roles
-    ADD CONSTRAINT group_policies_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON DELETE CASCADE;
-
-ALTER TABLE ONLY public.things
-    ADD CONSTRAINT things_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE;
 ```

--- a/things/postgres/README.md
+++ b/things/postgres/README.md
@@ -1,0 +1,84 @@
+# Things - DB Schema
+
+```sql
+CREATE TABLE public.group_roles (
+    group_id uuid NOT NULL,
+    member_id uuid NOT NULL,
+    role character varying(15)
+);
+
+CREATE TABLE public.groups (
+    id uuid NOT NULL,
+    org_id uuid NOT NULL,
+    name character varying(254) NOT NULL,
+    description character varying(1024),
+    metadata jsonb,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone
+);
+
+CREATE TABLE public.profiles (
+    id uuid NOT NULL,
+    group_id uuid NOT NULL,
+    name character varying(1024) NOT NULL,
+    config jsonb,
+    metadata jsonb
+);
+
+CREATE TABLE public.things (
+    id uuid NOT NULL,
+    group_id uuid NOT NULL,
+    key character varying(4096) NOT NULL,
+    name character varying(1024) NOT NULL,
+    metadata jsonb,
+    profile_id uuid NOT NULL
+);
+
+ALTER TABLE ONLY public.profiles
+    ADD CONSTRAINT channels_id_key UNIQUE (id);
+
+ALTER TABLE ONLY public.gorp_migrations
+    ADD CONSTRAINT gorp_migrations_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.profiles
+    ADD CONSTRAINT group_name_prs UNIQUE (group_id, name);
+
+ALTER TABLE ONLY public.things
+    ADD CONSTRAINT group_name_ths UNIQUE (group_id, name);
+
+ALTER TABLE ONLY public.group_roles
+    ADD CONSTRAINT group_policies_pkey PRIMARY KEY (group_id, member_id);
+
+ALTER TABLE ONLY public.groups
+    ADD CONSTRAINT groups_id_key UNIQUE (id);
+
+ALTER TABLE ONLY public.groups
+    ADD CONSTRAINT groups_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.groups
+    ADD CONSTRAINT org_name UNIQUE (org_id, name);
+
+ALTER TABLE ONLY public.profiles
+    ADD CONSTRAINT profiles_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.things
+    ADD CONSTRAINT things_id_key UNIQUE (id);
+
+ALTER TABLE ONLY public.things
+    ADD CONSTRAINT things_key_key UNIQUE (key);
+
+ALTER TABLE ONLY public.things
+    ADD CONSTRAINT things_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.profiles
+    ADD CONSTRAINT channels_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.things
+    ADD CONSTRAINT fk_things_profile_id FOREIGN KEY (profile_id) REFERENCES public.profiles(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+ALTER TABLE ONLY public.group_roles
+    ADD CONSTRAINT group_policies_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.things
+    ADD CONSTRAINT things_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE;
+```

--- a/users/postgres/README.md
+++ b/users/postgres/README.md
@@ -1,0 +1,14 @@
+# Users - DB Schema
+
+```sql
+CREATE TYPE user_status AS ENUM ('enabled', 'disabled');
+
+CREATE TABLE IF NOT EXISTS users (
+    id          UUID UNIQUE NOT NULL,
+    email       VARCHAR(254) UNIQUE NOT NULL,
+    password    CHAR(60) NOT NULL,
+    metadata    JSONB,
+    status      USER_STATUS NOT NULL DEFAULT 'enabled',
+    PRIMARY KEY (id)
+);
+```

--- a/webhooks/postgres/README.md
+++ b/webhooks/postgres/README.md
@@ -1,0 +1,14 @@
+# Webhooks - DB Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS webhooks (
+    id          UUID UNIQUE, 
+    thing_id    UUID NOT NULL,
+    group_id    UUID NOT NULL,
+    name        VARCHAR(254) NOT NULL,
+    url         VARCHAR(254) NOT NULL,
+    headers     JSONB,
+    metadata    JSONB,    
+    PRIMARY KEY (thing_id, name)
+);
+```


### PR DESCRIPTION
This PR creates a `README.md` file in each service's `postgres/` directory, describing that database's schema. 

For simple schemas, i.e. ones with few migrations in the `postgres/init.go` source file, the final schema was mostly copy-pasted based on the migrations.

For more complex ones, i.e. ones with multiple migrations (such as [`things/postgres/init.go`](https://github.com/MainfluxLabs/mainflux/blob/58726211da7ea7933598c5d7d7ac9eb3a9002955/things/postgres/init.go)), an up to date schema was created using the `pg_dump` utility on a running db container. Unfortunately, while `pg_dump` produces a valid and reproducible schema, it's not as readable as human-written SQL - e.g. table constraints are added one by one using `ALTER TABLE ... ADD CONSTRAINT` statements instead of right inside the associated `CREATE TABLE` statement, so these schemas could be manually cleaned up to be more readable. 