### PR TITLE
NOISSUE - Further tidying of pg_dump output in Postgres DB schema documentation

### DIFF
--- a/auth/postgres/README.md
+++ b/auth/postgres/README.md
@@ -2,40 +2,40 @@
 
 ```sql
 CREATE TABLE keys (
-    id character varying(254) NOT NULL,
-    type smallint,
-    subject character varying(254) NOT NULL,
-    issuer_id uuid NOT NULL,
-    issued_at timestamp without time zone NOT NULL,
-    expires_at timestamp without time zone,
+    id         VARCHAR(254) NOT NULL,
+    type       SMALLINT,
+    subject    VARCHAR(254) NOT NULL,
+    issuer_id  UUID NOT NULL,
+    issued_at  TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    expires_at TIMESTAMP WITHOUT TIME ZONE,
     CONSTRAINT keys_pkey PRIMARY KEY (id, issuer_id)
 );
 
 CREATE TABLE member_relations (
-    member_id uuid NOT NULL,
-    org_id uuid NOT NULL,
-    role character varying(10) NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
+    member_id  UUID NOT NULL,
+    org_id     UUID NOT NULL,
+    role       VARCHAR(10) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE,
+    updated_at TIMESTAMP WITH TOME ZONE,
     CONSTRAINT member_relations_pkey PRIMARY KEY (member_id, org_id),
     CONSTRAINT member_relations_org_id_fkey FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE
 );
 
 CREATE TABLE orgs (
-    id uuid NOT NULL,
-    owner_id uuid NOT NULL,
-    name character varying(254) NOT NULL,
-    description character varying(1024),
-    metadata jsonb,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    CONSTRAINT orgs_id_key UNIQUE (id),
-    CONSTRAINT orgs_pkey PRIMARY KEY (id, owner_id)
+    id          UUID NOT NULL,
+    owner_id    UUID NOT NULL,
+    name        VARCHAR(254) NOT NULL,
+    description VARCHAR(1024),
+    metadata    JSONB,
+    created_at  TIMESTAMP WITH TOME ZONE,
+    updated_at  TIMESTAMP WITH TIME ZONE,
+    CONSTRAINT  orgs_id_key UNIQUE (id),
+    CONSTRAINT  orgs_pkey PRIMARY KEY (id, owner_id)
 );
 
 CREATE TABLE users_roles (
-    role character varying(12) CHECK (role IN ('root', 'admin')),
-    user_id uuid NOT NULL,
+    role       VARCHAR(12) CHECK (role IN ('root', 'admin')),
+    user_id    UUID NOT NULL,
     CONSTRAINT users_roles_pkey PRIMARY KEY (user_id),
 );
 ```

--- a/consumers/writers/postgres/README.md
+++ b/consumers/writers/postgres/README.md
@@ -2,26 +2,26 @@
 
 ```sql
 CREATE TABLE json (
-    created bigint,
-    subtopic character varying(254),
-    publisher character varying(254),
-    protocol text,
-    payload jsonb
+    created   BIGINT,
+    subtopic  VARCHAR(254),
+    publisher VARCHAR(254),
+    protocol  TEXT,
+    payload   JSONB
 );
 
 CREATE TABLE messages (
-    subtopic character varying(254) NOT NULL,
-    publisher uuid NOT NULL,
-    protocol text,
-    name text NOT NULL,
-    unit text,
-    value double precision,
-    string_value text,
-    bool_value boolean,
-    data_value bytea,
-    sum double precision,
-    time double precision NOT NULL,
-    update_time double precision
+    subtopic     VARCHAR(254) NOT NULL,
+    publisher    UUID NOT NULL,
+    protocol     TEXT,
+    name         TEXT NOT NULL,
+    unit         TEXT,
+    value        DOUBLE PRECISION,
+    string_value TEXT,
+    bool_value   BOOLEAN,
+    data_value   BYTEA,
+    sum          DOUBLE PRECISION,
+    time         DOUBLE PRECISION NOT NULL,
+    update_time  DOUBLE PRECISION
 );
 ```
 

--- a/readers/postgres/README.md
+++ b/readers/postgres/README.md
@@ -6,26 +6,26 @@ Postgres reader provides message repository implementation for Postgres.
 
 ```sql
 CREATE TABLE json (
-    created bigint,
-    subtopic character varying(254),
-    publisher character varying(254),
-    protocol text,
-    payload jsonb
+    created   BIGINT,
+    subtopic  VARCHAR(254),
+    publisher VARCHAR(254),
+    protocol  TEXT,
+    payload   JSONB
 );
 
 CREATE TABLE messages (
-    subtopic character varying(254) NOT NULL,
-    publisher uuid NOT NULL,
-    protocol text,
-    name text NOT NULL,
-    unit text,
-    value double precision,
-    string_value text,
-    bool_value boolean,
-    data_value text,
-    sum double precision,
-    time double precision NOT NULL,
-    update_time double precision
+    subtopic     VARCHAR(254) NOT NULL,
+    publisher    UUID NOT NULL,
+    protocol     TEXT,
+    name         TEXT NOT NULL,
+    unit         TEXT,
+    value        DOUBLE PRECISION,
+    string_value TEXT,
+    bool_value   BOOLEAN,
+    data_value   TEXT,
+    sum          DOUBLE PRECISION,
+    time         DOUBLE PRECISION NOT NULL,
+    update_time  DOUBLE PRECISION
 );
 ```
 

--- a/things/postgres/README.md
+++ b/things/postgres/README.md
@@ -2,33 +2,33 @@
 
 ```sql
 CREATE TABLE group_roles (
-    group_id uuid NOT NULL,
-    member_id uuid NOT NULL,
-    role character varying(15),
+    group_id   UUID NOT NULL,
+    member_id  UUID NOT NULL,
+    role       VARCHAR(15),
 
     CONSTRAINT group_policies_pkey PRIMARY KEY (group_id, member_id),
     CONSTRAINT group_policies_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE
 );
 
 CREATE TABLE groups (
-    id uuid UNIQUE NOT NULL,
-    org_id uuid NOT NULL,
-    name character varying(254) NOT NULL,
-    description character varying(1024),
-    metadata jsonb,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
+    id          UUID UNIQUE NOT NULL,
+    org_id      UUID NOT NULL,
+    name        VARCHAR(254) NOT NULL,
+    description VARCHAR(1024),
+    metadata    JSONB,
+    created_at  TIMESTAMP WITH TIME ZONE,
+    updated_at  TIMESTAMP WITH TIME ZONE,
 
-    CONSTRAINT groups_pkey PRIMARY KEY (id),
-    CONSTRAINT org_name UNIQUE (org_id, name)
+    CONSTRAINT  groups_pkey PRIMARY KEY (id),
+    CONSTRAINT  org_name UNIQUE (org_id, name)
 );
 
 CREATE TABLE profiles (
-    id uuid UNIQUE NOT NULL,
-    group_id uuid NOT NULL,
-    name character varying(1024) NOT NULL,
-    config jsonb,
-    metadata jsonb,
+    id         UUID UNIQUE NOT NULL,
+    group_id   UUID NOT NULL,
+    name       VARCHAR(1024) NOT NULL,
+    config     JSONB,
+    metadata   JSONB,
 
     CONSTRAINT group_name_prs UNIQUE (group_id, name),
     CONSTRAINT profiles_pkey PRIMARY KEY (id),
@@ -36,12 +36,12 @@ CREATE TABLE profiles (
 );
 
 CREATE TABLE things (
-    id uuid UNIQUE NOT NULL,
-    group_id uuid NOT NULL,
-    key character varying(4096) UNIQUE NOT NULL,
-    name character varying(1024) NOT NULL,
-    metadata jsonb,
-    profile_id uuid NOT NULL,
+    id         UUID UNIQUE NOT NULL,
+    group_id   UUID NOT NULL,
+    key        VARCHAR(4096) UNIQUE NOT NULL,
+    name       VARCHAR(1024) NOT NULL,
+    metadata   JSONB,
+    profile_id UUID NOT NULL,
 
     CONSTRAINT group_name_ths UNIQUE (group_id, name),
     CONSTRAINT things_pkey PRIMARY KEY (id),

--- a/things/postgres/README.md
+++ b/things/postgres/README.md
@@ -24,11 +24,11 @@ CREATE TABLE groups (
 );
 
 CREATE TABLE profiles (
-    id         UUID UNIQUE NOT NULL,
-    group_id   UUID NOT NULL,
-    name       VARCHAR(1024) NOT NULL,
-    config     JSONB,
-    metadata   JSONB,
+    id        UUID UNIQUE NOT NULL,
+    group_id  UUID NOT NULL,
+    name      VARCHAR(1024) NOT NULL,
+    config    JSONB,
+    metadata  JSONB,
 
     CONSTRAINT group_name_prs UNIQUE (group_id, name),
     CONSTRAINT profiles_pkey PRIMARY KEY (id),


### PR DESCRIPTION
Uppercase SQL types and prettify indentation in output of `pg_dump` CREATE_TABLE statements.