### PR TITLE
NOISSUE - Idiomatic return in users:emailer.New

### DIFF
--- a/users/emailer/emailer.go
+++ b/users/emailer/emailer.go
@@ -20,11 +20,15 @@ type emailer struct {
 // New creates new emailer utility
 func New(resetURL, emailVerifyURL string, c *email.Config) (users.Emailer, error) {
 	e, err := email.New(c)
+	if err != nil {
+		return nil, err
+	}
+
 	return &emailer{
 		resetURL:       resetURL,
 		emailVerifyURL: emailVerifyURL,
 		agent:          e,
-	}, err
+	}, nil
 }
 
 func (e *emailer) SendPasswordReset(To []string, host string, token string) error {


### PR DESCRIPTION
Previously, if obtaining an emailer Agent failed, we returned a partially-initialized instance of `emailer` and a propagated error from `email.New(...)`. I thought this was fine because, from the caller's point of view the non-nil error signifies that the return value is not valid, but the most idiomatic (and safest) thing to do here is to return `nil` instead.