### PR TITLE
NOISSUE - Remove references to deprecated Bootstrap service from Go SDK

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -23,7 +23,6 @@ func main() {
 		UsersURL:        fmt.Sprintf("%s/svcusers", defURL),
 		ReaderURL:       fmt.Sprintf("%s/reader", defURL),
 		HTTPAdapterURL:  fmt.Sprintf("%s/http", defURL),
-		BootstrapURL:    defURL,
 		CertsURL:        defURL,
 		MsgContentType:  sdk.ContentType(msgContentType),
 		TLSVerification: false,

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -369,7 +369,6 @@ type SDK interface {
 
 type mfSDK struct {
 	authURL        string
-	bootstrapURL   string
 	certsURL       string
 	httpAdapterURL string
 	readerURL      string
@@ -384,7 +383,6 @@ type mfSDK struct {
 // Config contains sdk configuration parameters.
 type Config struct {
 	AuthURL        string
-	BootstrapURL   string
 	CertsURL       string
 	HTTPAdapterURL string
 	ReaderURL      string
@@ -400,7 +398,6 @@ type Config struct {
 func NewSDK(conf Config) SDK {
 	return &mfSDK{
 		authURL:        conf.AuthURL,
-		bootstrapURL:   conf.BootstrapURL,
 		certsURL:       conf.CertsURL,
 		httpAdapterURL: conf.HTTPAdapterURL,
 		readerURL:      conf.ReaderURL,

--- a/tools/provision/provision.go
+++ b/tools/provision/provision.go
@@ -64,7 +64,6 @@ func Provision(conf Config) {
 		UsersURL:        conf.Host,
 		ReaderURL:       defReaderURL,
 		HTTPAdapterURL:  fmt.Sprintf("%s/http", conf.Host),
-		BootstrapURL:    conf.Host,
 		CertsURL:        conf.Host,
 		MsgContentType:  sdk.ContentType(msgContentType),
 		TLSVerification: false,


### PR DESCRIPTION
Removes the `BootstrapURL` struct field in the SDK implementation, its `Config`, all all places that initialized those fields.