### PR TITLE
MF-368 - Restoring SenML messages from .csv file

### DIFF
--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
+	"io"
+	"strconv"
 
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
@@ -103,7 +105,7 @@ func deleteMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 			return nil, errors.ErrAuthentication
 		}
 
-		err :=  svc.DeleteMessages(ctx, req.pageMeta, table)
+		err := svc.DeleteMessages(ctx, req.pageMeta, table)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +151,12 @@ func restoreEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 			return nil, err
 		}
 
-		if err := svc.Restore(ctx, req.Messages...); err != nil {
+		messages, err := convertCSVToSenML(req.Messages)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+		}
+
+		if err := svc.Restore(ctx, messages...); err != nil {
 			return nil, err
 		}
 
@@ -177,10 +184,120 @@ func generateCSV(page readers.MessagesPage) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func convertCSVToSenML(csvMessages []byte) ([]senml.Message, error) {
+	reader := csv.NewReader(bytes.NewReader(csvMessages))
+
+	header, err := reader.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	expectedHeader := []string{
+		"profile",
+		"subtopic",
+		"publisher",
+		"protocol",
+		"name",
+		"unit",
+		"value",
+		"string_value",
+		"bool_value",
+		"data_value",
+		"sum",
+		"time",
+		"update_time",
+	}
+
+	if len(header) != len(expectedHeader) {
+		return nil, fmt.Errorf("invalid CSV header: expected %d fields, got %d", len(expectedHeader), len(header))
+	}
+
+	var messages []senml.Message
+
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if len(record) != len(expectedHeader) {
+			return nil, fmt.Errorf("invalid CSV record length: expected %d, got %d", len(expectedHeader), len(record))
+		}
+
+		msg := senml.Message{
+			Subtopic:  record[1],
+			Publisher: record[2],
+			Protocol:  record[3],
+			Name:      record[4],
+			Unit:      record[5],
+		}
+
+		if v := record[6]; v != "" {
+			val, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value at column 6: %w", err)
+			}
+			msg.Value = &val
+		}
+
+		if v := record[7]; v != "" {
+			msg.StringValue = &v
+		}
+
+		if v := record[8]; v != "" {
+			val, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid bool_value at column 8: %w", err)
+			}
+			msg.BoolValue = &val
+		}
+
+		if v := record[9]; v != "" {
+			msg.DataValue = &v
+		}
+
+		if v := record[10]; v != "" {
+			val, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid sum at column 10: %w", err)
+			}
+			msg.Sum = &val
+		}
+
+		if v := record[11]; v != "" {
+			val, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid time at column 11: %w", err)
+			}
+			msg.Time = val
+		}
+
+		if v := record[12]; v != "" {
+			val, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid update_time at column 12: %w", err)
+			}
+			msg.UpdateTime = val
+		}
+
+		messages = append(messages, msg)
+	}
+
+	if len(messages) == 0 {
+		return nil, errors.New("no messages found in CSV")
+	}
+
+	return messages, nil
+}
+
 func convertSenMLToCSV(page readers.MessagesPage, writer *csv.Writer) error {
 	for _, msg := range page.Messages {
 		if m, ok := msg.(senml.Message); ok {
 			row := []string{
+				"",
 				m.Subtopic,
 				m.Publisher,
 				m.Protocol,

--- a/readers/api/requests.go
+++ b/readers/api/requests.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/transformers/senml"
 	"github.com/MainfluxLabs/mainflux/readers"
 )
 
@@ -44,7 +43,7 @@ func (req listAllMessagesReq) validate() error {
 
 type restoreMessagesReq struct {
 	token    string
-	Messages []senml.Message `json:"messages"`
+	Messages []byte
 }
 
 func (req restoreMessagesReq) validate() error {


### PR DESCRIPTION
This small PR changes messages restoring logic. Now you can restore SenML messages with a simple request:

`curl -X POST "http://localhost/reader/restore" \
  -H "Authorization: Bearer <token> \
  -H "Content-Type: application/json" \
  --data-binary @backup.csv
`

Resolves #368 