### PR TITLE
MF-802 - Disable self-register at runtime in users service

### DIFF
--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -316,7 +316,7 @@ func newService(db *sqlx.DB, tracer opentracing.Tracer, ac protomfx.AuthServiceC
 
 	idProvider := uuid.New()
 
-	svc := users.New(userRepo, verificationRepo, c.emailVerifyEnabled, hasher, ac, svcEmailer, idProvider)
+	svc := users.New(userRepo, verificationRepo, c.emailVerifyEnabled, c.selfRegisterEnabled, hasher, ac, svcEmailer, idProvider)
 	svc = httpapi.LoggingMiddleware(svc, logger)
 	svc = httpapi.MetricsMiddleware(
 		svc,

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -50,7 +50,7 @@ func newUserService() users.Service {
 	auth := mocks.NewAuthService(admin.ID, usersList, orgsList)
 	emailer := usmocks.NewEmailer()
 
-	return users.New(usersRepo, verificationsRepo, true, hasher, auth, emailer, idProvider)
+	return users.New(usersRepo, verificationsRepo, true, true, hasher, auth, emailer, idProvider)
 }
 
 func newUserServer(svc users.Service) *httptest.Server {

--- a/users/api/http/endpoint_test.go
+++ b/users/api/http/endpoint_test.go
@@ -145,7 +145,7 @@ func newService() users.Service {
 	hasher := usmocks.NewHasher()
 	auth := mocks.NewAuthService(admin.ID, usersList, nil)
 	email := usmocks.NewEmailer()
-	return users.New(usersRepo, verificationsRepo, true, hasher, auth, email, idProvider)
+	return users.New(usersRepo, verificationsRepo, true, true, hasher, auth, email, idProvider)
 }
 
 func newServer(svc users.Service) *httptest.Server {

--- a/users/api/http/transport.go
+++ b/users/api/http/transport.go
@@ -448,7 +448,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		errors.Contains(err, users.ErrRecoveryToken):
 		w.WriteHeader(http.StatusInternalServerError)
 	case errors.Contains(err, users.ErrSelfRegisterDisabled):
-		w.WriteHeader(http.StatusNotImplemented)
+		w.WriteHeader(http.StatusForbidden)
 	default:
 		apiutil.EncodeError(err, w)
 	}

--- a/users/api/http/transport.go
+++ b/users/api/http/transport.go
@@ -447,6 +447,8 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	case errors.Contains(err, uuid.ErrGeneratingID),
 		errors.Contains(err, users.ErrRecoveryToken):
 		w.WriteHeader(http.StatusInternalServerError)
+	case errors.Contains(err, users.ErrSelfRegisterDisabled):
+		w.WriteHeader(http.StatusNotImplemented)
 	default:
 		apiutil.EncodeError(err, w)
 	}

--- a/users/service.go
+++ b/users/service.go
@@ -36,6 +36,9 @@ var (
 
 	// ErrEmailVerificationExpired indicates that the e-mail verification token has expired.
 	ErrEmailVerificationExpired = errors.New("e-mail verification token expired")
+
+	// ErrSelfRegisterDisabled indicates that self-registration is disabled in the service config.
+	ErrSelfRegisterDisabled = errors.New("self register disabled")
 )
 
 // Service specifies an API that must be fulfilled by the domain service
@@ -133,29 +136,35 @@ type UserPage struct {
 var _ Service = (*usersService)(nil)
 
 type usersService struct {
-	users              UserRepository
-	emailVerifications EmailVerificationRepository
-	emailVerifyEnabled bool
-	hasher             Hasher
-	email              Emailer
-	auth               protomfx.AuthServiceClient
-	idProvider         uuid.IDProvider
+	users               UserRepository
+	emailVerifications  EmailVerificationRepository
+	emailVerifyEnabled  bool
+	selfRegisterEnabled bool
+	hasher              Hasher
+	email               Emailer
+	auth                protomfx.AuthServiceClient
+	idProvider          uuid.IDProvider
 }
 
 // New instantiates the users service implementation
-func New(users UserRepository, verifications EmailVerificationRepository, emailVerifyEnabled bool, hasher Hasher, auth protomfx.AuthServiceClient, e Emailer, idp uuid.IDProvider) Service {
+func New(users UserRepository, verifications EmailVerificationRepository, emailVerifyEnabled bool, selfRegisterEnabled bool, hasher Hasher, auth protomfx.AuthServiceClient, e Emailer, idp uuid.IDProvider) Service {
 	return &usersService{
-		users:              users,
-		emailVerifications: verifications,
-		emailVerifyEnabled: emailVerifyEnabled,
-		hasher:             hasher,
-		auth:               auth,
-		email:              e,
-		idProvider:         idp,
+		users:               users,
+		emailVerifications:  verifications,
+		emailVerifyEnabled:  emailVerifyEnabled,
+		selfRegisterEnabled: selfRegisterEnabled,
+		hasher:              hasher,
+		auth:                auth,
+		email:               e,
+		idProvider:          idp,
 	}
 }
 
 func (svc usersService) SelfRegister(ctx context.Context, user User, redirectPath string) (string, error) {
+	if !svc.selfRegisterEnabled {
+		return "", ErrSelfRegisterDisabled
+	}
+
 	_, err := svc.users.RetrieveByEmail(ctx, user.Email)
 	if err != nil && !errors.Contains(err, errors.ErrNotFound) {
 		return "", err

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -69,7 +69,7 @@ func newService() users.Service {
 	authSvc := mocks.NewAuthService(admin.ID, usersList, nil)
 	e := usmocks.NewEmailer()
 
-	return users.New(userRepo, verificationRepo, true, hasher, authSvc, e, idProvider)
+	return users.New(userRepo, verificationRepo, true, true, hasher, authSvc, e, idProvider)
 }
 
 func TestSelfRegister(t *testing.T) {


### PR DESCRIPTION
Fixes #802 by passing the `selfRegisterEnabled` config flag to the users service, and checking for its value in the `SelfRegister` service method, in which case it returns `ErrSelfRegisterDisabled`, which gets encoded as a `501 Not Implemented` HTTP status code.