### PR TITLE
NOISSUE - Fix wrong count of Profile fields in CSV provisioning

### DIFF
--- a/cli/provision.go
+++ b/cli/provision.go
@@ -32,7 +32,7 @@ const (
 	thingProfileID
 )
 
-const csvProfilesFieldCount = 12
+const csvProfilesFieldCount = 10
 
 // These constants define the order of the CSV columns (fields) of records containing Profiles to be provisioned
 const (


### PR DESCRIPTION
This PR fixes a tiny bug introduced in PR #702 -- after two Profile config fields were removed from the CSV structure the total count of Profile fields in a CSV record wasn't subsequently decremented.