### PR TITLE
NOISSUE - Empty array and returning the correct total for aggregations

### DIFF
--- a/readers/api/responses.go
+++ b/readers/api/responses.go
@@ -18,7 +18,7 @@ var (
 type listMessagesRes struct {
 	readers.PageMetadata
 	Total    uint64            `json:"total"`
-	Messages []readers.Message `json:"messages,omitempty"`
+	Messages []readers.Message `json:"messages"`
 }
 
 func (res listMessagesRes) Headers() map[string]string {

--- a/readers/postgres/aggregations.go
+++ b/readers/postgres/aggregations.go
@@ -82,6 +82,7 @@ func (as *aggregationService) readAggregatedMessages(rpm readers.PageMetadata) (
 	if err != nil {
 		return nil, err
 	}
+
 	if rows == nil {
 		return []readers.Message{}, nil
 	}
@@ -305,23 +306,21 @@ func (countStrt CountStrategy) GetSelectedFields(config QueryConfig) string {
 func (countStrt CountStrategy) GetAggregateExpression(config QueryConfig) string {
 	switch config.Format {
 	case defTable:
-		return fmt.Sprintf("SUM(m.%s)", config.AggField)
+		return fmt.Sprintf("COUNT(m.%s)", config.AggField)
 	default:
 		jsonPath := buildJSONPath(config.AggField)
-		return fmt.Sprintf("SUM(CAST(m.%s AS float))", jsonPath)
+		return fmt.Sprintf("COUNT(m.%s)", jsonPath)
 	}
 }
 
 func buildTimeIntervals(config QueryConfig) string {
 	return fmt.Sprintf(`
-		SELECT generate_series(
-			date_trunc('%s', NOW() - interval '%d %s'),
-			date_trunc('%s', NOW()),
-			interval '1 %s'
-		) as interval_time
-		ORDER BY interval_time DESC
-		LIMIT %d`,
-		config.AggInterval, config.Limit, config.AggInterval, config.AggInterval, config.AggInterval, config.Limit)
+        SELECT DISTINCT date_trunc('%s', to_timestamp(%s / 1000000000)) as interval_time
+        FROM %s 
+        %s
+        ORDER BY interval_time DESC
+        LIMIT %d`,
+		config.AggInterval, config.TimeColumn, config.Format, config.Condition, config.Limit)
 }
 
 func buildTimeJoinCondition(config QueryConfig, tableAlias string) string {
@@ -337,6 +336,39 @@ func buildValueCondition(config QueryConfig) string {
 		jsonPath := buildJSONPath(config.AggField)
 		return fmt.Sprintf("CAST(m.%s as FLOAT) = ia.agg_value", jsonPath)
 	}
+}
+
+func (as *aggregationService) readAggregatedCount(rpm readers.PageMetadata) (uint64, error) {
+	params := as.buildQueryParams(rpm)
+
+	timeColumn := as.getTimeColumn(rpm.Format)
+	baseCondition := as.buildBaseCondition(rpm)
+	nameCondition := as.buildNameCondition(rpm)
+	condition := as.combineConditions(baseCondition, nameCondition)
+
+	query := fmt.Sprintf(`
+        SELECT COUNT(DISTINCT date_trunc('%s', to_timestamp(%s / 1000000000)))
+        FROM %s
+        %s`,
+		rpm.AggInterval, timeColumn, rpm.Format, condition)
+
+	rows, err := as.db.NamedQuery(query, params)
+	if err != nil {
+		if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code == pgerrcode.UndefinedTable {
+			return 0, nil
+		}
+		return 0, errors.Wrap(readers.ErrReadMessages, err)
+	}
+	defer rows.Close()
+
+	var total uint64
+	if rows.Next() {
+		if err := rows.Scan(&total); err != nil {
+			return 0, err
+		}
+	}
+
+	return total, nil
 }
 
 func (as *aggregationService) buildNameCondition(rpm readers.PageMetadata) string {

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -173,10 +173,6 @@ func (tr postgresRepository) readAll(rpm readers.PageMetadata) (readers.Messages
 			return page, err
 		}
 
-		if messages == nil {
-			messages = []readers.Message{}
-		}
-
 		page.Messages = messages
 
 		total, err := tr.aggregator.readAggregatedCount(rpm)

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -178,7 +178,12 @@ func (tr postgresRepository) readAll(rpm readers.PageMetadata) (readers.Messages
 		}
 
 		page.Messages = messages
-		page.Total = uint64(len(messages))
+
+		total, err := tr.aggregator.readAggregatedCount(rpm)
+		if err != nil {
+			return page, err
+		}
+		page.Total = total
 		return page, nil
 	}
 

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -172,13 +172,13 @@ func (tr postgresRepository) readAll(rpm readers.PageMetadata) (readers.Messages
 		if err != nil {
 			return page, err
 		}
-		page.Messages = messages
 
-		total, err := tr.readCount(rpm, format, order, params)
-		if err != nil {
-			return page, err
+		if messages == nil {
+			messages = []readers.Message{}
 		}
-		page.Total = total
+
+		page.Messages = messages
+		page.Total = uint64(len(messages))
 		return page, nil
 	}
 


### PR DESCRIPTION
This small PR adds a new default return on aggregation requests:
`{
  "offset": 0,
  "limit": 2,
  "publisher": "d9069ec3-93b6-49ad-85b4-440babcde080",
  "name": "badname",
  "format": "messages",
  "agg_interval": "hour",
  "agg_type": "count",
  "total": 0,
  "messages": []
}`