### PR TITLE
MF-745 - Remove format filter when reading messages

### DIFF
--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -47,6 +47,7 @@ func listAllMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 				return nil, err
 			}
 			req.pageMeta.Publisher = pc.PublisherID
+			req.pageMeta.Format = dbutil.GetTableName(pc.ProfileConfig.GetContentType())
 
 			p, err := svc.ListAllMessages(req.pageMeta)
 			if err != nil {
@@ -103,7 +104,7 @@ func deleteMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 			return nil, errors.ErrAuthentication
 		}
 
-		err :=  svc.DeleteMessages(ctx, req.pageMeta, table)
+		err := svc.DeleteMessages(ctx, req.pageMeta, table)
 		if err != nil {
 			return nil, err
 		}

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -94,11 +94,6 @@ func decodeListAllMessages(_ context.Context, r *http.Request) (interface{}, err
 		return nil, err
 	}
 
-	format, err := apiutil.ReadStringQuery(r, formatKey, defFormat)
-	if err != nil {
-		return nil, err
-	}
-
 	subtopic, err := apiutil.ReadStringQuery(r, subtopicKey, "")
 	if err != nil {
 		return nil, err
@@ -155,7 +150,6 @@ func decodeListAllMessages(_ context.Context, r *http.Request) (interface{}, err
 		pageMeta: readers.PageMetadata{
 			Offset:      offset,
 			Limit:       limit,
-			Format:      format,
 			Subtopic:    subtopic,
 			Protocol:    protocol,
 			Name:        name,

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -23,7 +23,6 @@ import (
 
 const (
 	octetStreamContentType = "application/octet-stream"
-	formatKey              = "format"
 	subtopicKey            = "subtopic"
 	protocolKey            = "protocol"
 	valueKey               = "v"


### PR DESCRIPTION
Small change that allows you to query databases based on content-type.

Old way to get JSON messages:
- `http://localhost/reader/messages?format=json` 

Now:
- `http://localhost/reader/messages`

Resolves #745.