### PR TITLE
MF-811 - Move database layer errors to pkg/dbutil

### DIFF
--- a/auth/api/http/keys/transport.go
+++ b/auth/api/http/keys/transport.go
@@ -12,6 +12,7 @@ import (
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
@@ -96,9 +97,9 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	case errors.Contains(err, errors.ErrAuthentication),
 		err == apiutil.ErrBearerToken:
 		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, errors.ErrNotFound):
+	case errors.Contains(err, dbutil.ErrNotFound):
 		w.WriteHeader(http.StatusNotFound)
-	case errors.Contains(err, errors.ErrConflict):
+	case errors.Contains(err, dbutil.ErrConflict):
 		w.WriteHeader(http.StatusConflict)
 	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
 		w.WriteHeader(http.StatusUnsupportedMediaType)

--- a/auth/jwt/tokenizer.go
+++ b/auth/jwt/tokenizer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/golang-jwt/jwt/v4"
 )
@@ -21,7 +22,7 @@ type claims struct {
 
 func (c claims) Valid() error {
 	if c.Type == nil || *c.Type > auth.APIKey || c.Issuer != issuerName {
-		return errors.ErrMalformedEntity
+		return dbutil.ErrMalformedEntity
 	}
 
 	return c.StandardClaims.Valid()

--- a/auth/jwt/tokenizer.go
+++ b/auth/jwt/tokenizer.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux/auth"
-	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/golang-jwt/jwt/v4"
 )
@@ -22,7 +22,7 @@ type claims struct {
 
 func (c claims) Valid() error {
 	if c.Type == nil || *c.Type > auth.APIKey || c.Issuer != issuerName {
-		return dbutil.ErrMalformedEntity
+		return apiutil.ErrMalformedEntity
 	}
 
 	return c.StandardClaims.Valid()

--- a/auth/mocks/keys.go
+++ b/auth/mocks/keys.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/MainfluxLabs/mainflux/auth"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 )
 
 var _ auth.KeyRepository = (*keyRepositoryMock)(nil)
@@ -30,7 +30,7 @@ func (krm *keyRepositoryMock) Save(ctx context.Context, key auth.Key) (string, e
 	defer krm.mu.Unlock()
 
 	if _, ok := krm.keys[key.ID]; ok {
-		return "", errors.ErrConflict
+		return "", dbutil.ErrConflict
 	}
 
 	krm.keys[key.ID] = key
@@ -44,7 +44,7 @@ func (krm *keyRepositoryMock) Retrieve(ctx context.Context, issuerID, id string)
 		return key, nil
 	}
 
-	return auth.Key{}, errors.ErrNotFound
+	return auth.Key{}, dbutil.ErrNotFound
 }
 func (krm *keyRepositoryMock) Remove(ctx context.Context, issuerID, id string) error {
 	krm.mu.Lock()

--- a/auth/mocks/memberships.go
+++ b/auth/mocks/memberships.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 )
 
@@ -32,7 +32,7 @@ func (mrm *orgMembershipsRepositoryMock) Save(_ context.Context, oms ...auth.Org
 
 	for _, om := range oms {
 		if om.OrgID == "" {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 
 		m := auth.OrgMembership{
@@ -54,11 +54,11 @@ func (mrm *orgMembershipsRepositoryMock) Remove(_ context.Context, orgID string,
 
 	for _, memberID := range memberIDs {
 		if _, ok := mrm.memberships[memberID]; !ok {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 
 		if _, ok := mrm.membershipsByOrgID[orgID]; !ok {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 
 		delete(mrm.memberships, memberID)
@@ -73,7 +73,7 @@ func (mrm *orgMembershipsRepositoryMock) Update(_ context.Context, oms ...auth.O
 
 	for _, om := range oms {
 		if _, ok := mrm.memberships[om.MemberID]; !ok {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 		mrm.memberships[om.MemberID] = []auth.OrgMembership{
 			{
@@ -98,7 +98,7 @@ func (mrm *orgMembershipsRepositoryMock) RetrieveRole(_ context.Context, memberI
 		}
 	}
 
-	return "", errors.ErrNotFound
+	return "", dbutil.ErrNotFound
 }
 
 func (mrm *orgMembershipsRepositoryMock) RetrieveByOrg(_ context.Context, orgID string, pm apiutil.PageMetadata) (auth.OrgMembershipsPage, error) {

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 )
@@ -35,7 +35,7 @@ func (orm *orgRepositoryMock) Save(_ context.Context, orgs ...auth.Org) error {
 
 	for _, org := range orgs {
 		if _, ok := orm.orgs[org.ID]; ok {
-			return errors.ErrConflict
+			return dbutil.ErrConflict
 		}
 
 		orm.orgs[org.ID] = org
@@ -49,7 +49,7 @@ func (orm *orgRepositoryMock) Update(_ context.Context, org auth.Org) error {
 	defer orm.mu.Unlock()
 
 	if _, ok := orm.orgs[org.ID]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 
 	orm.orgs[org.ID] = org
@@ -63,7 +63,7 @@ func (orm *orgRepositoryMock) Remove(_ context.Context, ownerID string, ids ...s
 
 	for _, id := range ids {
 		if _, ok := orm.orgs[id]; !ok && orm.orgs[id].OwnerID != ownerID {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 		delete(orm.orgs, id)
 	}
@@ -77,7 +77,7 @@ func (orm *orgRepositoryMock) RetrieveByID(_ context.Context, id string) (auth.O
 
 	org, ok := orm.orgs[id]
 	if !ok {
-		return auth.Org{}, errors.ErrNotFound
+		return auth.Org{}, dbutil.ErrNotFound
 	}
 
 	return org, nil

--- a/auth/mocks/roles.go
+++ b/auth/mocks/roles.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/MainfluxLabs/mainflux/auth"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 )
 
 type rolesRepositoryMock struct {
@@ -44,7 +44,7 @@ func (rrm *rolesRepositoryMock) UpdateRole(ctx context.Context, id, role string)
 	defer rrm.mu.Unlock()
 
 	if _, ok := rrm.roles[id]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 
 	rrm.roles[id] = role
@@ -57,7 +57,7 @@ func (rrm *rolesRepositoryMock) RemoveRole(ctx context.Context, id string) error
 	defer rrm.mu.Unlock()
 
 	if _, ok := rrm.roles[id]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 
 	delete(rrm.roles, id)

--- a/auth/postgres/key.go
+++ b/auth/postgres/key.go
@@ -33,10 +33,10 @@ func (kr repo) Save(ctx context.Context, key auth.Key) (string, error) {
 	if _, err := kr.db.NamedExecContext(ctx, q, dbKey); err != nil {
 
 		if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code == pgerrcode.UniqueViolation {
-			return "", errors.Wrap(errors.ErrConflict, err)
+			return "", errors.Wrap(dbutil.ErrConflict, err)
 		}
 
-		return "", errors.Wrap(errors.ErrCreateEntity, err)
+		return "", errors.Wrap(dbutil.ErrCreateEntity, err)
 	}
 
 	return dbKey.ID, nil
@@ -48,10 +48,10 @@ func (kr repo) Retrieve(ctx context.Context, issuerID, id string) (auth.Key, err
 	if err := kr.db.QueryRowxContext(ctx, q, issuerID, id).StructScan(&key); err != nil {
 		pgErr, ok := err.(*pgconn.PgError)
 		if err == sql.ErrNoRows || ok && pgerrcode.InvalidTextRepresentation == pgErr.Code {
-			return auth.Key{}, errors.Wrap(errors.ErrNotFound, err)
+			return auth.Key{}, errors.Wrap(dbutil.ErrNotFound, err)
 		}
 
-		return auth.Key{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return auth.Key{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
 	return toKey(key), nil
@@ -64,7 +64,7 @@ func (kr repo) Remove(ctx context.Context, issuerID, id string) error {
 		IssuerID: issuerID,
 	}
 	if _, err := kr.db.NamedExecContext(ctx, q, key); err != nil {
-		return errors.Wrap(errors.ErrRemoveEntity, err)
+		return errors.Wrap(dbutil.ErrRemoveEntity, err)
 	}
 
 	return nil

--- a/auth/postgres/key_test.go
+++ b/auth/postgres/key_test.go
@@ -58,7 +58,7 @@ func TestKeySave(t *testing.T) {
 				ID:        id,
 				IssuerID:  id,
 			},
-			err: errors.ErrConflict,
+			err: dbutil.ErrConflict,
 		},
 	}
 
@@ -100,13 +100,13 @@ func TestKeyRetrieve(t *testing.T) {
 			desc:  "retrieve key with empty issuer id",
 			id:    key.ID,
 			owner: "",
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "retrieve non-existent key",
 			id:    "",
 			owner: key.IssuerID,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 

--- a/auth/postgres/memberships.go
+++ b/auth/postgres/memberships.go
@@ -85,10 +85,10 @@ func (omr orgMembershipsRepository) RetrieveRole(ctx context.Context, memberID, 
 	if err := omr.db.QueryRowxContext(ctx, q, memberID, orgID).StructScan(&membership); err != nil {
 		pgErr, ok := err.(*pgconn.PgError)
 		if err == sql.ErrNoRows || ok && pgerrcode.InvalidTextRepresentation == pgErr.Code {
-			return "", errors.Wrap(errors.ErrNotFound, err)
+			return "", errors.Wrap(dbutil.ErrNotFound, err)
 		}
 
-		return "", errors.Wrap(errors.ErrRetrieveEntity, err)
+		return "", errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
 	return membership.Role, nil
@@ -112,9 +112,9 @@ func (omr orgMembershipsRepository) Save(ctx context.Context, oms ...auth.OrgMem
 			if ok {
 				switch pgErr.Code {
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrMalformedEntity, err)
+					return errors.Wrap(dbutil.ErrMalformedEntity, err)
 				case pgerrcode.ForeignKeyViolation:
-					return errors.Wrap(errors.ErrConflict, errors.New(pgErr.Detail))
+					return errors.Wrap(dbutil.ErrConflict, errors.New(pgErr.Detail))
 				case pgerrcode.UniqueViolation:
 					return errors.Wrap(auth.ErrOrgMembershipExists, errors.New(pgErr.Detail))
 				}
@@ -152,9 +152,9 @@ func (omr orgMembershipsRepository) Remove(ctx context.Context, orgID string, id
 			if ok {
 				switch pgErr.Code {
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrMalformedEntity, err)
+					return errors.Wrap(dbutil.ErrMalformedEntity, err)
 				case pgerrcode.UniqueViolation:
-					return errors.Wrap(errors.ErrConflict, err)
+					return errors.Wrap(dbutil.ErrConflict, err)
 				}
 			}
 
@@ -182,22 +182,22 @@ func (omr orgMembershipsRepository) Update(ctx context.Context, oms ...auth.OrgM
 			if ok {
 				switch pgErr.Code {
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrMalformedEntity, err)
+					return errors.Wrap(dbutil.ErrMalformedEntity, err)
 				case pgerrcode.StringDataRightTruncationDataException:
-					return errors.Wrap(errors.ErrMalformedEntity, err)
+					return errors.Wrap(dbutil.ErrMalformedEntity, err)
 				}
 			}
 
-			return errors.Wrap(errors.ErrUpdateEntity, err)
+			return errors.Wrap(dbutil.ErrUpdateEntity, err)
 		}
 
 		cnt, errdb := row.RowsAffected()
 		if errdb != nil {
-			return errors.Wrap(errors.ErrUpdateEntity, errdb)
+			return errors.Wrap(dbutil.ErrUpdateEntity, errdb)
 		}
 
 		if cnt != 1 {
-			return errors.Wrap(errors.ErrNotFound, err)
+			return errors.Wrap(dbutil.ErrNotFound, err)
 		}
 	}
 
@@ -209,7 +209,7 @@ func (omr orgMembershipsRepository) BackupAll(ctx context.Context) ([]auth.OrgMe
 
 	rows, err := omr.db.NamedQueryContext(ctx, q, map[string]interface{}{})
 	if err != nil {
-		return []auth.OrgMembership{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return []auth.OrgMembership{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 	defer rows.Close()
 
@@ -217,7 +217,7 @@ func (omr orgMembershipsRepository) BackupAll(ctx context.Context) ([]auth.OrgMe
 	for rows.Next() {
 		dbom := dbOrgMembership{}
 		if err := rows.StructScan(&dbom); err != nil {
-			return []auth.OrgMembership{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+			return []auth.OrgMembership{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
 
 		oms = append(oms, toOrgMembership(dbom))
@@ -233,7 +233,7 @@ func (omr orgMembershipsRepository) BackupByOrg(ctx context.Context, orgID strin
 		"org_id": orgID,
 	})
 	if err != nil {
-		return []auth.OrgMembership{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return []auth.OrgMembership{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 	defer rows.Close()
 
@@ -241,7 +241,7 @@ func (omr orgMembershipsRepository) BackupByOrg(ctx context.Context, orgID strin
 	for rows.Next() {
 		dbom := dbOrgMembership{}
 		if err := rows.StructScan(&dbom); err != nil {
-			return []auth.OrgMembership{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+			return []auth.OrgMembership{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
 
 		oms = append(oms, toOrgMembership(dbom))

--- a/auth/postgres/memberships_test.go
+++ b/auth/postgres/memberships_test.go
@@ -98,22 +98,22 @@ func TestSaveOrgMemberships(t *testing.T) {
 		{
 			desc:           "create org memberships with invalid org id",
 			orgMemberships: invalidOrgIDmRel,
-			err:            errors.ErrMalformedEntity,
+			err:            dbutil.ErrMalformedEntity,
 		},
 		{
 			desc:           "create org memberships without org id",
 			orgMemberships: emptyOrgData,
-			err:            errors.ErrMalformedEntity,
+			err:            dbutil.ErrMalformedEntity,
 		},
 		{
 			desc:           "create org memberships with empty member ids",
 			orgMemberships: noMembershipData,
-			err:            errors.ErrMalformedEntity,
+			err:            dbutil.ErrMalformedEntity,
 		},
 		{
 			desc:           "create org memberships with invalid member ids",
 			orgMemberships: invalidMembershipData,
-			err:            errors.ErrMalformedEntity,
+			err:            dbutil.ErrMalformedEntity,
 		},
 	}
 
@@ -175,13 +175,13 @@ func TestRemoveOrgMemberships(t *testing.T) {
 			desc:      "remove org memberships with invalid org id",
 			orgID:     invalidID,
 			memberIDs: memberIDs,
-			err:       errors.ErrMalformedEntity,
+			err:       dbutil.ErrMalformedEntity,
 		},
 		{
 			desc:      "remove org memberships without org id",
 			orgID:     "",
 			memberIDs: memberIDs,
-			err:       errors.ErrMalformedEntity,
+			err:       dbutil.ErrMalformedEntity,
 		},
 		{
 			desc:      "remove org memberships without member IDs",
@@ -193,7 +193,7 @@ func TestRemoveOrgMemberships(t *testing.T) {
 			desc:      "remove org memberships with invalid member id",
 			orgID:     orgID,
 			memberIDs: []string{invalidID},
-			err:       errors.ErrMalformedEntity,
+			err:       dbutil.ErrMalformedEntity,
 		},
 
 		{
@@ -387,27 +387,27 @@ func TestUpdateOrgMemberships(t *testing.T) {
 		}, {
 			desc:          "update membership with invalid org id",
 			orgMembership: invalidOrgData,
-			err:           errors.ErrMalformedEntity,
+			err:           dbutil.ErrMalformedEntity,
 		}, {
 			desc:          "update membership with unknown org id",
 			orgMembership: unknownOrgData,
-			err:           errors.ErrNotFound,
+			err:           dbutil.ErrNotFound,
 		}, {
 			desc:          "update membership without org id",
 			orgMembership: emptyOrgData,
-			err:           errors.ErrMalformedEntity,
+			err:           dbutil.ErrMalformedEntity,
 		}, {
 			desc:          "update membership with invalid member id",
 			orgMembership: invalidMembershipData,
-			err:           errors.ErrMalformedEntity,
+			err:           dbutil.ErrMalformedEntity,
 		}, {
 			desc:          "update membership with unknown member id",
 			orgMembership: unknownMembershipData,
-			err:           errors.ErrNotFound,
+			err:           dbutil.ErrNotFound,
 		}, {
 			desc:          "update membership with empty member",
 			orgMembership: emptyMembershipData,
-			err:           errors.ErrMalformedEntity,
+			err:           dbutil.ErrMalformedEntity,
 		},
 	}
 

--- a/auth/postgres/orgs_test.go
+++ b/auth/postgres/orgs_test.go
@@ -63,17 +63,17 @@ func TestSave(t *testing.T) {
 		{
 			desc: "save org with invalid owner id",
 			org:  invalidOwnerOrg,
-			err:  errors.ErrMalformedEntity,
+			err:  dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "save org with invalid org id",
 			org:  invalidIDOrg,
-			err:  errors.ErrMalformedEntity,
+			err:  dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "save empty org",
 			org:  auth.Org{},
-			err:  errors.ErrMalformedEntity,
+			err:  dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "save org",
@@ -83,7 +83,7 @@ func TestSave(t *testing.T) {
 		{
 			desc: "save existing org",
 			org:  org,
-			err:  errors.ErrConflict,
+			err:  dbutil.ErrConflict,
 		},
 	}
 
@@ -143,12 +143,12 @@ func TestUpdate(t *testing.T) {
 		{
 			desc: "update org with invalid org id",
 			org:  invalidIDOrg,
-			err:  errors.ErrMalformedEntity,
+			err:  dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "update with empty org",
 			org:  auth.Org{},
-			err:  errors.ErrMalformedEntity,
+			err:  dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "update org",
@@ -195,25 +195,25 @@ func TestDelete(t *testing.T) {
 			desc:    "remove org with invalid org id",
 			orgID:   invalidID,
 			ownerID: ownerID,
-			err:     errors.ErrMalformedEntity,
+			err:     dbutil.ErrMalformedEntity,
 		},
 		{
 			desc:    "remove org with unknown org id",
 			orgID:   unknownID,
 			ownerID: ownerID,
-			err:     errors.ErrRemoveEntity,
+			err:     dbutil.ErrRemoveEntity,
 		},
 		{
 			desc:    "remove org with invalid owner id",
 			orgID:   orgID,
 			ownerID: invalidID,
-			err:     errors.ErrMalformedEntity,
+			err:     dbutil.ErrMalformedEntity,
 		},
 		{
 			desc:    "remove org with unknown owner id",
 			orgID:   orgID,
 			ownerID: unknownID,
-			err:     errors.ErrRemoveEntity,
+			err:     dbutil.ErrRemoveEntity,
 		},
 		{
 			desc:    "remove org",
@@ -225,7 +225,7 @@ func TestDelete(t *testing.T) {
 			desc:    "remove removed org",
 			orgID:   orgID,
 			ownerID: ownerID,
-			err:     errors.ErrRemoveEntity,
+			err:     dbutil.ErrRemoveEntity,
 		},
 	}
 
@@ -270,17 +270,17 @@ func TestRetrieveByID(t *testing.T) {
 		{
 			desc:  "retrieve org with unknown org id",
 			orgID: unknownID,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "retrieve org with invalid org id",
 			orgID: invalidID,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "retrieve org without org id",
 			orgID: "",
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -455,7 +455,7 @@ func TestRetrieveOrgsByMember(t *testing.T) {
 				Order:  idOrder,
 			},
 			size: 0,
-			err:  errors.ErrRetrieveEntity,
+			err:  dbutil.ErrRetrieveEntity,
 		},
 		{
 			desc:     "retrieve orgs by member without member id",
@@ -467,7 +467,7 @@ func TestRetrieveOrgsByMember(t *testing.T) {
 				Order:  idOrder,
 			},
 			size: 0,
-			err:  errors.ErrRetrieveEntity,
+			err:  dbutil.ErrRetrieveEntity,
 		},
 	}
 

--- a/auth/postgres/roles.go
+++ b/auth/postgres/roles.go
@@ -27,7 +27,7 @@ func (rr rolesRepository) SaveRole(ctx context.Context, userID, role string) err
 	dbur := toDBUsersRole(userID, role)
 
 	if _, err := rr.db.NamedExecContext(ctx, q, dbur); err != nil {
-		return errors.Wrap(errors.ErrCreateEntity, err)
+		return errors.Wrap(dbutil.ErrCreateEntity, err)
 	}
 
 	return nil
@@ -40,14 +40,14 @@ func (rr rolesRepository) RetrieveRole(ctx context.Context, userID string) (stri
 
 	rows, err := rr.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
-		return "", errors.Wrap(errors.ErrRetrieveEntity, err)
+		return "", errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 	defer rows.Close()
 
 	var role string
 	for rows.Next() {
 		if err := rows.Scan(&role); err != nil {
-			return "", errors.Wrap(errors.ErrRetrieveEntity, err)
+			return "", errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
 	}
 
@@ -60,7 +60,7 @@ func (rr rolesRepository) UpdateRole(ctx context.Context, userID, role string) e
 	dbur := toDBUsersRole(userID, role)
 
 	if _, err := rr.db.NamedExecContext(ctx, q, dbur); err != nil {
-		return errors.Wrap(errors.ErrUpdateEntity, err)
+		return errors.Wrap(dbutil.ErrUpdateEntity, err)
 	}
 
 	return nil
@@ -72,7 +72,7 @@ func (rr rolesRepository) RemoveRole(ctx context.Context, userID string) error {
 	dbur := dbUserRole{UserID: userID}
 
 	if _, err := rr.db.NamedExecContext(ctx, q, dbur); err != nil {
-		return errors.Wrap(errors.ErrRemoveEntity, err)
+		return errors.Wrap(dbutil.ErrRemoveEntity, err)
 	}
 
 	return nil

--- a/auth/postgres/roles_test.go
+++ b/auth/postgres/roles_test.go
@@ -41,31 +41,31 @@ func TestSaveRole(t *testing.T) {
 			desc: "save already existing role",
 			id:   userID,
 			role: auth.RoleRootAdmin,
-			err:  errors.ErrCreateEntity,
+			err:  dbutil.ErrCreateEntity,
 		},
 		{
 			desc: "save invalid role",
 			id:   userID,
 			role: invalid,
-			err:  errors.ErrCreateEntity,
+			err:  dbutil.ErrCreateEntity,
 		},
 		{
 			desc: "save with invalid user id",
 			id:   invalid,
 			role: auth.RoleRootAdmin,
-			err:  errors.ErrCreateEntity,
+			err:  dbutil.ErrCreateEntity,
 		},
 		{
 			desc: "save without user id",
 			id:   "",
 			role: auth.RoleRootAdmin,
-			err:  errors.ErrCreateEntity,
+			err:  dbutil.ErrCreateEntity,
 		},
 		{
 			desc: "save without user role",
 			id:   userID,
 			role: "",
-			err:  errors.ErrCreateEntity,
+			err:  dbutil.ErrCreateEntity,
 		},
 	}
 
@@ -109,7 +109,7 @@ func TestRetrieve(t *testing.T) {
 			desc: "retrieve role for invalid user id",
 			id:   invalid,
 			role: "",
-			err:  errors.ErrRetrieveEntity,
+			err:  dbutil.ErrRetrieveEntity,
 		},
 	}
 
@@ -146,19 +146,19 @@ func TestUpdateRole(t *testing.T) {
 			desc: "update role for invalid user id",
 			id:   invalid,
 			role: auth.RoleRootAdmin,
-			err:  errors.ErrUpdateEntity,
+			err:  dbutil.ErrUpdateEntity,
 		},
 		{
 			desc: "update with empty role",
 			id:   userID,
 			role: "",
-			err:  errors.ErrUpdateEntity,
+			err:  dbutil.ErrUpdateEntity,
 		},
 		{
 			desc: "update with empty user id",
 			id:   "",
 			role: auth.RoleRootAdmin,
-			err:  errors.ErrUpdateEntity,
+			err:  dbutil.ErrUpdateEntity,
 		},
 	}
 
@@ -191,12 +191,12 @@ func TestDeleteRole(t *testing.T) {
 		{
 			desc: "delete role for invalid user id",
 			id:   invalid,
-			err:  errors.ErrRemoveEntity,
+			err:  dbutil.ErrRemoveEntity,
 		},
 		{
 			desc: "delete role without user id",
 			id:   "",
-			err:  errors.ErrRemoveEntity,
+			err:  dbutil.ErrRemoveEntity,
 		},
 	}
 

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/MainfluxLabs/mainflux/auth/jwt"
 	"github.com/MainfluxLabs/mainflux/auth/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	thmocks "github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
@@ -240,7 +241,7 @@ func TestRetrieve(t *testing.T) {
 			desc:  "retrieve non-existing login key",
 			id:    "invalid",
 			token: userToken,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "retrieve with wrong login key",
@@ -519,7 +520,7 @@ func TestRemoveOrg(t *testing.T) {
 			desc:  "remove non-existing org",
 			token: ownerToken,
 			id:    invalid,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "remove org as viewer",
@@ -549,13 +550,13 @@ func TestRemoveOrg(t *testing.T) {
 			desc:  "remove removed org",
 			token: ownerToken,
 			id:    res.ID,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "remove non-existing org",
 			token: ownerToken,
 			id:    invalid,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -635,7 +636,7 @@ func TestUpdateOrg(t *testing.T) {
 			desc:  "update non-existing org",
 			token: ownerToken,
 			org:   auth.Org{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -736,14 +737,14 @@ func TestViewOrg(t *testing.T) {
 			token: ownerToken,
 			orgID: "",
 			org:   auth.Org{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "view non-existing org",
 			token: ownerToken,
 			orgID: invalid,
 			org:   auth.Org{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -839,7 +840,7 @@ func TestCreateOrgMemberships(t *testing.T) {
 			token:       ownerToken,
 			orgID:       "",
 			memberships: memberships,
-			err:         errors.ErrNotFound,
+			err:         dbutil.ErrNotFound,
 		},
 	}
 
@@ -928,7 +929,7 @@ func TestRemoveOrgMemberships(t *testing.T) {
 			token:    ownerToken,
 			orgID:    invalid,
 			memberID: editorID,
-			err:      errors.ErrNotFound,
+			err:      dbutil.ErrNotFound,
 		},
 	}
 
@@ -1026,7 +1027,7 @@ func TestUpdateOrgMemberships(t *testing.T) {
 			token:      ownerToken,
 			orgID:      invalid,
 			membership: memberships[1],
-			err:        errors.ErrNotFound,
+			err:        dbutil.ErrNotFound,
 		},
 	}
 
@@ -1167,7 +1168,7 @@ func TestListOrgMemberships(t *testing.T) {
 			orgID: invalid,
 			meta:  apiutil.PageMetadata{},
 			size:  0,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 

--- a/certs/api/transport.go
+++ b/certs/api/transport.go
@@ -12,6 +12,7 @@ import (
 	"github.com/MainfluxLabs/mainflux/certs"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -141,11 +142,11 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		err == apiutil.ErrMissingCertData,
 		err == apiutil.ErrLimitSize:
 		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, errors.ErrConflict):
+	case errors.Contains(err, dbutil.ErrConflict):
 		w.WriteHeader(http.StatusConflict)
-	case errors.Contains(err, errors.ErrCreateEntity),
-		errors.Contains(err, errors.ErrRetrieveEntity),
-		errors.Contains(err, errors.ErrRemoveEntity):
+	case errors.Contains(err, dbutil.ErrCreateEntity),
+		errors.Contains(err, dbutil.ErrRetrieveEntity),
+		errors.Contains(err, dbutil.ErrRemoveEntity):
 		w.WriteHeader(http.StatusInternalServerError)
 	default:
 		w.WriteHeader(http.StatusInternalServerError)

--- a/certs/mocks/certs.go
+++ b/certs/mocks/certs.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/MainfluxLabs/mainflux/certs"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 )
 
 var _ certs.Repository = (*certsRepoMock)(nil)
@@ -63,7 +63,7 @@ func (c *certsRepoMock) RetrieveAll(ctx context.Context, ownerID string, offset,
 
 	oc, ok := c.certsByThingID[ownerID]
 	if !ok {
-		return certs.Page{}, errors.ErrNotFound
+		return certs.Page{}, dbutil.ErrNotFound
 	}
 
 	var crts []certs.Cert
@@ -89,7 +89,7 @@ func (c *certsRepoMock) Remove(ctx context.Context, ownerID, serial string) erro
 	defer c.mu.Unlock()
 	crt, ok := c.certsBySerial[serial]
 	if !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 	delete(c.certsBySerial, crt.Serial)
 	delete(c.certsByThingID, crt.ThingID)
@@ -105,7 +105,7 @@ func (c *certsRepoMock) RetrieveByThing(ctx context.Context, ownerID, thingID st
 
 	cs, ok := c.certsByThingID[ownerID][thingID]
 	if !ok {
-		return certs.Page{}, errors.ErrNotFound
+		return certs.Page{}, dbutil.ErrNotFound
 	}
 
 	var crts []certs.Cert
@@ -130,7 +130,7 @@ func (c *certsRepoMock) RetrieveBySerial(ctx context.Context, ownerID, serialID 
 
 	crt, ok := c.certsBySerial[serialID]
 	if !ok {
-		return certs.Cert{}, errors.ErrNotFound
+		return certs.Cert{}, dbutil.ErrNotFound
 	}
 
 	return crt, nil

--- a/certs/mocks/pki.go
+++ b/certs/mocks/pki.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux/certs/pki"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 )
 
@@ -150,7 +151,7 @@ func (a *agent) Read(serial string) (pki.Cert, error) {
 
 	crt, ok := a.certs[serial]
 	if !ok {
-		return pki.Cert{}, errors.ErrNotFound
+		return pki.Cert{}, dbutil.ErrNotFound
 	}
 
 	return crt, nil

--- a/certs/service_test.go
+++ b/certs/service_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/MainfluxLabs/mainflux/certs"
 	ctmocks "github.com/MainfluxLabs/mainflux/certs/mocks"
 	"github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	thmocks "github.com/MainfluxLabs/mainflux/pkg/mocks"
@@ -403,7 +404,7 @@ func TestViewCert(t *testing.T) {
 			token:    token,
 			serialID: wrongValue,
 			cert:     certs.Cert{},
-			err:      errors.ErrNotFound,
+			err:      dbutil.ErrNotFound,
 		},
 	}
 

--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MainfluxLabs/mainflux"
 	"github.com/MainfluxLabs/mainflux/coap"
 	log "github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
@@ -88,13 +89,13 @@ func handler(w mux.ResponseWriter, m *mux.Message) {
 	case codes.POST:
 		err = service.Publish(context.Background(), key, msg)
 	default:
-		err = errors.ErrNotFound
+		err = dbutil.ErrNotFound
 	}
 	if err != nil {
 		switch {
 		case err == errBadOptions:
 			resp.Code = codes.BadOption
-		case err == errors.ErrNotFound:
+		case err == dbutil.ErrNotFound:
 			resp.Code = codes.NotFound
 		case errors.Contains(err, errors.ErrAuthorization),
 			errors.Contains(err, errors.ErrAuthentication):

--- a/consumers/notifiers/mocks/notifier.go
+++ b/consumers/notifiers/mocks/notifier.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/consumers/notifiers"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 )
@@ -69,7 +69,7 @@ func (nrm *notifierRepositoryMock) Save(_ context.Context, nfs ...notifiers.Noti
 	for _, nf := range nfs {
 		for _, n := range nrm.notifiers {
 			if n.GroupID == nf.GroupID && n.Name == nf.Name {
-				return []notifiers.Notifier{}, errors.ErrConflict
+				return []notifiers.Notifier{}, dbutil.ErrConflict
 			}
 		}
 
@@ -126,7 +126,7 @@ func (nrm *notifierRepositoryMock) RetrieveByID(_ context.Context, id string) (n
 		}
 	}
 
-	return notifiers.Notifier{}, errors.ErrNotFound
+	return notifiers.Notifier{}, dbutil.ErrNotFound
 }
 
 func (nrm *notifierRepositoryMock) Update(_ context.Context, nf notifiers.Notifier) error {
@@ -134,7 +134,7 @@ func (nrm *notifierRepositoryMock) Update(_ context.Context, nf notifiers.Notifi
 	defer nrm.mu.Unlock()
 
 	if _, ok := nrm.notifiers[nf.ID]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 	nrm.notifiers[nf.ID] = nf
 
@@ -147,7 +147,7 @@ func (nrm *notifierRepositoryMock) Remove(_ context.Context, ids ...string) erro
 
 	for _, id := range ids {
 		if _, ok := nrm.notifiers[id]; !ok {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 		delete(nrm.notifiers, id)
 	}

--- a/consumers/notifiers/service.go
+++ b/consumers/notifiers/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
@@ -100,7 +101,7 @@ func (ns *notifierService) CreateNotifiers(ctx context.Context, token string, no
 	nfs := []Notifier{}
 	for _, notifier := range notifiers {
 		if err := ns.sender.ValidateContacts(notifier.Contacts); err != nil {
-			return []Notifier{}, errors.Wrap(errors.ErrMalformedEntity, err)
+			return []Notifier{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
 		}
 
 		nf, err := ns.createNotifier(ctx, &notifier, token)
@@ -131,7 +132,7 @@ func (ns *notifierService) createNotifier(ctx context.Context, notifier *Notifie
 	}
 
 	if len(nfs) == 0 {
-		return Notifier{}, errors.ErrCreateEntity
+		return Notifier{}, dbutil.ErrCreateEntity
 	}
 
 	return nfs[0], nil
@@ -175,7 +176,7 @@ func (ns *notifierService) UpdateNotifier(ctx context.Context, token string, not
 	}
 
 	if err := ns.sender.ValidateContacts(notifier.Contacts); err != nil {
-		return errors.Wrap(errors.ErrMalformedEntity, err)
+		return errors.Wrap(dbutil.ErrMalformedEntity, err)
 	}
 
 	return ns.notifierRepo.Update(ctx, notifier)

--- a/consumers/notifiers/service_test.go
+++ b/consumers/notifiers/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MainfluxLabs/mainflux/consumers/notifiers"
 	ntmocks "github.com/MainfluxLabs/mainflux/consumers/notifiers/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
@@ -170,7 +171,7 @@ func runCreateNotifiersTest(t *testing.T, svcName string, validContacts []string
 			desc:      "create notifier with invalid contacts",
 			notifiers: []notifiers.Notifier{invalidContactsNf},
 			token:     token,
-			err:       errors.ErrMalformedEntity,
+			err:       dbutil.ErrMalformedEntity,
 		},
 		{
 			desc:      "create notifier with invalid group id",
@@ -370,13 +371,13 @@ func runUpdateNotifierTest(t *testing.T, svcName string, validContacts []string)
 			desc:     "update non-existing notifier",
 			notifier: invalidIDNf,
 			token:    token,
-			err:      errors.ErrNotFound,
+			err:      dbutil.ErrNotFound,
 		},
 		{
 			desc:     "create notifier with invalid contacts",
 			notifier: invalidContactsNf,
 			token:    token,
-			err:      errors.ErrMalformedEntity,
+			err:      dbutil.ErrMalformedEntity,
 		},
 		{
 			desc:     "create notifier with invalid name",
@@ -423,7 +424,7 @@ func runViewNotifierTest(t *testing.T, validContacts []string) {
 		"view non-existing notifier": {
 			id:    wrongValue,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -467,7 +468,7 @@ func runRemoveNotifiersTest(t *testing.T, validContacts []string) {
 			desc:  "remove non-existing notifier",
 			id:    wrongValue,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 

--- a/mqtt/mocks/subscriptions.go
+++ b/mqtt/mocks/subscriptions.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/MainfluxLabs/mainflux/mqtt"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 )
 
 var _ mqtt.Repository = (*subRepoMock)(nil)
@@ -40,7 +40,7 @@ func (srm *subRepoMock) RetrieveByGroupID(_ context.Context, pm mqtt.PageMetadat
 	}
 
 	if len(subs) == 0 {
-		return mqtt.Page{}, errors.ErrNotFound
+		return mqtt.Page{}, dbutil.ErrNotFound
 	}
 
 	return mqtt.Page{
@@ -56,7 +56,7 @@ func (srm *subRepoMock) Save(_ context.Context, sub mqtt.Subscription) error {
 	for _, s := range srm.subs {
 		for _, m := range s {
 			if m.Subtopic == sub.Subtopic && m.ThingID == sub.ThingID && m.GroupID == sub.GroupID {
-				return errors.ErrConflict
+				return dbutil.ErrConflict
 			}
 		}
 	}
@@ -78,7 +78,7 @@ func (srm *subRepoMock) Remove(_ context.Context, sub mqtt.Subscription) error {
 		}
 	}
 
-	return errors.ErrNotFound
+	return dbutil.ErrNotFound
 }
 
 func (srm *subRepoMock) UpdateStatus(_ context.Context, sub mqtt.Subscription) error {

--- a/mqtt/postgres/subscriptions_test.go
+++ b/mqtt/postgres/subscriptions_test.go
@@ -61,12 +61,12 @@ func TestSave(t *testing.T) {
 		{
 			desc: "save existing subscription",
 			sub:  sub,
-			err:  errors.ErrConflict,
+			err:  dbutil.ErrConflict,
 		},
 		{
 			desc: "save invalid subscription",
 			sub:  invalidSub,
-			err:  errors.ErrCreateEntity,
+			err:  dbutil.ErrCreateEntity,
 		},
 	}
 
@@ -233,7 +233,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				},
 				Subscriptions: nil,
 			},
-			err: errors.ErrRetrieveEntity,
+			err: dbutil.ErrRetrieveEntity,
 		},
 	}
 

--- a/mqtt/service_test.go
+++ b/mqtt/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/mqtt"
 	"github.com/MainfluxLabs/mainflux/mqtt/mocks"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	thmocks "github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
@@ -64,7 +65,7 @@ func TestCreateSubscription(t *testing.T) {
 		{
 			desc: "create with existing subscription",
 			sub:  sub,
-			err:  errors.ErrConflict,
+			err:  dbutil.ErrConflict,
 		},
 	}
 
@@ -105,7 +106,7 @@ func TestRemoveSubscription(t *testing.T) {
 		{
 			desc: "subscription does not exist",
 			sub:  mqtt.Subscription{},
-			err:  errors.ErrNotFound,
+			err:  dbutil.ErrNotFound,
 		},
 	}
 
@@ -263,7 +264,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				},
 				Subscriptions: nil,
 			},
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 		{
 			desc:    "retrieve subscriptions by group without thing key",

--- a/pkg/apiutil/converters.go
+++ b/pkg/apiutil/converters.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	mfjson "github.com/MainfluxLabs/mainflux/pkg/transformers/json"
 	"github.com/MainfluxLabs/mainflux/pkg/transformers/senml"
@@ -169,7 +168,7 @@ func GenerateJSON(page readers.MessagesPage) ([]byte, error) {
 
 	data, err := json.Marshal(page.Messages)
 	if err != nil {
-		return nil, errors.Wrap(dbutil.ErrCreateEntity, err)
+		return nil, errors.Wrap(ErrMalformedEntity, err)
 	}
 
 	return data, nil

--- a/pkg/apiutil/converters.go
+++ b/pkg/apiutil/converters.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	mfjson "github.com/MainfluxLabs/mainflux/pkg/transformers/json"
 	"github.com/MainfluxLabs/mainflux/pkg/transformers/senml"
@@ -168,7 +169,7 @@ func GenerateJSON(page readers.MessagesPage) ([]byte, error) {
 
 	data, err := json.Marshal(page.Messages)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCreateEntity, err)
+		return nil, errors.Wrap(dbutil.ErrCreateEntity, err)
 	}
 
 	return data, nil

--- a/pkg/apiutil/converters.go
+++ b/pkg/apiutil/converters.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	mfjson "github.com/MainfluxLabs/mainflux/pkg/transformers/json"
 	"github.com/MainfluxLabs/mainflux/pkg/transformers/senml"
 	"github.com/MainfluxLabs/mainflux/readers"
@@ -168,7 +167,7 @@ func GenerateJSON(page readers.MessagesPage) ([]byte, error) {
 
 	data, err := json.Marshal(page.Messages)
 	if err != nil {
-		return nil, errors.Wrap(ErrMalformedEntity, err)
+		return nil, err
 	}
 
 	return data, nil

--- a/pkg/apiutil/transport.go
+++ b/pkg/apiutil/transport.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	"github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/readers"
 	kithttp "github.com/go-kit/kit/transport/http"
@@ -124,14 +125,14 @@ func EncodeError(err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusUnauthorized)
 	case errors.Contains(err, errors.ErrAuthorization):
 		w.WriteHeader(http.StatusForbidden)
-	case errors.Contains(err, errors.ErrNotFound):
+	case errors.Contains(err, dbutil.ErrNotFound):
 		w.WriteHeader(http.StatusNotFound)
-	case errors.Contains(err, errors.ErrConflict):
+	case errors.Contains(err, dbutil.ErrConflict):
 		w.WriteHeader(http.StatusConflict)
-	case errors.Contains(err, errors.ErrCreateEntity),
-		errors.Contains(err, errors.ErrUpdateEntity),
-		errors.Contains(err, errors.ErrRetrieveEntity),
-		errors.Contains(err, errors.ErrRemoveEntity):
+	case errors.Contains(err, dbutil.ErrCreateEntity),
+		errors.Contains(err, dbutil.ErrUpdateEntity),
+		errors.Contains(err, dbutil.ErrRetrieveEntity),
+		errors.Contains(err, dbutil.ErrRemoveEntity):
 		w.WriteHeader(http.StatusInternalServerError)
 	default:
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/dbutil/errors.go
+++ b/pkg/dbutil/errors.go
@@ -1,0 +1,29 @@
+package dbutil
+
+import "github.com/MainfluxLabs/mainflux/pkg/errors"
+
+var (
+	// ErrMalformedEntity indicates a malformed entity specification.
+	ErrMalformedEntity = errors.New("malformed entity specification")
+
+	// ErrNotFound indicates a non-existent entity request.
+	ErrNotFound = errors.New("entity not found")
+
+	// ErrConflict indicates that entity already exists.
+	ErrConflict = errors.New("entity already exists")
+
+	// ErrCreateEntity indicates error in creating entity or entities.
+	ErrCreateEntity = errors.New("failed to create entity in the db")
+
+	// ErrRetrieveEntity indicates error in viewing entity or entities.
+	ErrRetrieveEntity = errors.New("failed to retrieve entity")
+
+	// ErrUpdateEntity indicates error in updating entity or entities.
+	ErrUpdateEntity = errors.New("failed to update entity")
+
+	// ErrRemoveEntity indicates error in removing entity.
+	ErrRemoveEntity = errors.New("failed to remove entity")
+
+	// ErrScanMetadata indicates problem with metadata in db.
+	ErrScanMetadata = errors.New("failed to scan metadata in db")
+)

--- a/pkg/dbutil/errors.go
+++ b/pkg/dbutil/errors.go
@@ -6,24 +6,24 @@ var (
 	// ErrMalformedEntity indicates a malformed entity specification.
 	ErrMalformedEntity = errors.New("malformed entity specification")
 
-	// ErrNotFound indicates a non-existent entity request.
+	// ErrNotFound indicates that an entity was not found in the database.
 	ErrNotFound = errors.New("entity not found")
 
-	// ErrConflict indicates that entity already exists.
+	// ErrConflict indicates that entity an entity with conflicting properties already exists.
 	ErrConflict = errors.New("entity already exists")
 
-	// ErrCreateEntity indicates error in creating entity or entities.
-	ErrCreateEntity = errors.New("failed to create entity in the db")
+	// ErrCreateEntity indicates an error in attempting to create an entity or entities.
+	ErrCreateEntity = errors.New("failed to create entity")
 
-	// ErrRetrieveEntity indicates error in viewing entity or entities.
+	// ErrRetrieveEntity indicates an error in attempting to retrieve an entity or entities.
 	ErrRetrieveEntity = errors.New("failed to retrieve entity")
 
-	// ErrUpdateEntity indicates error in updating entity or entities.
+	// ErrUpdateEntity indicates an error in attempting to update an entity or entities.
 	ErrUpdateEntity = errors.New("failed to update entity")
 
-	// ErrRemoveEntity indicates error in removing entity.
+	// ErrRemoveEntity indicates an error in attempting to remove an entity or entities.
 	ErrRemoveEntity = errors.New("failed to remove entity")
 
-	// ErrScanMetadata indicates problem with metadata in db.
-	ErrScanMetadata = errors.New("failed to scan metadata in db")
+	// ErrScanMetadata indicates an error in attempting to decode entity metadata from the database.
+	ErrScanMetadata = errors.New("failed to scan metadata from db")
 )

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -10,30 +10,6 @@ var (
 	// ErrAuthorization indicates failure occurred while authorizing the entity.
 	ErrAuthorization = New("failed to perform authorization over the entity")
 
-	// ErrMalformedEntity indicates a malformed entity specification.
-	ErrMalformedEntity = New("malformed entity specification")
-
-	// ErrNotFound indicates a non-existent entity request.
-	ErrNotFound = New("entity not found")
-
-	// ErrConflict indicates that entity already exists.
-	ErrConflict = New("entity already exists")
-
-	// ErrCreateEntity indicates error in creating entity or entities.
-	ErrCreateEntity = New("failed to create entity in the db")
-
-	// ErrRetrieveEntity indicates error in viewing entity or entities.
-	ErrRetrieveEntity = New("failed to retrieve entity")
-
-	// ErrUpdateEntity indicates error in updating entity or entities.
-	ErrUpdateEntity = New("failed to update entity")
-
-	// ErrRemoveEntity indicates error in removing entity.
-	ErrRemoveEntity = New("failed to remove entity")
-
-	// ErrScanMetadata indicates problem with metadata in db.
-	ErrScanMetadata = New("failed to scan metadata in db")
-
 	// ErrSaveMessages indicates failure occurred while saving messages to database.
 	ErrSaveMessages = New("failed to save messages to database")
 

--- a/pkg/mocks/auth.go
+++ b/pkg/mocks/auth.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/MainfluxLabs/mainflux/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/users"
@@ -130,7 +131,7 @@ func (svc authServiceMock) GetOwnerIDByOrgID(_ context.Context, req *protomfx.Or
 			return &protomfx.OwnerID{Value: org.OwnerID}, nil
 		}
 	}
-	return nil, errors.ErrNotFound
+	return nil, dbutil.ErrNotFound
 }
 
 func (svc authServiceMock) AssignRole(_ context.Context, _ *protomfx.AssignRoleReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {

--- a/pkg/mocks/things.go
+++ b/pkg/mocks/things.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/things"
 )
@@ -57,7 +57,7 @@ func (svc *mainfluxThings) ViewThing(_ context.Context, token, id string) (thing
 
 	}
 
-	return things.Thing{}, errors.ErrNotFound
+	return things.Thing{}, dbutil.ErrNotFound
 }
 
 func (svc *mainfluxThings) RemoveThings(_ context.Context, token string, ids ...string) error {
@@ -66,7 +66,7 @@ func (svc *mainfluxThings) RemoveThings(_ context.Context, token string, ids ...
 
 	for _, id := range ids {
 		if _, ok := svc.things[id]; !ok {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 
 		delete(svc.things, id)
@@ -79,7 +79,7 @@ func (svc *mainfluxThings) ViewProfile(_ context.Context, token, id string) (thi
 	if c, ok := svc.profiles[id]; ok {
 		return c, nil
 	}
-	return things.Profile{}, errors.ErrNotFound
+	return things.Profile{}, dbutil.ErrNotFound
 }
 
 func (svc *mainfluxThings) UpdateThing(context.Context, string, things.Thing) error {

--- a/pkg/mocks/thingsauth.go
+++ b/pkg/mocks/thingsauth.go
@@ -6,6 +6,7 @@ package mocks
 import (
 	"context"
 
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/things"
@@ -120,19 +121,19 @@ func (svc thingsServiceMock) GetGroupIDByThingID(_ context.Context, in *protomfx
 	if th, ok := svc.things[in.GetValue()]; ok {
 		return &protomfx.GroupID{Value: th.GroupID}, nil
 	}
-	return nil, errors.ErrNotFound
+	return nil, dbutil.ErrNotFound
 }
 
 func (svc thingsServiceMock) GetGroupIDByProfileID(_ context.Context, in *protomfx.ProfileID, _ ...grpc.CallOption) (*protomfx.GroupID, error) {
 	if pr, ok := svc.profiles[in.GetValue()]; ok {
 		return &protomfx.GroupID{Value: pr.GroupID}, nil
 	}
-	return nil, errors.ErrNotFound
+	return nil, dbutil.ErrNotFound
 }
 
 func (svc thingsServiceMock) GetProfileIDByThingID(_ context.Context, in *protomfx.ThingID, _ ...grpc.CallOption) (*protomfx.ProfileID, error) {
 	if th, ok := svc.things[in.GetValue()]; ok {
 		return &protomfx.ProfileID{Value: th.ProfileID}, nil
 	}
-	return nil, errors.ErrNotFound
+	return nil, dbutil.ErrNotFound
 }

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -124,7 +124,7 @@ func backupMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 		case csvFormat:
 			data, err = apiutil.GenerateCSV(page, req.pageMeta.Format)
 		default:
-			return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+			return nil, errors.Wrap(dbutil.ErrMalformedEntity, err)
 		}
 
 		if err != nil {

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -221,7 +221,7 @@ func backupSenMLMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoin
 				return nil, errors.Wrap(errors.ErrBackupMessages, err)
 			}
 		default:
-			return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+			return nil, errors.Wrap(apiutil.ErrMalformedEntity, err)
 		}
 
 		return backupFileRes{

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -13,6 +13,7 @@ import (
 	auth "github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/readers"
@@ -244,16 +245,16 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusUnauthorized)
 	case errors.Contains(err, errors.ErrAuthorization):
 		w.WriteHeader(http.StatusForbidden)
-	case errors.Contains(err, errors.ErrNotFound):
+	case errors.Contains(err, dbutil.ErrNotFound):
 		w.WriteHeader(http.StatusNotFound)
 	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
 		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, errors.ErrConflict):
+	case errors.Contains(err, dbutil.ErrConflict):
 		w.WriteHeader(http.StatusConflict)
-	case errors.Contains(err, errors.ErrScanMetadata):
+	case errors.Contains(err, dbutil.ErrScanMetadata):
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	case errors.Contains(err, readers.ErrReadMessages),
-		errors.Contains(err, errors.ErrCreateEntity):
+		errors.Contains(err, dbutil.ErrCreateEntity):
 		w.WriteHeader(http.StatusInternalServerError)
 	default:
 		w.WriteHeader(http.StatusInternalServerError)

--- a/rules/service.go
+++ b/rules/service.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
@@ -108,7 +109,7 @@ func (rs *rulesService) createRule(ctx context.Context, rule Rule, token string)
 		return Rule{}, err
 	}
 	if len(rls) == 0 {
-		return Rule{}, errors.ErrCreateEntity
+		return Rule{}, dbutil.ErrCreateEntity
 	}
 
 	return rls[0], nil

--- a/things/api/grpc/server.go
+++ b/things/api/grpc/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/things"
@@ -279,7 +280,7 @@ func encodeError(err error) error {
 		return status.Error(codes.Unauthenticated, err.Error())
 	case errors.Contains(err, errors.ErrAuthorization):
 		return status.Error(codes.PermissionDenied, err.Error())
-	case errors.Contains(err, errors.ErrNotFound):
+	case errors.Contains(err, dbutil.ErrNotFound):
 		return status.Error(codes.NotFound, err.Error())
 	default:
 		return status.Error(codes.Internal, "internal server error")

--- a/things/api/http/groups/transport.go
+++ b/things/api/http/groups/transport.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
@@ -322,7 +323,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		err == apiutil.ErrInvalidOrder,
 		err == apiutil.ErrInvalidDirection:
 		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, errors.ErrScanMetadata):
+	case errors.Contains(err, dbutil.ErrScanMetadata):
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)

--- a/things/api/http/profiles/transport.go
+++ b/things/api/http/profiles/transport.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
@@ -394,7 +395,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		err == apiutil.ErrInvalidDirection,
 		err == apiutil.ErrInvalidIDFormat:
 		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, errors.ErrScanMetadata):
+	case errors.Contains(err, dbutil.ErrScanMetadata):
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)

--- a/things/api/http/things/transport.go
+++ b/things/api/http/things/transport.go
@@ -13,6 +13,7 @@ import (
 	"github.com/MainfluxLabs/mainflux"
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
@@ -543,7 +544,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		err == apiutil.ErrInvalidDirection,
 		err == apiutil.ErrInvalidIDFormat:
 		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, errors.ErrScanMetadata):
+	case errors.Contains(err, dbutil.ErrScanMetadata):
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)

--- a/things/mocks/cache.go
+++ b/things/mocks/cache.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/things"
 )
 
@@ -41,7 +41,7 @@ func (tcm *thingCacheMock) ID(_ context.Context, key string) (string, error) {
 
 	id, ok := tcm.things[key]
 	if !ok {
-		return "", errors.ErrNotFound
+		return "", dbutil.ErrNotFound
 	}
 
 	return id, nil
@@ -75,7 +75,7 @@ func (tcm *thingCacheMock) ViewGroup(_ context.Context, thingID string) (string,
 
 	groupID, ok := tcm.groups[thingID]
 	if !ok {
-		return "", errors.ErrNotFound
+		return "", dbutil.ErrNotFound
 	}
 
 	return groupID, nil
@@ -116,7 +116,7 @@ func (pcm *profileCacheMock) ViewGroup(_ context.Context, profileID string) (str
 
 	groupID, ok := pcm.groups[profileID]
 	if !ok {
-		return "", errors.ErrNotFound
+		return "", dbutil.ErrNotFound
 	}
 
 	return groupID, nil
@@ -162,7 +162,7 @@ func (gcm *groupCacheMock) ViewRole(_ context.Context, groupID, memberID string)
 	key := mKey(groupID, memberID)
 	role, ok := gcm.members[key]
 	if !ok {
-		return "", errors.ErrNotFound
+		return "", dbutil.ErrNotFound
 	}
 
 	return role, nil

--- a/things/mocks/groups.go
+++ b/things/mocks/groups.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
@@ -49,7 +49,7 @@ func (grm *groupRepositoryMock) Save(_ context.Context, group things.Group) (thi
 	grm.mu.Lock()
 	defer grm.mu.Unlock()
 	if _, ok := grm.groups[group.ID]; ok {
-		return things.Group{}, errors.ErrConflict
+		return things.Group{}, dbutil.ErrConflict
 	}
 
 	grm.groups[group.ID] = group
@@ -61,7 +61,7 @@ func (grm *groupRepositoryMock) Update(_ context.Context, group things.Group) (t
 	defer grm.mu.Unlock()
 	up, ok := grm.groups[group.ID]
 	if !ok {
-		return things.Group{}, errors.ErrNotFound
+		return things.Group{}, dbutil.ErrNotFound
 	}
 	up.Name = group.Name
 	up.Description = group.Description
@@ -78,7 +78,7 @@ func (grm *groupRepositoryMock) Remove(_ context.Context, ids ...string) error {
 
 	for _, id := range ids {
 		if _, ok := grm.groups[id]; !ok {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 
 		for _, thingID := range grm.things[id] {
@@ -161,7 +161,7 @@ func (grm *groupRepositoryMock) RetrieveByID(_ context.Context, id string) (thin
 
 	val, ok := grm.groups[id]
 	if !ok {
-		return things.Group{}, errors.ErrNotFound
+		return things.Group{}, dbutil.ErrNotFound
 	}
 	return val, nil
 }

--- a/things/mocks/memberships.go
+++ b/things/mocks/memberships.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/things"
 )
@@ -45,7 +45,7 @@ func (gmr *groupMembershipsRepositoryMock) RetrieveRole(_ context.Context, gm th
 		}
 	}
 
-	return "", errors.ErrNotFound
+	return "", dbutil.ErrNotFound
 }
 
 func (gmr *groupMembershipsRepositoryMock) RetrieveByGroup(_ context.Context, groupID string, pm apiutil.PageMetadata) (things.GroupMembershipsPage, error) {
@@ -129,7 +129,7 @@ func (gmr *groupMembershipsRepositoryMock) Update(_ context.Context, gms ...thin
 
 	for _, gm := range gms {
 		if _, ok := gmr.groupMemberships[gm.GroupID]; !ok {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 		gmr.groupMemberships[gm.GroupID] = []things.GroupMembership{
 			{
@@ -148,7 +148,7 @@ func (gmr *groupMembershipsRepositoryMock) Remove(_ context.Context, groupID str
 
 	memberships, ok := gmr.groupMemberships[groupID]
 	if !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 
 	for _, memberID := range memberIDs {
@@ -162,7 +162,7 @@ func (gmr *groupMembershipsRepositoryMock) Remove(_ context.Context, groupID str
 		}
 
 		if !found {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 	}
 

--- a/things/mocks/profiles.go
+++ b/things/mocks/profiles.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
@@ -52,7 +52,7 @@ func (prm *profileRepositoryMock) Update(_ context.Context, profile things.Profi
 	defer prm.mu.Unlock()
 
 	if _, ok := prm.profiles[profile.ID]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 	profile.GroupID = prm.profiles[profile.ID].GroupID
 
@@ -70,7 +70,7 @@ func (prm *profileRepositoryMock) RetrieveByID(_ context.Context, id string) (th
 		}
 	}
 
-	return things.Profile{}, errors.ErrNotFound
+	return things.Profile{}, dbutil.ErrNotFound
 }
 
 func (prm *profileRepositoryMock) RetrieveByGroups(_ context.Context, groupIDs []string, pm apiutil.PageMetadata) (things.ProfilesPage, error) {
@@ -159,7 +159,7 @@ func (prm *profileRepositoryMock) RetrieveByThing(_ context.Context, thID string
 		}
 	}
 
-	return things.Profile{}, errors.ErrNotFound
+	return things.Profile{}, dbutil.ErrNotFound
 }
 
 func (prm *profileRepositoryMock) Remove(_ context.Context, ids ...string) error {
@@ -168,7 +168,7 @@ func (prm *profileRepositoryMock) Remove(_ context.Context, ids ...string) error
 
 	for _, id := range ids {
 		if _, ok := prm.profiles[id]; !ok {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 
 		delete(prm.profiles, id)

--- a/things/mocks/things.go
+++ b/things/mocks/things.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
@@ -39,7 +39,7 @@ func (trm *thingRepositoryMock) Save(_ context.Context, ths ...things.Thing) ([]
 	for i := range ths {
 		for _, th := range trm.things {
 			if th.Key == ths[i].Key {
-				return []things.Thing{}, errors.ErrConflict
+				return []things.Thing{}, dbutil.ErrConflict
 			}
 		}
 
@@ -58,7 +58,7 @@ func (trm *thingRepositoryMock) Update(_ context.Context, thing things.Thing) er
 	defer trm.mu.Unlock()
 
 	if _, ok := trm.things[thing.ID]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 	thing.Key = trm.things[thing.ID].Key
 	thing.GroupID = trm.things[thing.ID].GroupID
@@ -74,13 +74,13 @@ func (trm *thingRepositoryMock) UpdateKey(_ context.Context, id, val string) err
 
 	for _, th := range trm.things {
 		if th.Key == val {
-			return errors.ErrConflict
+			return dbutil.ErrConflict
 		}
 	}
 
 	th, ok := trm.things[id]
 	if !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 
 	th.Key = val
@@ -99,7 +99,7 @@ func (trm *thingRepositoryMock) RetrieveByID(_ context.Context, id string) (thin
 		}
 	}
 
-	return things.Thing{}, errors.ErrNotFound
+	return things.Thing{}, dbutil.ErrNotFound
 }
 
 func (trm *thingRepositoryMock) RetrieveByGroups(_ context.Context, groupIDs []string, pm apiutil.PageMetadata) (things.ThingsPage, error) {
@@ -193,7 +193,7 @@ func (trm *thingRepositoryMock) Remove(_ context.Context, ids ...string) error {
 
 	for _, id := range ids {
 		if _, ok := trm.things[id]; !ok {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 		delete(trm.things, id)
 	}
@@ -211,7 +211,7 @@ func (trm *thingRepositoryMock) RetrieveByKey(_ context.Context, key string) (st
 		}
 	}
 
-	return "", errors.ErrNotFound
+	return "", dbutil.ErrNotFound
 }
 
 func (trm *thingRepositoryMock) BackupAll(_ context.Context) ([]things.Thing, error) {

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -47,17 +47,17 @@ func (gr groupRepository) Save(ctx context.Context, g things.Group) (things.Grou
 		if ok {
 			switch pgErr.Code {
 			case pgerrcode.InvalidTextRepresentation:
-				return things.Group{}, errors.Wrap(errors.ErrMalformedEntity, err)
+				return things.Group{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
 			case pgerrcode.ForeignKeyViolation:
-				return things.Group{}, errors.Wrap(errors.ErrCreateEntity, err)
+				return things.Group{}, errors.Wrap(dbutil.ErrCreateEntity, err)
 			case pgerrcode.UniqueViolation:
-				return things.Group{}, errors.Wrap(errors.ErrConflict, err)
+				return things.Group{}, errors.Wrap(dbutil.ErrConflict, err)
 			case pgerrcode.StringDataRightTruncationDataException:
-				return things.Group{}, errors.Wrap(errors.ErrMalformedEntity, err)
+				return things.Group{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
 			}
 		}
 
-		return things.Group{}, errors.Wrap(errors.ErrCreateEntity, err)
+		return things.Group{}, errors.Wrap(dbutil.ErrCreateEntity, err)
 	}
 
 	defer row.Close()
@@ -76,7 +76,7 @@ func (gr groupRepository) Update(ctx context.Context, g things.Group) (things.Gr
 
 	dbu, err := toDBGroup(g)
 	if err != nil {
-		return things.Group{}, errors.Wrap(errors.ErrUpdateEntity, err)
+		return things.Group{}, errors.Wrap(dbutil.ErrUpdateEntity, err)
 	}
 
 	row, err := gr.db.NamedQueryContext(ctx, q, dbu)
@@ -85,21 +85,21 @@ func (gr groupRepository) Update(ctx context.Context, g things.Group) (things.Gr
 		if ok {
 			switch pgErr.Code {
 			case pgerrcode.InvalidTextRepresentation:
-				return things.Group{}, errors.Wrap(errors.ErrMalformedEntity, err)
+				return things.Group{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
 			case pgerrcode.UniqueViolation:
-				return things.Group{}, errors.Wrap(errors.ErrConflict, err)
+				return things.Group{}, errors.Wrap(dbutil.ErrConflict, err)
 			case pgerrcode.StringDataRightTruncationDataException:
-				return things.Group{}, errors.Wrap(errors.ErrMalformedEntity, err)
+				return things.Group{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
 			}
 		}
-		return things.Group{}, errors.Wrap(errors.ErrUpdateEntity, err)
+		return things.Group{}, errors.Wrap(dbutil.ErrUpdateEntity, err)
 	}
 
 	defer row.Close()
 	row.Next()
 	dbu = dbGroup{}
 	if err := row.StructScan(&dbu); err != nil {
-		return g, errors.Wrap(errors.ErrUpdateEntity, err)
+		return g, errors.Wrap(dbutil.ErrUpdateEntity, err)
 	}
 
 	return toGroup(dbu)
@@ -119,22 +119,22 @@ func (gr groupRepository) Remove(ctx context.Context, groupIDs ...string) error 
 			if ok {
 				switch pqErr.Code {
 				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(errors.ErrMalformedEntity, err)
+					return errors.Wrap(dbutil.ErrMalformedEntity, err)
 				case pgerrcode.ForeignKeyViolation:
-					return errors.Wrap(errors.ErrConflict, err)
+					return errors.Wrap(dbutil.ErrConflict, err)
 				}
 			}
 
-			return errors.Wrap(errors.ErrUpdateEntity, err)
+			return errors.Wrap(dbutil.ErrUpdateEntity, err)
 		}
 
 		cnt, err := res.RowsAffected()
 		if err != nil {
-			return errors.Wrap(errors.ErrRemoveEntity, err)
+			return errors.Wrap(dbutil.ErrRemoveEntity, err)
 		}
 
 		if cnt != 1 {
-			return errors.Wrap(errors.ErrRemoveEntity, err)
+			return errors.Wrap(dbutil.ErrRemoveEntity, err)
 		}
 	}
 
@@ -147,14 +147,14 @@ func (gr groupRepository) BackupAll(ctx context.Context) ([]things.Group, error)
 	var items []dbGroup
 	err := gr.db.SelectContext(ctx, &items, query)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return nil, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
 	var groups []things.Group
 	for _, i := range items {
 		gr, err := toGroup(i)
 		if err != nil {
-			return []things.Group{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+			return []things.Group{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
 
 		groups = append(groups, gr)
@@ -169,14 +169,14 @@ func (gr groupRepository) BackupByOrg(ctx context.Context, orgID string) ([]thin
 	var items []dbGroup
 	err := gr.db.SelectContext(ctx, &items, query, orgID)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return nil, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
 	var groups []things.Group
 	for _, i := range items {
 		gr, err := toGroup(i)
 		if err != nil {
-			return []things.Group{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+			return []things.Group{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
 
 		groups = append(groups, gr)
@@ -216,9 +216,9 @@ func (gr groupRepository) RetrieveByID(ctx context.Context, id string) (things.G
 		pgErr, ok := err.(*pgconn.PgError)
 		//  If there is no result or ID is in an invalid format, return ErrNotFound.
 		if err == sql.ErrNoRows || ok && pgerrcode.InvalidTextRepresentation == pgErr.Code {
-			return things.Group{}, errors.Wrap(errors.ErrNotFound, err)
+			return things.Group{}, errors.Wrap(dbutil.ErrNotFound, err)
 		}
-		return things.Group{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return things.Group{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 	return toGroup(dbu)
 }
@@ -235,7 +235,7 @@ func (gr groupRepository) RetrieveByIDs(ctx context.Context, groupIDs []string, 
 	nq, name := dbutil.GetNameQuery(pm.Name)
 	m, mq, err := dbutil.GetMetadataQuery(pm.Metadata)
 	if err != nil {
-		return things.GroupPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return things.GroupPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 	whereClause := dbutil.BuildWhereClause(iq, nq, mq)
 	query := fmt.Sprintf(`SELECT id, name, org_id, description, metadata, created_at, updated_at FROM groups %s ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
@@ -258,7 +258,7 @@ func (gr groupRepository) RetrieveAll(ctx context.Context, pm apiutil.PageMetada
 	nq, name := dbutil.GetNameQuery(pm.Name)
 	m, mq, err := dbutil.GetMetadataQuery(pm.Metadata)
 	if err != nil {
-		return things.GroupPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return things.GroupPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
 	whereClause := dbutil.BuildWhereClause(nq, mq)
@@ -297,7 +297,7 @@ func (gr groupRepository) retrieveIDs(ctx context.Context, query string, params 
 func (gr groupRepository) retrieve(ctx context.Context, query, cquery string, params map[string]interface{}) (things.GroupPage, error) {
 	rows, err := gr.db.NamedQueryContext(ctx, query, params)
 	if err != nil {
-		return things.GroupPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return things.GroupPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 	defer rows.Close()
 
@@ -305,18 +305,18 @@ func (gr groupRepository) retrieve(ctx context.Context, query, cquery string, pa
 	for rows.Next() {
 		dbg := dbGroup{}
 		if err := rows.StructScan(&dbg); err != nil {
-			return things.GroupPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+			return things.GroupPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
 		gr, err := toGroup(dbg)
 		if err != nil {
-			return things.GroupPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+			return things.GroupPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
 		items = append(items, gr)
 	}
 
 	total, err := dbutil.Total(ctx, gr.db, cquery, params)
 	if err != nil {
-		return things.GroupPage{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return things.GroupPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
 	page := things.GroupPage{

--- a/things/postgres/groups_test.go
+++ b/things/postgres/groups_test.go
@@ -59,7 +59,7 @@ func TestSaveGroup(t *testing.T) {
 				OrgID: orgID,
 				Name:  groupName,
 			},
-			err: errors.ErrConflict,
+			err: dbutil.ErrConflict,
 		},
 		{
 			desc: "save group with invalid name",
@@ -68,7 +68,7 @@ func TestSaveGroup(t *testing.T) {
 				OrgID: orgID,
 				Name:  invalidName,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "save group with invalid description",
@@ -78,7 +78,7 @@ func TestSaveGroup(t *testing.T) {
 				Name:        groupName,
 				Description: invalidDesc,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 	}
 
@@ -130,7 +130,7 @@ func TestRetrieveGroupByID(t *testing.T) {
 	assert.True(t, retrieved.Description == description, fmt.Sprintf("Save group, Description: expected %v got %v\n", retrieved.Description, description))
 
 	retrieved, err = groupRepo.RetrieveByID(context.Background(), generateUUID(t))
-	assert.True(t, errors.Contains(err, errors.ErrNotFound), fmt.Sprintf("Retrieve group: expected %s got %s\n", errors.ErrNotFound, err))
+	assert.True(t, errors.Contains(err, dbutil.ErrNotFound), fmt.Sprintf("Retrieve group: expected %s got %s\n", dbutil.ErrNotFound, err))
 }
 
 func TestUpdateGroup(t *testing.T) {
@@ -189,7 +189,7 @@ func TestUpdateGroup(t *testing.T) {
 				ID:   wrongUid,
 				Name: fmt.Sprintf("%s-%d", groupName, 2),
 			},
-			err: errors.ErrUpdateEntity,
+			err: dbutil.ErrUpdateEntity,
 		},
 		{
 			desc: "update group for invalid name",
@@ -197,7 +197,7 @@ func TestUpdateGroup(t *testing.T) {
 				ID:   groupID,
 				Name: invalidName,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "update group for invalid description",
@@ -205,7 +205,7 @@ func TestUpdateGroup(t *testing.T) {
 				ID:          groupID,
 				Description: invalidDesc,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 	}
 

--- a/things/postgres/memberships_test.go
+++ b/things/postgres/memberships_test.go
@@ -88,12 +88,12 @@ func TestSave(t *testing.T) {
 		{
 			desc: "save group memberships without group ids",
 			gms:  gmsWithoutGroupIDs,
-			err:  errors.ErrMalformedEntity,
+			err:  dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "save group memberships without member id",
 			gms:  gmsWithoutMemberIDs,
-			err:  errors.ErrMalformedEntity,
+			err:  dbutil.ErrMalformedEntity,
 		},
 	}
 
@@ -147,7 +147,7 @@ func TestRetrieveRole(t *testing.T) {
 				MemberID: memberID,
 			},
 			role: "",
-			err:  errors.ErrNotFound,
+			err:  dbutil.ErrNotFound,
 		},
 		{
 			desc: "retrieve member role without member id",
@@ -156,7 +156,7 @@ func TestRetrieveRole(t *testing.T) {
 				MemberID: "",
 			},
 			role: "",
-			err:  errors.ErrNotFound,
+			err:  dbutil.ErrNotFound,
 		},
 	}
 
@@ -230,7 +230,7 @@ func TestRetrieveByGroup(t *testing.T) {
 				Limit:  n,
 				Total:  0,
 			},
-			err: errors.ErrRetrieveEntity,
+			err: dbutil.ErrRetrieveEntity,
 		},
 		{
 			desc:    "retrieve group memberships without group id",
@@ -242,7 +242,7 @@ func TestRetrieveByGroup(t *testing.T) {
 			},
 			size: 0,
 
-			err: errors.ErrRetrieveEntity,
+			err: dbutil.ErrRetrieveEntity,
 		},
 	}
 
@@ -295,13 +295,13 @@ func TestRemoveGroupMemberships(t *testing.T) {
 			desc:      "remove group memberships without group id",
 			groupID:   "",
 			memberIDs: memberIDs,
-			err:       errors.ErrRemoveEntity,
+			err:       dbutil.ErrRemoveEntity,
 		},
 		{
 			desc:      "remove group memberships without member ids",
 			groupID:   group.ID,
 			memberIDs: []string{""},
-			err:       errors.ErrRemoveEntity,
+			err:       dbutil.ErrRemoveEntity,
 		},
 		{
 			desc:      "remove group memberships",
@@ -362,7 +362,7 @@ func TestUpdateGroupMemberships(t *testing.T) {
 				GroupID:  "",
 				Role:     things.Viewer,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "update group membership without member id",
@@ -371,7 +371,7 @@ func TestUpdateGroupMemberships(t *testing.T) {
 				GroupID:  group.ID,
 				Role:     things.Viewer,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "update group membership",

--- a/things/postgres/profiles_test.go
+++ b/things/postgres/profiles_test.go
@@ -54,21 +54,21 @@ func TestSaveProfiles(t *testing.T) {
 		{
 			desc:     "save profiles that already exist",
 			profiles: prs,
-			err:      errors.ErrConflict,
+			err:      dbutil.ErrConflict,
 		},
 		{
 			desc: "save profile with invalid ID",
 			profiles: []things.Profile{
 				{ID: "invalid", GroupID: group.ID, Name: profileName},
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "save profile with invalid name",
 			profiles: []things.Profile{
 				{ID: id, GroupID: group.ID, Name: invalidName},
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 	}
 
@@ -114,7 +114,7 @@ func TestUpdateProfile(t *testing.T) {
 			profile: things.Profile{
 				ID: nonexistentProfileID,
 			},
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 	}
 
@@ -168,11 +168,11 @@ func TestRetrieveProfileByID(t *testing.T) {
 		},
 		"retrieve profile with non-existing profile": {
 			ID:  nonexistentProfileID,
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 		"retrieve profile with malformed ID": {
 			ID:  wrongID,
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 	}
 
@@ -370,7 +370,7 @@ func TestRetrieveProfileByThing(t *testing.T) {
 		"retrieve profile with malformed UUID": {
 			thID:    "wrong",
 			profile: things.Profile{},
-			err:     errors.ErrNotFound,
+			err:     dbutil.ErrNotFound,
 		},
 	}
 
@@ -422,7 +422,7 @@ func TestRemoveProfile(t *testing.T) {
 	}{
 		"remove non-existing profile": {
 			prID: "wrong",
-			err:  errors.ErrRemoveEntity,
+			err:  dbutil.ErrRemoveEntity,
 		},
 		"remove profile": {
 			prID: prID1,

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -81,33 +81,33 @@ func TestSaveThings(t *testing.T) {
 		{
 			desc:   "save things that already exist",
 			things: ths,
-			err:    errors.ErrConflict,
+			err:    dbutil.ErrConflict,
 		},
 		{
 			desc: "save thing with invalid ID",
 			things: []things.Thing{
 				{ID: "invalid", GroupID: group.ID, Key: thkey},
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "save thing with invalid name",
 			things: []things.Thing{
 				{ID: thID, GroupID: group.ID, Key: thkey, Name: invalidName},
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		{
 			desc: "save thing with invalid Key",
 			things: []things.Thing{
 				{ID: thID, GroupID: group.ID, Key: nonexistentThingKey},
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		{
 			desc:   "save things with conflicting keys",
 			things: ths,
-			err:    errors.ErrConflict,
+			err:    dbutil.ErrConflict,
 		},
 	}
 
@@ -170,7 +170,7 @@ func TestUpdateThing(t *testing.T) {
 				ID:      nonexistentThingID,
 				GroupID: group.ID,
 			},
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 		{
 			desc: "update existing thing ID",
@@ -197,7 +197,7 @@ func TestUpdateThing(t *testing.T) {
 				Key:  thkey,
 				Name: invalidName,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 	}
 
@@ -271,13 +271,13 @@ func TestUpdateKey(t *testing.T) {
 			desc: "update key of a non-existing thing",
 			id:   nonexistentThingID,
 			key:  newKey,
-			err:  errors.ErrNotFound,
+			err:  dbutil.ErrNotFound,
 		},
 		{
 			desc: "update key with existing key value",
 			id:   th2.ID,
 			key:  th1.Key,
-			err:  errors.ErrConflict,
+			err:  dbutil.ErrConflict,
 		},
 	}
 
@@ -330,11 +330,11 @@ func TestRetrieveThingByID(t *testing.T) {
 		},
 		"retrieve non-existing thing with existing user": {
 			ID:  nonexistentThingID,
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 		"retrieve thing with malformed ID": {
 			ID:  wrongID,
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 	}
 
@@ -387,7 +387,7 @@ func TestRetrieveByKey(t *testing.T) {
 		"retrieve non-existent thing by key": {
 			key: wrongID,
 			ID:  "",
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 	}
 
@@ -713,7 +713,7 @@ func TestRetrieveByProfile(t *testing.T) {
 				Limit:  n,
 			},
 			size: 0,
-			err:  errors.ErrNotFound,
+			err:  dbutil.ErrNotFound,
 		},
 		"retrieve all things by profile sorted by name ascendant": {
 			prID: prID,
@@ -843,7 +843,7 @@ func TestRemoveThing(t *testing.T) {
 	}{
 		"remove non-existing thing": {
 			thingID: "wrong",
-			err:     errors.ErrRemoveEntity,
+			err:     dbutil.ErrRemoveEntity,
 		},
 		"remove thing": {
 			thingID: thing.ID,

--- a/things/redis/profiles.go
+++ b/things/redis/profiles.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/things"
 	"github.com/go-redis/redis/v8"
@@ -30,12 +31,12 @@ func NewProfileCache(client *redis.Client) things.ProfileCache {
 func (pc *profileCache) SaveGroup(ctx context.Context, profileID string, groupID string) error {
 	gk := groupByProfileIDKey(profileID)
 	if err := pc.client.Set(ctx, gk, groupID, 0).Err(); err != nil {
-		return errors.Wrap(errors.ErrCreateEntity, err)
+		return errors.Wrap(dbutil.ErrCreateEntity, err)
 	}
 
 	pk := profilesByGroupIDKey(groupID)
 	if err := pc.client.SAdd(ctx, pk, profileID).Err(); err != nil {
-		return errors.Wrap(errors.ErrCreateEntity, err)
+		return errors.Wrap(dbutil.ErrCreateEntity, err)
 	}
 
 	return nil
@@ -48,16 +49,16 @@ func (pc *profileCache) RemoveGroup(ctx context.Context, profileID string) error
 		if err == redis.Nil {
 			return nil
 		}
-		return errors.Wrap(errors.ErrRemoveEntity, err)
+		return errors.Wrap(dbutil.ErrRemoveEntity, err)
 	}
 
 	if err := pc.client.Del(ctx, gk).Err(); err != nil {
-		return errors.Wrap(errors.ErrRemoveEntity, err)
+		return errors.Wrap(dbutil.ErrRemoveEntity, err)
 	}
 
 	pk := profilesByGroupIDKey(groupID)
 	if err := pc.client.SRem(ctx, pk, profileID).Err(); err != nil {
-		return errors.Wrap(errors.ErrRemoveEntity, err)
+		return errors.Wrap(dbutil.ErrRemoveEntity, err)
 	}
 
 	return nil
@@ -67,7 +68,7 @@ func (pc *profileCache) ViewGroup(ctx context.Context, profileID string) (string
 	gk := groupByProfileIDKey(profileID)
 	groupID, err := pc.client.Get(ctx, gk).Result()
 	if err != nil {
-		return "", errors.Wrap(errors.ErrNotFound, err)
+		return "", errors.Wrap(dbutil.ErrNotFound, err)
 	}
 
 	return groupID, nil

--- a/things/redis/streams_test.go
+++ b/things/redis/streams_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
@@ -324,7 +325,7 @@ func TestRemoveThing(t *testing.T) {
 			desc:  "remove non-existent thing",
 			id:    strconv.FormatUint(math.MaxUint64, 10),
 			key:   "",
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 			event: nil,
 		},
 	}
@@ -455,7 +456,7 @@ func TestUpdateProfile(t *testing.T) {
 				Name: "c",
 			},
 			key:   token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 			event: nil,
 		},
 	}
@@ -580,7 +581,7 @@ func TestRemoveProfile(t *testing.T) {
 			desc:  "remove non-existent profile",
 			id:    strconv.FormatUint(math.MaxUint64, 10),
 			key:   "",
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 			event: nil,
 		},
 	}

--- a/things/service.go
+++ b/things/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
@@ -295,7 +296,7 @@ func (ts *thingsService) createThing(ctx context.Context, thing *Thing) (Thing, 
 		return Thing{}, err
 	}
 	if len(ths) == 0 {
-		return Thing{}, errors.ErrCreateEntity
+		return Thing{}, dbutil.ErrCreateEntity
 	}
 
 	return ths[0], nil
@@ -584,7 +585,7 @@ func (ts *thingsService) createProfile(ctx context.Context, profile *Profile) (P
 		return Profile{}, err
 	}
 	if len(prs) == 0 {
-		return Profile{}, errors.ErrCreateEntity
+		return Profile{}, dbutil.ErrCreateEntity
 	}
 
 	return prs[0], nil

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	authmock "github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
@@ -126,7 +127,7 @@ func TestCreateThings(t *testing.T) {
 			desc:   "create new thing with wrong group id",
 			things: []things.Thing{{Name: "e", GroupID: wrongValue, ProfileID: prID}},
 			token:  token,
-			err:    errors.ErrNotFound,
+			err:    dbutil.ErrNotFound,
 		},
 		{
 			desc:   "create thing with wrong credentials",
@@ -205,7 +206,7 @@ func TestUpdateThing(t *testing.T) {
 			desc:  "update non-existing thing",
 			thing: other,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "update thing with profile from different group",
@@ -266,7 +267,7 @@ func TestUpdateKey(t *testing.T) {
 			token: token,
 			id:    emptyValue,
 			key:   wrongValue,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -317,7 +318,7 @@ func TestViewThing(t *testing.T) {
 		"view non-existing thing": {
 			id:    emptyValue,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -366,7 +367,7 @@ func TestViewMetadataByKey(t *testing.T) {
 		},
 		"view metadata from a non-existing thing": {
 			key: otherKey,
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 	}
 
@@ -661,7 +662,7 @@ func TestListThingsByProfile(t *testing.T) {
 				Limit:  n,
 			},
 			size: 0,
-			err:  errors.ErrNotFound,
+			err:  dbutil.ErrNotFound,
 		},
 		"list all things by profile sorted by name ascendant": {
 			token: token,
@@ -915,13 +916,13 @@ func TestRemoveThings(t *testing.T) {
 			desc:  "remove removed thing",
 			id:    th.ID,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "remove non-existing thing",
 			id:    emptyValue,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -954,7 +955,7 @@ func TestCreateProfiles(t *testing.T) {
 			desc:     "create new profile with wrong group id",
 			profiles: []things.Profile{{Name: "e", GroupID: wrongValue}},
 			token:    token,
-			err:      errors.ErrNotFound,
+			err:      dbutil.ErrNotFound,
 		},
 		{
 			desc:     "create profile with wrong credentials",
@@ -1017,7 +1018,7 @@ func TestUpdateProfile(t *testing.T) {
 			desc:    "update non-existing profile",
 			profile: other,
 			token:   token,
-			err:     errors.ErrNotFound,
+			err:     dbutil.ErrNotFound,
 		},
 	}
 
@@ -1063,12 +1064,12 @@ func TestViewProfile(t *testing.T) {
 		"view non-existing profile": {
 			id:    emptyValue,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		"view profile with metadata": {
 			id:    emptyValue,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -1464,7 +1465,7 @@ func TestViewProfileByThing(t *testing.T) {
 			token:   token,
 			thID:    "non-existent",
 			profile: things.Profile{},
-			err:     errors.ErrNotFound,
+			err:     dbutil.ErrNotFound,
 		},
 		"view profile by existent thing with invalid token": {
 			token:   wrongValue,
@@ -1519,13 +1520,13 @@ func TestRemoveProfile(t *testing.T) {
 			desc:  "remove removed profile",
 			id:    prID,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "remove non-existing profile",
 			id:    emptyValue,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -1563,7 +1564,7 @@ func TestGetPubConfByKey(t *testing.T) {
 		},
 		"non-existing thing": {
 			key: wrongValue,
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 	}
 
@@ -1604,7 +1605,7 @@ func TestIdentify(t *testing.T) {
 		"identify non-existing thing": {
 			token: wrongValue,
 			id:    emptyValue,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -1646,7 +1647,7 @@ func TestCreateGroups(t *testing.T) {
 			desc:  "create group without org",
 			token: token,
 			group: things.Group{Name: "test-group", Description: "test"},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -1896,7 +1897,7 @@ func TestRemoveGroup(t *testing.T) {
 			desc:  "remove non-existing group",
 			token: token,
 			id:    wrongValue,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "remove group as viewer",
@@ -1926,13 +1927,13 @@ func TestRemoveGroup(t *testing.T) {
 			desc:  "remove removed group",
 			token: token,
 			id:    grID,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "remove non-existing group",
 			token: token,
 			id:    wrongValue,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -2007,7 +2008,7 @@ func TestUpdateGroup(t *testing.T) {
 			desc:  "update non-existing group",
 			token: token,
 			group: things.Group{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -2100,14 +2101,14 @@ func TestViewGroup(t *testing.T) {
 			token: token,
 			grID:  emptyValue,
 			res:   things.Group{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "view non-existing group",
 			token: token,
 			grID:  wrongValue,
 			res:   things.Group{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -2184,21 +2185,21 @@ func TestViewGroupByThing(t *testing.T) {
 			token: token,
 			thID:  emptyValue,
 			res:   things.Group{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "view group by non-existing thing",
 			token: token,
 			thID:  wrongValue,
 			res:   things.Group{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "view group by thing without user rights",
 			token: otherToken,
 			thID:  th.ID,
 			res:   things.Group{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -2269,21 +2270,21 @@ func TestViewGroupByProfile(t *testing.T) {
 			token: token,
 			prID:  emptyValue,
 			res:   things.Group{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "view group by profile with non-existing profile",
 			token: token,
 			prID:  wrongValue,
 			res:   things.Group{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		{
 			desc:  "view group by profile without user rights",
 			token: otherToken,
 			prID:  prID,
 			res:   things.Group{},
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -2360,7 +2361,7 @@ func TestCreateGroupMemberships(t *testing.T) {
 			desc:        "create group memberships without group id",
 			token:       token,
 			memberships: []things.GroupMembership{{MemberID: "2", Email: "member2@gmail.com", Role: things.Viewer}},
-			err:         errors.ErrNotFound,
+			err:         dbutil.ErrNotFound,
 		},
 	}
 
@@ -2491,7 +2492,7 @@ func TestListGroupMemberships(t *testing.T) {
 			groupID: wrongValue,
 			meta:    apiutil.PageMetadata{},
 			size:    0,
-			err:     errors.ErrNotFound,
+			err:     dbutil.ErrNotFound,
 		},
 	}
 
@@ -2576,7 +2577,7 @@ func TestUpdateMemberships(t *testing.T) {
 			desc:       "update group membership with non-existing group",
 			token:      token,
 			membership: things.GroupMembership{MemberID: editor.ID, GroupID: wrongValue, Email: editor.Email, Role: things.Editor},
-			err:        errors.ErrNotFound,
+			err:        dbutil.ErrNotFound,
 		},
 	}
 
@@ -2660,7 +2661,7 @@ func TestRemoveGroupMemberships(t *testing.T) {
 			token:    token,
 			groupID:  wrongValue,
 			memberID: editor.ID,
-			err:      errors.ErrNotFound,
+			err:      dbutil.ErrNotFound,
 		},
 	}
 

--- a/users/api/grpc/server.go
+++ b/users/api/grpc/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/users"
@@ -86,7 +87,7 @@ func encodeError(err error) error {
 		return status.Error(codes.InvalidArgument, err.Error())
 	case errors.Contains(err, errors.ErrAuthentication):
 		return status.Error(codes.Unauthenticated, err.Error())
-	case errors.Contains(err, errors.ErrNotFound):
+	case errors.Contains(err, dbutil.ErrNotFound):
 		return status.Error(codes.NotFound, err.Error())
 	default:
 		return status.Error(codes.Internal, "internal server error")

--- a/users/api/http/endpoint_test.go
+++ b/users/api/http/endpoint_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
@@ -66,7 +67,7 @@ var (
 	newUser               = users.User{Email: "newuser@example.com", Password: validPass, Status: "enabled"}
 	usersList             = []users.User{admin, user}
 	metadata              = map[string]interface{}{"key": "value"}
-	notFoundRes           = toJSON(apiutil.ErrorRes{Err: errors.ErrNotFound.Error()})
+	notFoundRes           = toJSON(apiutil.ErrorRes{Err: dbutil.ErrNotFound.Error()})
 	unauthRes             = toJSON(apiutil.ErrorRes{Err: errors.ErrAuthentication.Error()})
 	weakPassword          = toJSON(apiutil.ErrorRes{Err: users.ErrPasswordFormat.Error()})
 	malformedRes          = toJSON(apiutil.ErrorRes{Err: apiutil.ErrMalformedEntity.Error()})

--- a/users/mocks/hasher.go
+++ b/users/mocks/hasher.go
@@ -4,6 +4,7 @@
 package mocks
 
 import (
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/users"
 )
@@ -20,7 +21,7 @@ func NewHasher() users.Hasher {
 
 func (hm *hasherMock) Hash(pwd string) (string, error) {
 	if pwd == "" {
-		return "", errors.ErrMalformedEntity
+		return "", dbutil.ErrMalformedEntity
 	}
 	return pwd, nil
 }

--- a/users/mocks/hasher.go
+++ b/users/mocks/hasher.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/users"
 )
@@ -21,7 +21,7 @@ func NewHasher() users.Hasher {
 
 func (hm *hasherMock) Hash(pwd string) (string, error) {
 	if pwd == "" {
-		return "", dbutil.ErrMalformedEntity
+		return "", apiutil.ErrMalformedEntity
 	}
 	return pwd, nil
 }

--- a/users/mocks/users.go
+++ b/users/mocks/users.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/users"
 )
@@ -41,7 +41,7 @@ func (urm *userRepositoryMock) Save(ctx context.Context, u users.User) (string, 
 	defer urm.mu.Unlock()
 
 	if _, ok := urm.usersByEmail[u.Email]; ok {
-		return "", errors.ErrConflict
+		return "", dbutil.ErrConflict
 	}
 
 	urm.usersByEmail[u.Email] = u
@@ -54,7 +54,7 @@ func (urm *userRepositoryMock) Update(ctx context.Context, u users.User) error {
 	defer urm.mu.Unlock()
 
 	if _, ok := urm.usersByEmail[u.Email]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 
 	urm.usersByEmail[u.Email] = u
@@ -67,7 +67,7 @@ func (urm *userRepositoryMock) UpdateUser(ctx context.Context, u users.User) err
 	defer urm.mu.Unlock()
 
 	if _, ok := urm.usersByEmail[u.Email]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 
 	urm.usersByEmail[u.Email] = u
@@ -81,7 +81,7 @@ func (urm *userRepositoryMock) RetrieveByEmail(ctx context.Context, email string
 
 	val, ok := urm.usersByEmail[email]
 	if !ok {
-		return users.User{}, errors.ErrNotFound
+		return users.User{}, dbutil.ErrNotFound
 	}
 
 	return val, nil
@@ -93,7 +93,7 @@ func (urm *userRepositoryMock) RetrieveByID(ctx context.Context, id string) (use
 
 	val, ok := urm.usersByID[id]
 	if !ok {
-		return users.User{}, errors.ErrNotFound
+		return users.User{}, dbutil.ErrNotFound
 	}
 
 	return val, nil
@@ -109,7 +109,7 @@ func (urm *userRepositoryMock) RetrieveByIDs(ctx context.Context, ids []string, 
 	if pm.Email != "" {
 		val, ok := urm.usersByEmail[pm.Email]
 		if !ok {
-			return users.UserPage{}, errors.ErrNotFound
+			return users.UserPage{}, dbutil.ErrNotFound
 		}
 		up.Offset = pm.Offset
 		up.Limit = pm.Limit
@@ -166,7 +166,7 @@ func (urm *userRepositoryMock) UpdatePassword(_ context.Context, token, password
 	defer urm.mu.Unlock()
 
 	if _, ok := urm.usersByEmail[token]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 	return nil
 }
@@ -177,7 +177,7 @@ func (urm *userRepositoryMock) ChangeStatus(ctx context.Context, id, status stri
 
 	u, ok := urm.usersByID[id]
 	if !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 	u.Status = status
 	urm.usersByID[id] = u

--- a/users/mocks/verifications.go
+++ b/users/mocks/verifications.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/users"
 )
 
@@ -32,7 +32,7 @@ func (vrm *emailVerificationsRepositoryMock) Save(ctx context.Context, verificat
 	defer vrm.mu.Unlock()
 
 	if _, ok := vrm.verificationsByToken[verification.Token]; ok {
-		return "", errors.ErrConflict
+		return "", dbutil.ErrConflict
 	}
 
 	vrm.verificationsByToken[verification.Token] = verification
@@ -45,7 +45,7 @@ func (vrm *emailVerificationsRepositoryMock) RetrieveByToken(ctx context.Context
 
 	v, ok := vrm.verificationsByToken[confirmationToken]
 	if !ok {
-		return users.EmailVerification{}, errors.ErrNotFound
+		return users.EmailVerification{}, dbutil.ErrNotFound
 	}
 
 	return v, nil
@@ -56,7 +56,7 @@ func (vrm *emailVerificationsRepositoryMock) Remove(ctx context.Context, confirm
 	defer vrm.mu.Unlock()
 
 	if _, ok := vrm.verificationsByToken[confirmationToken]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 
 	delete(vrm.verificationsByToken, confirmationToken)

--- a/users/postgres/users_test.go
+++ b/users/postgres/users_test.go
@@ -55,7 +55,7 @@ func TestUserSave(t *testing.T) {
 				Password: "password",
 				Status:   users.EnabledStatusKey,
 			},
-			err: errors.ErrConflict,
+			err: dbutil.ErrConflict,
 		},
 		{
 			desc: "invalid user status",
@@ -65,7 +65,7 @@ func TestUserSave(t *testing.T) {
 				Password: "password",
 				Status:   "invalid",
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 	}
 
@@ -102,7 +102,7 @@ func TestSingleUserRetrieval(t *testing.T) {
 		err   error
 	}{
 		"existing user":     {email, nil},
-		"non-existing user": {"unknown@example.com", errors.ErrNotFound},
+		"non-existing user": {"unknown@example.com", dbutil.ErrNotFound},
 	}
 
 	for desc, tc := range cases {
@@ -368,12 +368,12 @@ func TestUpdateUser(t *testing.T) {
 		"update user with invalid email": {
 			user:  wrongEmailUser,
 			email: wrongEmailUser.Email,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		"update disabled user": {
 			user:  disabledUser,
 			email: disabledUser.Email,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 		"update existing user": {
 			user:  updtUser,

--- a/users/postgres/verifications.go
+++ b/users/postgres/verifications.go
@@ -38,13 +38,13 @@ func (evr emailVerificationRepository) Save(ctx context.Context, ev users.EmailV
 		if ok {
 			switch pgErr.Code {
 			case pgerrcode.InvalidTextRepresentation:
-				return "", errors.Wrap(errors.ErrMalformedEntity, err)
+				return "", errors.Wrap(dbutil.ErrMalformedEntity, err)
 			case pgerrcode.UniqueViolation:
-				return "", errors.Wrap(errors.ErrConflict, err)
+				return "", errors.Wrap(dbutil.ErrConflict, err)
 			}
 		}
 
-		return "", errors.Wrap(errors.ErrCreateEntity, err)
+		return "", errors.Wrap(dbutil.ErrCreateEntity, err)
 	}
 
 	defer rows.Close()
@@ -71,10 +71,10 @@ func (evr emailVerificationRepository) RetrieveByToken(ctx context.Context, conf
 
 	if err := evr.db.QueryRowxContext(ctx, q, confirmToken).StructScan(&dbv); err != nil {
 		if err == sql.ErrNoRows {
-			return users.EmailVerification{}, errors.Wrap(errors.ErrNotFound, err)
+			return users.EmailVerification{}, errors.Wrap(dbutil.ErrNotFound, err)
 		}
 
-		return users.EmailVerification{}, errors.Wrap(errors.ErrRetrieveEntity, err)
+		return users.EmailVerification{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
 	return toVerification(dbv), nil
@@ -92,11 +92,11 @@ func (evr emailVerificationRepository) Remove(ctx context.Context, confirmToken 
 		if ok {
 			switch pgErr.Code {
 			case pgerrcode.InvalidTextRepresentation:
-				return errors.Wrap(errors.ErrMalformedEntity, err)
+				return errors.Wrap(dbutil.ErrMalformedEntity, err)
 			}
 		}
 
-		return errors.Wrap(errors.ErrRemoveEntity, err)
+		return errors.Wrap(dbutil.ErrRemoveEntity, err)
 	}
 
 	rowsDeleted, err := res.RowsAffected()
@@ -105,7 +105,7 @@ func (evr emailVerificationRepository) Remove(ctx context.Context, confirmToken 
 	}
 
 	if rowsDeleted != 1 {
-		return errors.Wrap(errors.ErrRemoveEntity, err)
+		return errors.Wrap(dbutil.ErrRemoveEntity, err)
 	}
 
 	return nil

--- a/users/postgres/verifications_test.go
+++ b/users/postgres/verifications_test.go
@@ -54,7 +54,7 @@ func TestVerificationSave(t *testing.T) {
 				CreatedAt: time.Now(),
 				ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
 			},
-			err: errors.ErrConflict,
+			err: dbutil.ErrConflict,
 		},
 	}
 
@@ -101,7 +101,7 @@ func TestVerificationRemove(t *testing.T) {
 			verification: users.EmailVerification{
 				Token: nonExistentToken,
 			},
-			err: errors.ErrRemoveEntity,
+			err: dbutil.ErrRemoveEntity,
 		},
 	}
 
@@ -145,7 +145,7 @@ func TestVerificationRetrieve(t *testing.T) {
 			verification: users.EmailVerification{
 				Token: nonExistentToken,
 			},
-			err: errors.ErrNotFound,
+			err: dbutil.ErrNotFound,
 		},
 	}
 

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
@@ -96,7 +97,7 @@ func TestSelfRegister(t *testing.T) {
 			desc:  "self register existing user",
 			user:  registerUser,
 			token: admin.Email,
-			err:   errors.ErrConflict,
+			err:   dbutil.ErrConflict,
 		},
 	}
 
@@ -122,7 +123,7 @@ func TestVerifyEmail(t *testing.T) {
 		{
 			desc:         "confirm verification with already registered e-mail",
 			verification: duplicateVerification,
-			err:          errors.ErrConflict,
+			err:          dbutil.ErrConflict,
 		},
 		{
 			desc:         "confirm expired verification",
@@ -207,7 +208,7 @@ func TestViewUser(t *testing.T) {
 			user:   users.User{},
 			token:  token,
 			userID: "",
-			err:    errors.ErrNotFound,
+			err:    dbutil.ErrNotFound,
 		},
 	}
 
@@ -394,7 +395,7 @@ func TestGenerateResetToken(t *testing.T) {
 		err   error
 	}{
 		"valid user reset token":  {registerUser.Email, nil},
-		"invalid user rest token": {nonExistingUser.Email, errors.ErrNotFound},
+		"invalid user rest token": {nonExistingUser.Email, dbutil.ErrNotFound},
 	}
 
 	for desc, tc := range cases {
@@ -420,7 +421,7 @@ func TestChangePassword(t *testing.T) {
 		"valid user change password invalid token":       {"", "", "newpassword", registerUser.Password, errors.ErrAuthentication},
 
 		"valid admin change user password ":            {adminToken, registerUser.Email, "newpassword", "", nil},
-		"valid admin change password with wrong email": {adminToken, "wrongemail@example.com", "newpassword", "", errors.ErrNotFound},
+		"valid admin change password with wrong email": {adminToken, "wrongemail@example.com", "newpassword", "", dbutil.ErrNotFound},
 		"valid admin change password invalid token":    {"", registerUser.Email, "newpassword", "", errors.ErrAuthentication},
 	}
 

--- a/users/users.go
+++ b/users/users.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/email"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
 )
 
 // Metadata to be used for Mainflux thing or profile for customized
@@ -37,7 +37,7 @@ type EmailVerification struct {
 // Validate returns an error if user representation is invalid.
 func (u User) Validate(passRegex *regexp.Regexp) error {
 	if !email.IsEmail(u.Email) {
-		return errors.ErrMalformedEntity
+		return dbutil.ErrMalformedEntity
 	}
 
 	if !passRegex.MatchString(u.Password) {

--- a/users/users.go
+++ b/users/users.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/pkg/email"
 )
 

--- a/users/users.go
+++ b/users/users.go
@@ -37,7 +37,7 @@ type EmailVerification struct {
 // Validate returns an error if user representation is invalid.
 func (u User) Validate(passRegex *regexp.Regexp) error {
 	if !email.IsEmail(u.Email) {
-		return dbutil.ErrMalformedEntity
+		return apiutil.ErrMalformedEntity
 	}
 
 	if !passRegex.MatchString(u.Password) {

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/users"
 	"github.com/stretchr/testify/assert"
@@ -56,28 +57,28 @@ func TestValidate(t *testing.T) {
 				Email:    "user@example..domain.com",
 				Password: password,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		"validate user with invalid domain": {
 			user: users.User{
 				Email:    "user@.sub.com",
 				Password: password,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		"validate user with empty email": {
 			user: users.User{
 				Email:    "",
 				Password: password,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		"validate user with invalid email": {
 			user: users.User{
 				Email:    "userexample.com",
 				Password: password,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		"validate user with utf8 email (cyrillic)": {
 			user: users.User{
@@ -98,42 +99,42 @@ func TestValidate(t *testing.T) {
 				Email:    "user@example.",
 				Password: password,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		"validate user with too long email tld": {
 			user: users.User{
 				Email:    "user@example." + randomString(maxTLDLen+1),
 				Password: password,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		"validate user with no email domain": {
 			user: users.User{
 				Email:    "user@.com",
 				Password: password,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		"validate user with too long email domain": {
 			user: users.User{
 				Email:    "user@" + randomString(maxDomainLen+1) + ".com",
 				Password: password,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		"validate user with no email local": {
 			user: users.User{
 				Email:    "@example.com",
 				Password: password,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 		"validate user with too long email local": {
 			user: users.User{
 				Email:    randomString(maxLocalLen+1) + "@example.com",
 				Password: password,
 			},
-			err: errors.ErrMalformedEntity,
+			err: dbutil.ErrMalformedEntity,
 		},
 	}
 

--- a/webhooks/mocks/webhooks.go
+++ b/webhooks/mocks/webhooks.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/webhooks"
 )
@@ -30,7 +30,7 @@ func (wrm *webhookRepositoryMock) Save(_ context.Context, whs ...webhooks.Webhoo
 	for _, wh := range whs {
 		for _, w := range wrm.webhooks {
 			if w.GroupID == wh.GroupID && w.Name == wh.Name {
-				return []webhooks.Webhook{}, errors.ErrConflict
+				return []webhooks.Webhook{}, dbutil.ErrConflict
 			}
 		}
 
@@ -104,7 +104,7 @@ func (wrm *webhookRepositoryMock) RetrieveByID(_ context.Context, id string) (we
 		}
 	}
 
-	return webhooks.Webhook{}, errors.ErrNotFound
+	return webhooks.Webhook{}, dbutil.ErrNotFound
 }
 
 func (wrm *webhookRepositoryMock) Update(_ context.Context, w webhooks.Webhook) error {
@@ -112,7 +112,7 @@ func (wrm *webhookRepositoryMock) Update(_ context.Context, w webhooks.Webhook) 
 	defer wrm.mu.Unlock()
 
 	if _, ok := wrm.webhooks[w.ID]; !ok {
-		return errors.ErrNotFound
+		return dbutil.ErrNotFound
 	}
 	wrm.webhooks[w.ID] = w
 
@@ -125,7 +125,7 @@ func (wrm *webhookRepositoryMock) Remove(_ context.Context, ids ...string) error
 
 	for _, id := range ids {
 		if _, ok := wrm.webhooks[id]; !ok {
-			return errors.ErrNotFound
+			return dbutil.ErrNotFound
 		}
 		delete(wrm.webhooks, id)
 	}

--- a/webhooks/service.go
+++ b/webhooks/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
@@ -99,7 +100,7 @@ func (ws *webhooksService) createWebhook(ctx context.Context, webhook *Webhook, 
 	}
 
 	if len(whs) == 0 {
-		return Webhook{}, errors.ErrCreateEntity
+		return Webhook{}, dbutil.ErrCreateEntity
 	}
 
 	return whs[0], nil

--- a/webhooks/service_test.go
+++ b/webhooks/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
@@ -386,7 +387,7 @@ func TestUpdateWebhook(t *testing.T) {
 			desc:    "update non-existing webhook",
 			webhook: invalidWh,
 			token:   token,
-			err:     errors.ErrNotFound,
+			err:     dbutil.ErrNotFound,
 		},
 	}
 
@@ -420,7 +421,7 @@ func TestViewWebhook(t *testing.T) {
 		"view non-existing webhook": {
 			id:    wrongValue,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 
@@ -458,7 +459,7 @@ func TestRemoveWebhooks(t *testing.T) {
 			desc:  "remove non-existing webhook",
 			id:    wrongValue,
 			token: token,
-			err:   errors.ErrNotFound,
+			err:   dbutil.ErrNotFound,
 		},
 	}
 


### PR DESCRIPTION
Moves all db layer-related errors to `pkg/dbutil` (`pkg/dbutil/errors.go`)
