### PR TITLE
MF-703 - Update rules_2 migration

### DIFF
--- a/rules/postgres/init.go
+++ b/rules/postgres/init.go
@@ -64,6 +64,9 @@ func migrateDB(db *sqlx.DB) error {
 				Up: []string{
 					`ALTER TABLE rules RENAME COLUMN condition TO conditions`,
 					`ALTER TABLE rules ADD COLUMN operator VARCHAR(3) NOT NULL DEFAULT ''`,
+					`UPDATE rules
+					 SET conditions = jsonb_build_array(jsonb_set(conditions, '{comparator}', conditions->'operator') - 'operator')
+					 WHERE jsonb_typeof(conditions) = 'object'`,
 				},
 			},
 		},

--- a/rules/postgres/init.go
+++ b/rules/postgres/init.go
@@ -63,7 +63,7 @@ func migrateDB(db *sqlx.DB) error {
 				Id: "rules_2",
 				Up: []string{
 					`ALTER TABLE rules RENAME COLUMN condition TO conditions`,
-					`ALTER TABLE rules ADD COLUMN operator VARCHAR(3) NOT NULL`,
+					`ALTER TABLE rules ADD COLUMN operator VARCHAR(3) NOT NULL DEFAULT ''`,
 				},
 			},
 		},


### PR DESCRIPTION
Migration fix: set default for operator and convert legacy condition object to array with comparator

Related to #703 