### PR TITLE
MF-790 - Asynchronously send e-mails from service methods

### DIFF
--- a/users/emailer/logging.go
+++ b/users/emailer/logging.go
@@ -1,0 +1,48 @@
+package emailer
+
+import (
+	"fmt"
+	"time"
+
+	log "github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/users"
+)
+
+type loggingMiddleware struct {
+	emailer users.Emailer
+	logger  log.Logger
+}
+
+var _ users.Emailer = (*loggingMiddleware)(nil)
+
+func LoggingMiddleware(e users.Emailer, logger log.Logger) users.Emailer {
+	return &loggingMiddleware{e, logger}
+}
+
+func (lm *loggingMiddleware) SendPasswordReset(To []string, redirectPath, token string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Emailer method send_password_reset took %s to complete", time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+
+	}(time.Now())
+
+	return lm.emailer.SendPasswordReset(To, redirectPath, token)
+}
+
+func (lm *loggingMiddleware) SendEmailVerification(To []string, redirectPath, token string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Emailer method send_email_verification took %s to complete", time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+
+	}(time.Now())
+
+	return lm.emailer.SendEmailVerification(To, redirectPath, token)
+}

--- a/users/emailer/metrics.go
+++ b/users/emailer/metrics.go
@@ -1,0 +1,43 @@
+package emailer
+
+import (
+	"time"
+
+	"github.com/MainfluxLabs/mainflux/users"
+	"github.com/go-kit/kit/metrics"
+)
+
+var _ users.Emailer = (*metricsMiddleware)(nil)
+
+type metricsMiddleware struct {
+	counter metrics.Counter
+	latency metrics.Histogram
+	emailer users.Emailer
+}
+
+// MetricsMiddleware instruments core service by tracking request count and latency.
+func MetricsMiddleware(emailer users.Emailer, counter metrics.Counter, latency metrics.Histogram) users.Emailer {
+	return &metricsMiddleware{
+		counter: counter,
+		latency: latency,
+		emailer: emailer,
+	}
+}
+
+func (ms *metricsMiddleware) SendPasswordReset(To []string, redirectPath, token string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "send_password_reset").Add(1)
+		ms.latency.With("method", "send_password_reset").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.emailer.SendPasswordReset(To, redirectPath, token)
+}
+
+func (ms *metricsMiddleware) SendEmailVerification(To []string, redirectPath, token string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "send_email_verification").Add(1)
+		ms.latency.With("method", "send_email_verification").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.emailer.SendEmailVerification(To, redirectPath, token)
+}


### PR DESCRIPTION
Addresses #790 by calling e-mail related methods from goroutines from within service methods.

However, I've got a question. As we're no longer propagating errors from e-mail related methods *outside* of the service methods that call them (because they're now called from goroutines), the HTTP logging middleware doesn't pick up on potential errors and sending emails can fail "silently" -- see for example [here](https://github.com/bool3max/mainflux/blob/8fca1883a98c702555f5e276b91013b12e8f08be/users/service.go#L501): the `error` return value from `svc.SendPasswordReset` never makes it out of `GenerateResetToken`.

One potential solution is to employ a "logging middleware", similar to that used by HTTP API handlers and services, but for the [`Emailer`](https://github.com/bool3max/mainflux/blob/8fca1883a98c702555f5e276b91013b12e8f08be/users/emailer.go#L7). 

Another slightly simpler one is to make the [concrete implementation of `Emailer`](https://github.com/bool3max/mainflux/blob/8fca1883a98c702555f5e276b91013b12e8f08be/users/emailer/emailer.go#L20) accept a `logger` and let it log errors from its methods, itself.

Thoughts?