### PR TITLE
MF-730 - Remove support for -1 limit to fetch all entities

### DIFF
--- a/consumers/notifiers/api/http/endpoint_test.go
+++ b/consumers/notifiers/api/http/endpoint_test.go
@@ -294,13 +294,6 @@ func runListNotifiersByGroupTest(t *testing.T, validContacts []string) {
 			res:    data[0:5],
 		},
 		{
-			desc:   "get a list of notifiers by group with no limit",
-			auth:   token,
-			status: http.StatusOK,
-			url:    fmt.Sprintf("%s/groups/%s/notifiers?limit=%d", ts.URL, groupID, -1),
-			res:    data,
-		},
-		{
 			desc:   "get a list of notifiers by group with negative offset",
 			auth:   token,
 			status: http.StatusBadRequest,

--- a/pkg/apiutil/transport.go
+++ b/pkg/apiutil/transport.go
@@ -167,12 +167,8 @@ func ReadLimitQuery(r *http.Request, key string, def uint64) (uint64, error) {
 		return 0, ErrInvalidQueryParams
 	}
 
-	if val < -1 || val == 0 {
+	if val <= 0 {
 		return 0, ErrInvalidQueryParams
-	}
-
-	if val == -1 {
-		val = 0
 	}
 
 	return uint64(val), nil

--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -142,12 +142,10 @@ func TestListAllMessages(t *testing.T) {
 	thSvc := thmocks.NewThingsServiceClient(nil, nil, nil)
 	authSvc := newAuthService()
 
-	tok, err := authSvc.Issue(context.Background(), &protomfx.IssueReq{Id: user.ID, Email: user.Email, Type: 0})
 	require.Nil(t, err, fmt.Sprintf("issue token for user got unexpected error: %s", err))
 	adminTok, err := authSvc.Issue(context.Background(), &protomfx.IssueReq{Id: admin.ID, Email: admin.Email})
 	require.Nil(t, err, fmt.Sprintf("issue token for admin got unexpected error: %s", err))
 
-	userToken := tok.GetValue()
 	adminToken := adminTok.GetValue()
 
 	repo := rmocks.NewMessageRepository("", fromSenml(messages))
@@ -163,23 +161,6 @@ func TestListAllMessages(t *testing.T) {
 		status int
 		res    pageRes
 	}{
-		{
-			desc:   "read all messages page as admin",
-			url:    fmt.Sprintf("%s/messages?limit=-1", ts.URL),
-			token:  adminToken,
-			status: http.StatusOK,
-			res: pageRes{
-				Total:    uint64(len(messages)),
-				Messages: messages,
-			},
-		},
-		{
-			desc:   "read all messages page as user",
-			url:    fmt.Sprintf("%s/messages?limit=-1", ts.URL),
-			token:  userToken,
-			status: http.StatusForbidden,
-			res:    pageRes{},
-		},
 		{
 			desc:   "read page with valid offset and limit",
 			url:    fmt.Sprintf("%s/messages?offset=0&limit=10", ts.URL),

--- a/things/api/http/profiles/endpoint_test.go
+++ b/things/api/http/profiles/endpoint_test.go
@@ -48,7 +48,6 @@ const (
 	orgID2         = "374106f7-030e-4881-8ab0-151195c29f93"
 	prefix         = "fe6b4e92-cc98-425e-b0aa-"
 	n              = 101
-	noLimit        = -1
 )
 
 var (
@@ -477,13 +476,6 @@ func TestListProfiles(t *testing.T) {
 			status: http.StatusOK,
 			url:    fmt.Sprintf("%s?offset=%d&limit=%d", profileURL, 0, 6),
 			res:    profiles[0:6],
-		},
-		{
-			desc:   "get a list of all profiles without limit",
-			auth:   token,
-			status: http.StatusOK,
-			url:    fmt.Sprintf("%s?limit=%d", profileURL, noLimit),
-			res:    []profileRes{},
 		},
 		{
 			desc:   "get a list of profiles with invalid token",

--- a/things/api/http/things/endpoint_test.go
+++ b/things/api/http/things/endpoint_test.go
@@ -49,7 +49,6 @@ const (
 	orgID2         = "374106f7-030e-4881-8ab0-151195c29f93"
 	prefix         = "fe6b4e92-cc98-425e-b0aa-"
 	n              = 101
-	noLimit        = -1
 )
 
 var (
@@ -1140,13 +1139,6 @@ func TestListThingsByProfile(t *testing.T) {
 			status: http.StatusOK,
 			url:    fmt.Sprintf("%s/%s/things?offset=%d&limit=%d", thingURL, pr.ID, 0, 5),
 			res:    data[0:5],
-		},
-		{
-			desc:   "get a list of things by profile with no limit",
-			auth:   token,
-			status: http.StatusOK,
-			url:    fmt.Sprintf("%s/%s/things?limit=%d", thingURL, pr.ID, noLimit),
-			res:    data,
 		},
 		{
 			desc:   "get a list of things by profile with invalid token",

--- a/users/api/http/endpoint_test.go
+++ b/users/api/http/endpoint_test.go
@@ -372,13 +372,6 @@ func TestListUsers(t *testing.T) {
 			res:    data[0:10],
 		},
 		{
-			desc:   "get list of all users with no limit",
-			url:    fmt.Sprintf("%s/users?limit=%d", ts.URL, -1),
-			token:  token,
-			status: http.StatusOK,
-			res:    data,
-		},
-		{
 			desc:   "get list of users with invalid token",
 			url:    fmt.Sprintf("%s/users?offset=%d&limit=%d&order=wrong", ts.URL, 0, 5),
 			token:  invalidToken,

--- a/webhooks/api/http/endpoint_test.go
+++ b/webhooks/api/http/endpoint_test.go
@@ -289,13 +289,6 @@ func TestListWebhooksByGroup(t *testing.T) {
 			res:    data[0:5],
 		},
 		{
-			desc:   "get a list of webhooks by group with no limit",
-			auth:   token,
-			status: http.StatusOK,
-			url:    fmt.Sprintf("%s/groups/%s/webhooks?limit=%d", ts.URL, groupID, -1),
-			res:    data,
-		},
-		{
 			desc:   "get a list of webhooks by group with negative offset",
 			auth:   token,
 			status: http.StatusBadRequest,


### PR DESCRIPTION
Removed the option to fetch all entities by setting the limit to -1. All queries must use a defined limit. Resolves #730