### PR TITLE
MF-803 - Fix permission check in svc.ViewUser

### DIFF
--- a/users/service.go
+++ b/users/service.go
@@ -352,8 +352,15 @@ func (svc usersService) Login(ctx context.Context, user User) (string, error) {
 }
 
 func (svc usersService) ViewUser(ctx context.Context, token, id string) (User, error) {
-	if _, err := svc.identify(ctx, token); err != nil {
+	currentUser, err := svc.identify(ctx, token)
+	if err != nil {
 		return User{}, err
+	}
+
+	if err := svc.isAdmin(ctx, token); err != nil {
+		if currentUser.id != id {
+			return User{}, errors.ErrAuthorization
+		}
 	}
 
 	dbUser, err := svc.users.RetrieveByID(ctx, id)

--- a/users/service.go
+++ b/users/service.go
@@ -352,13 +352,13 @@ func (svc usersService) Login(ctx context.Context, user User) (string, error) {
 }
 
 func (svc usersService) ViewUser(ctx context.Context, token, id string) (User, error) {
-	currentUser, err := svc.identify(ctx, token)
+	user, err := svc.identify(ctx, token)
 	if err != nil {
 		return User{}, err
 	}
 
 	if err := svc.isAdmin(ctx, token); err != nil {
-		if currentUser.id != id {
+		if user.id != id {
 			return User{}, errors.ErrAuthorization
 		}
 	}

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -203,11 +203,11 @@ func TestViewUser(t *testing.T) {
 			userID: registerUser.ID,
 			err:    errors.ErrAuthentication,
 		},
-		"view user with valid token and invalid user id": {
+		"view user as unauthorized user": {
 			user:   users.User{},
 			token:  token,
-			userID: "",
-			err:    errors.ErrNotFound,
+			userID: registerUser.ID,
+			err:    errors.ErrAuthorization,
 		},
 	}
 


### PR DESCRIPTION
Simple. Fixes #803. To view a specific user's profile, the user making the request must be authenticated as either the Root Admin or as the user whose profile they're trying to view.