### PR TITLE
MF-766 - Add batch deletion of organizations by IDs

### DIFF
--- a/api/openapi/auth.yml
+++ b/api/openapi/auth.yml
@@ -97,6 +97,22 @@ paths:
           description: Missing or invalid access token provided.
         '500':
           $ref: "#/components/responses/ServiceError"
+    patch:
+      summary: Removes organizations
+      description: Removes organizations with provided identifiers
+      tags:
+        - auth
+      requestBody:
+        $ref: "#/components/requestBodies/RemoveOrgReq"
+      responses:
+        '204':
+          description: Organizations removed.
+        '400':
+          description: Failed due to malformed JSON.
+        '401':
+          description: Missing or invalid access token provided.
+        '500':
+          $ref: "#/components/responses/ServiceError"      
   /orgs/search:
     post:
       summary: Search and retrieve organizations.
@@ -724,6 +740,19 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/SearchOrgsReqSchema"
+    RemoveOrgReq:
+      description: JSON-formatted document describing the identifiers of organizations for deleting.
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              thing_ids:
+                type: array
+                items:
+                  type: string
+                  format: uuid          
     OrgMembershipsReq:
       description: JSON-formatted document describing a request to create and update memberships.
       required: true

--- a/auth/api/http/orgs/endpoint.go
+++ b/auth/api/http/orgs/endpoint.go
@@ -85,7 +85,22 @@ func deleteOrgEndpoint(svc auth.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		if err := svc.RemoveOrg(ctx, req.token, req.id); err != nil {
+		if err := svc.RemoveOrgs(ctx, req.token, req.id); err != nil {
+			return nil, err
+		}
+
+		return deleteRes{}, nil
+	}
+}
+
+func deleteOrgsEndpoint(svc auth.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(deleteOrgsReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		if err := svc.RemoveOrgs(ctx, req.token, req.OrgIDs...); err != nil {
 			return nil, err
 		}
 

--- a/auth/api/http/orgs/requests.go
+++ b/auth/api/http/orgs/requests.go
@@ -95,6 +95,29 @@ func (req orgReq) validate() error {
 	return nil
 }
 
+type deleteOrgsReq struct {
+	token  string
+	OrgIDs []string `json:"org_ids,omitempty"`
+}
+
+func (req deleteOrgsReq) validate() error {
+	if req.token == "" {
+		return apiutil.ErrBearerToken
+	}
+
+	if len(req.OrgIDs) < 1 {
+		return apiutil.ErrEmptyList
+	}
+
+	for _, orgID := range req.OrgIDs {
+		if orgID == "" {
+			return apiutil.ErrMissingOrgID
+		}
+	}
+
+	return nil
+}
+
 type backupReq struct {
 	token string
 }

--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -121,9 +121,9 @@ func (lm *loggingMiddleware) UpdateOrg(ctx context.Context, token string, org au
 	return lm.svc.UpdateOrg(ctx, token, org)
 }
 
-func (lm *loggingMiddleware) RemoveOrg(ctx context.Context, token string, id string) (err error) {
+func (lm *loggingMiddleware) RemoveOrgs(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_org for id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method remove_orgs took %s to complete", time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -131,7 +131,7 @@ func (lm *loggingMiddleware) RemoveOrg(ctx context.Context, token string, id str
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.RemoveOrg(ctx, token, id)
+	return lm.svc.RemoveOrgs(ctx, token, ids...)
 }
 
 func (lm *loggingMiddleware) ViewOrg(ctx context.Context, token, id string) (o auth.Org, err error) {

--- a/auth/api/metrics.go
+++ b/auth/api/metrics.go
@@ -91,12 +91,12 @@ func (ms *metricsMiddleware) UpdateOrg(ctx context.Context, token string, org au
 	return ms.svc.UpdateOrg(ctx, token, org)
 }
 
-func (ms *metricsMiddleware) RemoveOrg(ctx context.Context, token string, id string) error {
+func (ms *metricsMiddleware) RemoveOrgs(ctx context.Context, token string, ids ...string) error {
 	defer func(begin time.Time) {
-		ms.counter.With("method", "remove_org").Add(1)
-		ms.latency.With("method", "remove_org").Observe(time.Since(begin).Seconds())
+		ms.counter.With("method", "remove_orgs").Add(1)
+		ms.latency.With("method", "remove_orgs").Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return ms.svc.RemoveOrg(ctx, token, id)
+	return ms.svc.RemoveOrgs(ctx, token, ids...)
 }
 
 func (ms *metricsMiddleware) ViewOrg(ctx context.Context, token, id string) (auth.Org, error) {

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -57,14 +57,16 @@ func (orm *orgRepositoryMock) Update(_ context.Context, org auth.Org) error {
 	return nil
 }
 
-func (orm *orgRepositoryMock) Remove(_ context.Context, owner, id string) error {
+func (orm *orgRepositoryMock) Remove(_ context.Context, owner string, ids ...string) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
-	if _, ok := orm.orgs[id]; !ok && orm.orgs[id].OwnerID != owner {
-		return errors.ErrNotFound
+	for _, id := range ids {
+		if _, ok := orm.orgs[id]; !ok && orm.orgs[id].OwnerID != owner {
+			return errors.ErrNotFound
+		}
+		delete(orm.orgs, id)
 	}
-	delete(orm.orgs, id)
 
 	return nil
 }

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -57,12 +57,12 @@ func (orm *orgRepositoryMock) Update(_ context.Context, org auth.Org) error {
 	return nil
 }
 
-func (orm *orgRepositoryMock) Remove(_ context.Context, owner string, ids ...string) error {
+func (orm *orgRepositoryMock) Remove(_ context.Context, ownerID string, ids ...string) error {
 	orm.mu.Lock()
 	defer orm.mu.Unlock()
 
 	for _, id := range ids {
-		if _, ok := orm.orgs[id]; !ok && orm.orgs[id].OwnerID != owner {
+		if _, ok := orm.orgs[id]; !ok && orm.orgs[id].OwnerID != ownerID {
 			return errors.ErrNotFound
 		}
 		delete(orm.orgs, id)

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -82,7 +82,7 @@ type OrgRepository interface {
 	Update(ctx context.Context, org Org) error
 
 	// Remove orgs
-	Remove(ctx context.Context, owner string, orgIDs ...string) error
+	Remove(ctx context.Context, ownerID string, orgIDs ...string) error
 
 	// RetrieveByID retrieves org by its id
 	RetrieveByID(ctx context.Context, id string) (Org, error)

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -60,8 +60,8 @@ type Orgs interface {
 	// ListOrgs retrieves orgs.
 	ListOrgs(ctx context.Context, token string, pm apiutil.PageMetadata) (OrgsPage, error)
 
-	// RemoveOrg removes the org identified with the provided ID.
-	RemoveOrg(ctx context.Context, token, id string) error
+	// RemoveOrgs removes the orgs identified with the provided IDs.
+	RemoveOrgs(ctx context.Context, token string, ids ...string) error
 
 	// GetOwnerIDByOrgID returns an owner ID for a given org ID.
 	GetOwnerIDByOrgID(ctx context.Context, orgID string) (string, error)
@@ -81,8 +81,8 @@ type OrgRepository interface {
 	// Update an org
 	Update(ctx context.Context, org Org) error
 
-	// Remove an org
-	Remove(ctx context.Context, owner, id string) error
+	// Remove orgs
+	Remove(ctx context.Context, owner string, orgIDs ...string) error
 
 	// RetrieveByID retrieves org by its id
 	RetrieveByID(ctx context.Context, id string) (Org, error)
@@ -152,17 +152,19 @@ func (svc service) ListOrgs(ctx context.Context, token string, pm apiutil.PageMe
 	return svc.orgs.RetrieveByMember(ctx, user.ID, pm)
 }
 
-func (svc service) RemoveOrg(ctx context.Context, token, id string) error {
+func (svc service) RemoveOrgs(ctx context.Context, token string, ids ...string) error {
 	user, err := svc.Identify(ctx, token)
 	if err != nil {
 		return err
 	}
 
-	if err := svc.canAccessOrg(ctx, token, id, Owner); err != nil {
-		return err
+	for _, id := range ids {
+		if err := svc.canAccessOrg(ctx, token, id, Owner); err != nil {
+			return err
+		}
 	}
 
-	return svc.orgs.Remove(ctx, user.ID, id)
+	return svc.orgs.Remove(ctx, user.ID, ids...)
 }
 
 func (svc service) UpdateOrg(ctx context.Context, token string, o Org) (Org, error) {

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -97,42 +97,44 @@ func (or orgRepository) Update(ctx context.Context, org auth.Org) error {
 	return nil
 }
 
-func (or orgRepository) Remove(ctx context.Context, owner, orgID string) error {
+func (or orgRepository) Remove(ctx context.Context, owner string, orgIDs ...string) error {
 	qd := `DELETE FROM orgs WHERE id = :id AND owner_id = :owner_id;`
-	org := auth.Org{
-		ID:      orgID,
-		OwnerID: owner,
-	}
-	dbo, err := toDBOrg(org)
-	if err != nil {
-		return errors.Wrap(errors.ErrUpdateEntity, err)
-	}
-
-	res, err := or.db.NamedExecContext(ctx, qd, dbo)
-	if err != nil {
-		pqErr, ok := err.(*pgconn.PgError)
-		if ok {
-			switch pqErr.Code {
-			case pgerrcode.InvalidTextRepresentation:
-				return errors.Wrap(errors.ErrMalformedEntity, err)
-			case pgerrcode.ForeignKeyViolation:
-				switch pqErr.ConstraintName {
-				case membershipsIDFkey:
-					return errors.Wrap(auth.ErrOrgNotEmpty, err)
-				}
-				return errors.Wrap(errors.ErrConflict, err)
-			}
+	for _, orgID := range orgIDs {
+		org := auth.Org{
+			ID:      orgID,
+			OwnerID: owner,
 		}
-		return errors.Wrap(errors.ErrUpdateEntity, err)
-	}
+		dbo, err := toDBOrg(org)
+		if err != nil {
+			return errors.Wrap(errors.ErrUpdateEntity, err)
+		}
 
-	cnt, err := res.RowsAffected()
-	if err != nil {
-		return errors.Wrap(errors.ErrRemoveEntity, err)
-	}
+		res, err := or.db.NamedExecContext(ctx, qd, dbo)
+		if err != nil {
+			pqErr, ok := err.(*pgconn.PgError)
+			if ok {
+				switch pqErr.Code {
+				case pgerrcode.InvalidTextRepresentation:
+					return errors.Wrap(errors.ErrMalformedEntity, err)
+				case pgerrcode.ForeignKeyViolation:
+					switch pqErr.ConstraintName {
+					case membershipsIDFkey:
+						return errors.Wrap(auth.ErrOrgNotEmpty, err)
+					}
+					return errors.Wrap(errors.ErrConflict, err)
+				}
+			}
+			return errors.Wrap(errors.ErrUpdateEntity, err)
+		}
 
-	if cnt != 1 {
-		return errors.Wrap(errors.ErrRemoveEntity, err)
+		cnt, err := res.RowsAffected()
+		if err != nil {
+			return errors.Wrap(errors.ErrRemoveEntity, err)
+		}
+
+		if cnt != 1 {
+			return errors.Wrap(errors.ErrRemoveEntity, err)
+		}
 	}
 	return nil
 }

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -97,12 +97,12 @@ func (or orgRepository) Update(ctx context.Context, org auth.Org) error {
 	return nil
 }
 
-func (or orgRepository) Remove(ctx context.Context, owner string, orgIDs ...string) error {
+func (or orgRepository) Remove(ctx context.Context, ownerID string, orgIDs ...string) error {
 	qd := `DELETE FROM orgs WHERE id = :id AND owner_id = :owner_id;`
 	for _, orgID := range orgIDs {
 		org := auth.Org{
 			ID:      orgID,
-			OwnerID: owner,
+			OwnerID: ownerID,
 		}
 		dbo, err := toDBOrg(org)
 		if err != nil {

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -560,7 +560,7 @@ func TestRemoveOrg(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		err := svc.RemoveOrg(context.Background(), tc.token, tc.id)
+		err := svc.RemoveOrgs(context.Background(), tc.token, tc.id)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }

--- a/auth/tracing/orgs.go
+++ b/auth/tracing/orgs.go
@@ -53,12 +53,12 @@ func (orm orgRepositoryMiddleware) Update(ctx context.Context, org auth.Org) err
 	return orm.repo.Update(ctx, org)
 }
 
-func (orm orgRepositoryMiddleware) Remove(ctx context.Context, owner, orgID string) error {
+func (orm orgRepositoryMiddleware) Remove(ctx context.Context, owner string, orgIDs ...string) error {
 	span := createSpan(ctx, orm.tracer, deleteOrg)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.Remove(ctx, owner, orgID)
+	return orm.repo.Remove(ctx, owner, orgIDs...)
 }
 
 func (orm orgRepositoryMiddleware) RetrieveByID(ctx context.Context, id string) (auth.Org, error) {

--- a/auth/tracing/orgs.go
+++ b/auth/tracing/orgs.go
@@ -53,12 +53,12 @@ func (orm orgRepositoryMiddleware) Update(ctx context.Context, org auth.Org) err
 	return orm.repo.Update(ctx, org)
 }
 
-func (orm orgRepositoryMiddleware) Remove(ctx context.Context, owner string, orgIDs ...string) error {
+func (orm orgRepositoryMiddleware) Remove(ctx context.Context, ownerID string, orgIDs ...string) error {
 	span := createSpan(ctx, orm.tracer, deleteOrg)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return orm.repo.Remove(ctx, owner, orgIDs...)
+	return orm.repo.Remove(ctx, ownerID, orgIDs...)
 }
 
 func (orm orgRepositoryMiddleware) RetrieveByID(ctx context.Context, id string) (auth.Org, error) {


### PR DESCRIPTION
PATCH endpoint `/orgs` accepting a list of `org_ids` in the request body

Resolves #766 