### PR TITLE
MF-821 - Check for apiutil, dbutil, and "errors" package errors in apiutil.EncodeError only

### DIFF
--- a/auth/api/http/keys/transport.go
+++ b/auth/api/http/keys/transport.go
@@ -12,7 +12,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
@@ -89,23 +88,6 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 }
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
-	switch {
-	case errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrMissingKeyID,
-		err == apiutil.ErrInvalidAPIKey:
-		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, errors.ErrAuthentication),
-		err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, dbutil.ErrNotFound):
-		w.WriteHeader(http.StatusNotFound)
-	case errors.Contains(err, dbutil.ErrConflict):
-		w.WriteHeader(http.StatusConflict)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	default:
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-
+	apiutil.EncodeError(err, w)
 	apiutil.WriteErrorResponse(err, w)
 }

--- a/auth/api/http/memberships/transport.go
+++ b/auth/api/http/memberships/transport.go
@@ -215,21 +215,8 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrMissingOrgID,
-		err == apiutil.ErrMissingMemberID,
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrNameSize,
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrInvalidRole,
-		err == apiutil.ErrInvalidQueryParams:
-		w.WriteHeader(http.StatusBadRequest)
-	case err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
 	case errors.Contains(err, auth.ErrOrgMembershipExists):
 		w.WriteHeader(http.StatusConflict)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
 	default:
 		apiutil.EncodeError(err, w)
 	}

--- a/auth/api/http/orgs/transport.go
+++ b/auth/api/http/orgs/transport.go
@@ -210,22 +210,8 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrMissingOrgID,
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrNameSize,
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrInvalidOrder,
-		err == apiutil.ErrInvalidDirection,
-		err == apiutil.ErrInvalidQueryParams:
-		w.WriteHeader(http.StatusBadRequest)
-	case err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
 	case errors.Contains(err, auth.ErrOrgNotEmpty):
 		w.WriteHeader(http.StatusConflict)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)
 	default:

--- a/certs/api/transport.go
+++ b/certs/api/transport.go
@@ -12,8 +12,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/certs"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -130,27 +128,6 @@ func decodeRevokeCerts(_ context.Context, r *http.Request) (interface{}, error) 
 }
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
-	switch {
-	case errors.Contains(err, errors.ErrAuthentication),
-		err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrMissingThingID,
-		err == apiutil.ErrMissingCertID,
-		err == apiutil.ErrMissingCertData,
-		err == apiutil.ErrLimitSize:
-		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, dbutil.ErrConflict):
-		w.WriteHeader(http.StatusConflict)
-	case errors.Contains(err, dbutil.ErrCreateEntity),
-		errors.Contains(err, dbutil.ErrRetrieveEntity),
-		errors.Contains(err, dbutil.ErrRemoveEntity):
-		w.WriteHeader(http.StatusInternalServerError)
-	default:
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-
+	apiutil.EncodeError(err, w)
 	apiutil.WriteErrorResponse(err, w)
 }

--- a/consumers/alarms/api/http/transport.go
+++ b/consumers/alarms/api/http/transport.go
@@ -130,19 +130,6 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrMissingAlarmID,
-		err == apiutil.ErrMissingGroupID,
-		err == apiutil.ErrMissingThingID:
-		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)
 	default:

--- a/consumers/notifiers/api/http/transport.go
+++ b/consumers/notifiers/api/http/transport.go
@@ -186,22 +186,6 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrMissingNotifierID,
-		err == apiutil.ErrMissingGroupID,
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrInvalidOrder,
-		err == apiutil.ErrInvalidDirection,
-		err == apiutil.ErrNameSize,
-		err == apiutil.ErrInvalidContact:
-		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)
 	default:

--- a/http/api/transport.go
+++ b/http/api/transport.go
@@ -107,18 +107,10 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case errors.Contains(err, errors.ErrAuthentication),
-		err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, errors.ErrAuthorization):
-		w.WriteHeader(http.StatusForbidden)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, messaging.ErrMalformedSubtopic),
-		errors.Contains(err, apiutil.ErrMalformedEntity):
+	case errors.Contains(err, messaging.ErrMalformedSubtopic):
 		w.WriteHeader(http.StatusBadRequest)
 	default:
-		w.WriteHeader(http.StatusInternalServerError)
+		apiutil.EncodeError(err, w)
 	}
 
 	apiutil.WriteErrorResponse(err, w)

--- a/mqtt/api/http/transport.go
+++ b/mqtt/api/http/transport.go
@@ -12,7 +12,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/mqtt"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
-	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -82,21 +81,6 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 }
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
-	switch {
-	case errors.Contains(err, apiutil.ErrMalformedEntity),
-		errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		err == apiutil.ErrMissingGroupID:
-		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, errors.ErrAuthentication),
-		err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, errors.ErrAuthorization):
-		w.WriteHeader(http.StatusForbidden)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	default:
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-
+	apiutil.EncodeError(err, w)
 	apiutil.WriteErrorResponse(err, w)
 }

--- a/pkg/apiutil/errors.go
+++ b/pkg/apiutil/errors.go
@@ -96,9 +96,6 @@ var (
 	// ErrMissingCertData indicates missing cert data (ttl, key_type or key_bits).
 	ErrMissingCertData = errors.New("missing certificate data")
 
-	// ErrInvalidTopic indicates an invalid subscription topic.
-	ErrInvalidTopic = errors.New("invalid Subscription topic")
-
 	// ErrInvalidContact indicates an invalid contact.
 	ErrInvalidContact = errors.New("invalid contact")
 
@@ -125,9 +122,6 @@ var (
 
 	// ErrInvalidAPIKey indicates an invalid API key type.
 	ErrInvalidAPIKey = errors.New("invalid api key type")
-
-	// ErrMaxLevelExceeded indicates an invalid group level.
-	ErrMaxLevelExceeded = errors.New("invalid group level (should be lower than 5)")
 
 	// ErrUnsupportedContentType indicates unacceptable or lack of Content-Type
 	ErrUnsupportedContentType = errors.New("unsupported content type")

--- a/pkg/apiutil/transport.go
+++ b/pkg/apiutil/transport.go
@@ -92,7 +92,6 @@ func LoggingErrorEncoder(logger logger.Logger, enc kithttp.ErrorEncoder) kithttp
 			errors.Contains(err, ErrEmptyList),
 			errors.Contains(err, ErrMissingCertID),
 			errors.Contains(err, ErrMissingCertData),
-			errors.Contains(err, ErrInvalidTopic),
 			errors.Contains(err, ErrInvalidContact),
 			errors.Contains(err, ErrMissingEmail),
 			errors.Contains(err, ErrMissingPass),
@@ -101,7 +100,6 @@ func LoggingErrorEncoder(logger logger.Logger, enc kithttp.ErrorEncoder) kithttp
 			errors.Contains(err, ErrInvalidResetPass),
 			errors.Contains(err, ErrInvalidComparator),
 			errors.Contains(err, ErrInvalidAPIKey),
-			errors.Contains(err, ErrMaxLevelExceeded),
 			errors.Contains(err, ErrUnsupportedContentType),
 			errors.Contains(err, ErrMalformedEntity),
 			errors.Contains(err, ErrInvalidRole),
@@ -121,14 +119,62 @@ func LoggingErrorEncoder(logger logger.Logger, enc kithttp.ErrorEncoder) kithttp
 
 func EncodeError(err error, w http.ResponseWriter) {
 	switch {
-	case errors.Contains(err, errors.ErrAuthentication):
+	case errors.Contains(err, errors.ErrAuthentication),
+		errors.Contains(err, ErrBearerToken),
+		errors.Contains(err, ErrBearerKey):
 		w.WriteHeader(http.StatusUnauthorized)
+	case errors.Contains(err, ErrMissingGroupID),
+		errors.Contains(err, ErrMissingOrgID),
+		errors.Contains(err, ErrMissingThingID),
+		errors.Contains(err, ErrMissingProfileID),
+		errors.Contains(err, ErrMissingMemberID),
+		errors.Contains(err, ErrMissingWebhookID),
+		errors.Contains(err, ErrMissingNotifierID),
+		errors.Contains(err, ErrMissingAlarmID),
+		errors.Contains(err, ErrMissingRuleID),
+		errors.Contains(err, ErrMissingUserID),
+		errors.Contains(err, ErrMissingRole),
+		errors.Contains(err, ErrMissingObject),
+		errors.Contains(err, ErrMissingKeyID),
+		errors.Contains(err, ErrInvalidIDFormat),
+		errors.Contains(err, ErrNameSize),
+		errors.Contains(err, ErrEmailSize),
+		errors.Contains(err, ErrInvalidStatus),
+		errors.Contains(err, ErrLimitSize),
+		errors.Contains(err, ErrOffsetSize),
+		errors.Contains(err, ErrInvalidOrder),
+		errors.Contains(err, ErrInvalidDirection),
+		errors.Contains(err, ErrEmptyList),
+		errors.Contains(err, ErrMissingCertID),
+		errors.Contains(err, ErrMissingCertData),
+		errors.Contains(err, ErrInvalidContact),
+		errors.Contains(err, ErrMissingEmail),
+		errors.Contains(err, ErrMissingEmailToken),
+		errors.Contains(err, ErrMissingRedirectPath),
+		errors.Contains(err, ErrMissingPass),
+		errors.Contains(err, ErrMissingConfPass),
+		errors.Contains(err, ErrInvalidResetPass),
+		errors.Contains(err, ErrInvalidComparator),
+		errors.Contains(err, ErrInvalidAPIKey),
+		errors.Contains(err, ErrInvalidQueryParams),
+		errors.Contains(err, ErrInvalidAggType),
+		errors.Contains(err, ErrNotFoundParam),
+		errors.Contains(err, ErrMalformedEntity),
+		errors.Contains(err, ErrInvalidRole),
+		errors.Contains(err, ErrMissingConditionField),
+		errors.Contains(err, ErrMissingConditionThreshold),
+		errors.Contains(err, ErrInvalidActionType),
+		errors.Contains(err, ErrMissingActionID),
+		errors.Contains(err, ErrInvalidOperator):
+		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, errors.ErrAuthorization):
 		w.WriteHeader(http.StatusForbidden)
 	case errors.Contains(err, dbutil.ErrNotFound):
 		w.WriteHeader(http.StatusNotFound)
 	case errors.Contains(err, dbutil.ErrConflict):
 		w.WriteHeader(http.StatusConflict)
+	case errors.Contains(err, ErrUnsupportedContentType):
+		w.WriteHeader(http.StatusUnsupportedMediaType)
 	case errors.Contains(err, dbutil.ErrCreateEntity),
 		errors.Contains(err, dbutil.ErrUpdateEntity),
 		errors.Contains(err, dbutil.ErrRetrieveEntity),

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -316,32 +316,12 @@ func encodeBackupFileResponse(_ context.Context, w http.ResponseWriter, response
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case errors.Contains(err, nil):
-	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrInvalidComparator:
-		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, errors.ErrAuthentication),
-		err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, errors.ErrAuthorization):
-		w.WriteHeader(http.StatusForbidden)
-	case errors.Contains(err, dbutil.ErrNotFound):
-		w.WriteHeader(http.StatusNotFound)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, dbutil.ErrConflict):
-		w.WriteHeader(http.StatusConflict)
 	case errors.Contains(err, dbutil.ErrScanMetadata):
 		w.WriteHeader(http.StatusUnprocessableEntity)
-	case errors.Contains(err, readers.ErrReadMessages),
-		errors.Contains(err, dbutil.ErrCreateEntity):
+	case errors.Contains(err, readers.ErrReadMessages):
 		w.WriteHeader(http.StatusInternalServerError)
 	default:
-		w.WriteHeader(http.StatusInternalServerError)
+		apiutil.EncodeError(err, w)
 	}
 
 	apiutil.WriteErrorResponse(err, w)

--- a/rules/api/http/transport.go
+++ b/rules/api/http/transport.go
@@ -170,28 +170,6 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrNameSize,
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrMissingRuleID,
-		err == apiutil.ErrMissingProfileID,
-		err == apiutil.ErrMissingGroupID,
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrInvalidOrder,
-		err == apiutil.ErrInvalidDirection,
-		err == apiutil.ErrMissingConditionField,
-		err == apiutil.ErrMissingConditionComparator,
-		err == apiutil.ErrMissingConditionThreshold,
-		err == apiutil.ErrMissingActionID,
-		err == apiutil.ErrInvalidActionType:
-		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)
 	default:

--- a/things/api/http/groups/transport.go
+++ b/things/api/http/groups/transport.go
@@ -306,23 +306,6 @@ func decodeBackupByOrg(_ context.Context, r *http.Request) (interface{}, error) 
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrMissingThingID,
-		err == apiutil.ErrMissingProfileID,
-		err == apiutil.ErrMissingGroupID,
-		err == apiutil.ErrMissingOrgID,
-		err == apiutil.ErrNameSize,
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrInvalidOrder,
-		err == apiutil.ErrInvalidDirection:
-		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, dbutil.ErrScanMetadata):
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	case errors.Contains(err, uuid.ErrGeneratingID):

--- a/things/api/http/memberships/transport.go
+++ b/things/api/http/memberships/transport.go
@@ -182,19 +182,6 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrMissingGroupID,
-		err == apiutil.ErrMissingMemberID,
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrInvalidRole:
-		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, things.ErrGroupMembershipExists):
 		w.WriteHeader(http.StatusConflict)
 	case errors.Contains(err, uuid.ErrGeneratingID):

--- a/things/api/http/profiles/transport.go
+++ b/things/api/http/profiles/transport.go
@@ -377,24 +377,6 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrMissingThingID,
-		err == apiutil.ErrMissingProfileID,
-		err == apiutil.ErrMissingGroupID,
-		err == apiutil.ErrMissingOrgID,
-		err == apiutil.ErrNameSize,
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrInvalidOrder,
-		err == apiutil.ErrInvalidDirection,
-		err == apiutil.ErrInvalidIDFormat:
-		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, dbutil.ErrScanMetadata):
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	case errors.Contains(err, uuid.ErrGeneratingID):

--- a/things/api/http/things/transport.go
+++ b/things/api/http/things/transport.go
@@ -525,25 +525,6 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case err == apiutil.ErrBearerToken,
-		err == apiutil.ErrBearerKey:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrMissingThingID,
-		err == apiutil.ErrMissingProfileID,
-		err == apiutil.ErrMissingGroupID,
-		err == apiutil.ErrMissingOrgID,
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrNameSize,
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrInvalidOrder,
-		err == apiutil.ErrInvalidDirection,
-		err == apiutil.ErrInvalidIDFormat:
-		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, dbutil.ErrScanMetadata):
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	case errors.Contains(err, uuid.ErrGeneratingID):

--- a/users/api/http/transport.go
+++ b/users/api/http/transport.go
@@ -420,30 +420,10 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, apiutil.ErrMalformedEntity),
-		errors.Contains(err, users.ErrPasswordFormat),
+	case errors.Contains(err, users.ErrPasswordFormat),
 		errors.Contains(err, errors.ErrInvalidPassword),
-		errors.Contains(err, users.ErrEmailVerificationExpired),
-		err == apiutil.ErrMissingEmail,
-		err == apiutil.ErrMissingPass,
-		err == apiutil.ErrMissingConfPass,
-		err == apiutil.ErrMissingUserID,
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrInvalidOrder,
-		err == apiutil.ErrInvalidDirection,
-		err == apiutil.ErrEmailSize,
-		err == apiutil.ErrInvalidResetPass,
-		err == apiutil.ErrInvalidStatus,
-		err == apiutil.ErrMissingRedirectPath,
-		err == errors.ErrInvalidPassword:
+		errors.Contains(err, users.ErrEmailVerificationExpired):
 		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, errors.ErrAuthentication),
-		err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
 	case errors.Contains(err, uuid.ErrGeneratingID),
 		errors.Contains(err, users.ErrRecoveryToken):
 		w.WriteHeader(http.StatusInternalServerError)

--- a/webhooks/api/http/transport.go
+++ b/webhooks/api/http/transport.go
@@ -216,24 +216,7 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 
 func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
-	case err == apiutil.ErrBearerToken:
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-	case errors.Contains(err, apiutil.ErrInvalidQueryParams),
-		errors.Contains(err, apiutil.ErrMalformedEntity),
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrInvalidIDFormat,
-		err == apiutil.ErrNameSize,
-		err == apiutil.ErrEmptyList,
-		err == apiutil.ErrMissingWebhookID,
-		err == apiutil.ErrMissingThingID,
-		err == apiutil.ErrMissingGroupID,
-		err == apiutil.ErrLimitSize,
-		err == apiutil.ErrOffsetSize,
-		err == apiutil.ErrInvalidOrder,
-		err == apiutil.ErrInvalidDirection,
-		err == ErrInvalidUrl:
+	case err == ErrInvalidUrl:
 		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, uuid.ErrGeneratingID):
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
When encoding error values to HTTP response status codes, now `apiutil.EncodeError` checks for all `apiutil`/`dbutil`/`pkg/errors` errors, while local `encodeError()` functions in each service's transport layer only check for errors specific to that service.

Additionally some unused errors were removed.