### PR TITLE
MF-843 - Refactor return value of service methods for retreving mulitple resources

### DIFF
--- a/auth/api/http/invites/endpoint.go
+++ b/auth/api/http/invites/endpoint.go
@@ -86,7 +86,7 @@ func listOrgInvitesByUserEndpoint(svc auth.Service, userType string) endpoint.En
 			return nil, err
 		}
 
-		response := buildOrgInvitesPageRes(page)
+		response := buildOrgInvitesPageRes(page, req.pm)
 
 		return response, nil
 	}
@@ -104,17 +104,17 @@ func listOrgInvitesByOrgEndpoint(svc auth.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		response := buildOrgInvitesPageRes(page)
+		response := buildOrgInvitesPageRes(page, req.pm)
 
 		return response, nil
 	}
 }
 
-func buildOrgInvitesPageRes(page auth.OrgInvitesPage) orgInvitePageRes {
+func buildOrgInvitesPageRes(page auth.OrgInvitesPage, pm auth.PageMetadataInvites) orgInvitePageRes {
 	response := orgInvitePageRes{
 		pageRes: pageRes{
-			Limit:  page.Limit,
-			Offset: page.Offset,
+			Limit:  pm.Limit,
+			Offset: pm.Offset,
 			Total:  page.Total,
 		},
 		Invites: make([]orgInviteRes, 0, len(page.Invites)),

--- a/auth/api/http/memberships/endpoint.go
+++ b/auth/api/http/memberships/endpoint.go
@@ -68,7 +68,7 @@ func listOrgMembershipsEndpoint(svc auth.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildOrgMembershipsResponse(page), nil
+		return buildOrgMembershipsResponse(page, pm), nil
 	}
 }
 
@@ -136,15 +136,15 @@ func restoreOrgMembershipsEndpoint(svc auth.Service) endpoint.Endpoint {
 	}
 }
 
-func buildOrgMembershipsResponse(omp auth.OrgMembershipsPage) orgMembershipPageRes {
+func buildOrgMembershipsResponse(omp auth.OrgMembershipsPage, pm apiutil.PageMetadata) orgMembershipPageRes {
 	res := orgMembershipPageRes{
 		pageRes: pageRes{
 			Total:  omp.Total,
-			Offset: omp.Offset,
-			Limit:  omp.Limit,
-			Email:  omp.Email,
-			Order:  omp.Order,
-			Dir:    omp.Dir,
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
+			Email:  pm.Email,
+			Order:  pm.Order,
+			Dir:    pm.Dir,
 		},
 		OrgMemberships: []viewOrgMembershipRes{},
 	}

--- a/auth/api/http/orgs/endpoint.go
+++ b/auth/api/http/orgs/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/MainfluxLabs/mainflux/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/go-kit/kit/endpoint"
 )
 
@@ -120,7 +121,7 @@ func listOrgsEndpoint(svc auth.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildOrgsResponse(page), nil
+		return buildOrgsResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -158,12 +159,12 @@ func restoreEndpoint(svc auth.Service) endpoint.Endpoint {
 	}
 }
 
-func buildOrgsResponse(op auth.OrgsPage) orgsPageRes {
+func buildOrgsResponse(op auth.OrgsPage, pm apiutil.PageMetadata) orgsPageRes {
 	res := orgsPageRes{
 		pageRes: pageRes{
 			Total:  op.Total,
-			Limit:  op.Limit,
-			Offset: op.Offset,
+			Limit:  pm.Limit,
+			Offset: pm.Offset,
 		},
 		Orgs: []viewOrgRes{},
 	}

--- a/auth/invites.go
+++ b/auth/invites.go
@@ -28,7 +28,7 @@ type OrgInvite struct {
 
 type OrgInvitesPage struct {
 	Invites []OrgInvite
-	apiutil.PageMetadata
+	Total   uint64
 }
 
 type PageMetadataInvites struct {

--- a/auth/memberships.go
+++ b/auth/memberships.go
@@ -32,7 +32,7 @@ type OrgMembership struct {
 // OrgMembershipsPage contains page related metadata as well as list of memberships that
 // belong to this page.
 type OrgMembershipsPage struct {
-	apiutil.PageMetadata
+	Total          uint64
 	OrgMemberships []OrgMembership
 }
 
@@ -165,12 +165,7 @@ func (svc service) ListOrgMemberships(ctx context.Context, token string, orgID s
 	if len(memberships) == 0 {
 		return OrgMembershipsPage{
 			OrgMemberships: []OrgMembership{},
-			PageMetadata: apiutil.PageMetadata{
-				Total:  0,
-				Offset: pm.Offset,
-				Limit:  pm.Limit,
-				Email:  pm.Email,
-			},
+			Total:          0,
 		}, nil
 	}
 
@@ -207,14 +202,7 @@ func (svc service) ListOrgMemberships(ctx context.Context, token string, orgID s
 
 	return OrgMembershipsPage{
 		OrgMemberships: oms,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  res.PageMetadata.Total,
-			Offset: res.PageMetadata.Offset,
-			Limit:  res.PageMetadata.Limit,
-			Email:  res.PageMetadata.Email,
-			Order:  res.PageMetadata.Order,
-			Dir:    res.PageMetadata.Dir,
-		},
+		Total:          res.PageMetadata.Total,
 	}, nil
 }
 

--- a/auth/mocks/invites.go
+++ b/auth/mocks/invites.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux/auth"
-	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 )
 
@@ -98,11 +97,7 @@ func (irm *invitesRepositoryMock) RetrieveOrgInvitesByOrg(ctx context.Context, o
 
 	return auth.OrgInvitesPage{
 		Invites: invites,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(irm.orgInvites)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:   uint64(len(irm.orgInvites)),
 	}, nil
 }
 
@@ -138,11 +133,7 @@ func (irm *invitesRepositoryMock) RetrieveOrgInvitesByUser(ctx context.Context, 
 
 	return auth.OrgInvitesPage{
 		Invites: invites,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(irm.orgInvites)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:   uint64(len(irm.orgInvites)),
 	}, nil
 }
 

--- a/auth/mocks/memberships.go
+++ b/auth/mocks/memberships.go
@@ -122,11 +122,7 @@ func (mrm *orgMembershipsRepositoryMock) RetrieveByOrg(_ context.Context, orgID 
 
 	return auth.OrgMembershipsPage{
 		OrgMemberships: oms,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(mrm.membershipsByOrgID[orgID])),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:          uint64(len(mrm.membershipsByOrgID[orgID])),
 	}, nil
 }
 

--- a/auth/mocks/orgs.go
+++ b/auth/mocks/orgs.go
@@ -100,12 +100,8 @@ func (orm *orgRepositoryMock) RetrieveByOwner(_ context.Context, ownerID string,
 	}
 
 	return auth.OrgsPage{
-		Orgs: orgs,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(orm.orgs)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Orgs:  orgs,
+		Total: uint64(len(orm.orgs)),
 	}, nil
 }
 
@@ -144,12 +140,8 @@ func (orm *orgRepositoryMock) RetrieveByMember(ctx context.Context, memberID str
 	})
 
 	return auth.OrgsPage{
-		Orgs: orgs,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(orm.orgs)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Orgs:  orgs,
+		Total: uint64(len(orm.orgs)),
 	}, nil
 }
 
@@ -180,12 +172,8 @@ func (orm *orgRepositoryMock) RetrieveAll(_ context.Context, pm apiutil.PageMeta
 	}
 
 	return auth.OrgsPage{
-		Orgs: orgs,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(orm.orgs)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Orgs:  orgs,
+		Total: uint64(len(orm.orgs)),
 	}, nil
 }
 

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -30,8 +30,8 @@ type Org struct {
 // OrgsPage contains page related metadata as well as list of orgs that
 // belong to this page.
 type OrgsPage struct {
-	apiutil.PageMetadata
-	Orgs []Org
+	Total uint64
+	Orgs  []Org
 }
 
 type User struct {

--- a/auth/postgres/invites.go
+++ b/auth/postgres/invites.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux/auth"
-	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/jackc/pgerrcode"
@@ -211,11 +210,7 @@ func (ir invitesRepository) RetrieveOrgInvitesByOrg(ctx context.Context, orgID s
 
 	page := auth.OrgInvitesPage{
 		Invites: invites,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:   total,
 	}
 
 	return page, nil
@@ -289,11 +284,7 @@ func (ir invitesRepository) RetrieveOrgInvitesByUser(ctx context.Context, userTy
 
 	page := auth.OrgInvitesPage{
 		Invites: invites,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:   total,
 	}
 
 	return page, nil

--- a/auth/postgres/memberships.go
+++ b/auth/postgres/memberships.go
@@ -68,11 +68,7 @@ func (omr orgMembershipsRepository) RetrieveByOrg(ctx context.Context, orgID str
 
 	page := auth.OrgMembershipsPage{
 		OrgMemberships: oms,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:          total,
 	}
 
 	return page, nil

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -260,12 +260,8 @@ func (or orgRepository) retrieve(ctx context.Context, query, cquery string, para
 	}
 
 	page := auth.OrgsPage{
-		Orgs: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: params["offset"].(uint64),
-			Limit:  params["limit"].(uint64),
-		},
+		Orgs:  items,
+		Total: total,
 	}
 
 	return page, nil

--- a/certs/api/endpoint.go
+++ b/certs/api/endpoint.go
@@ -46,8 +46,8 @@ func listSerials(svc certs.Service) endpoint.Endpoint {
 		res := certsPageRes{
 			pageRes: pageRes{
 				Total:  page.Total,
-				Offset: page.Offset,
-				Limit:  page.Limit,
+				Offset: req.offset,
+				Limit:  req.limit,
 			},
 			Certs: []certsRes{},
 		}

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -7,10 +7,8 @@ import "context"
 
 // ConfigsPage contains page related metadata as well as list
 type Page struct {
-	Total  uint64
-	Offset uint64
-	Limit  uint64
-	Certs  []Cert
+	Total uint64
+	Certs []Cert
 }
 
 // Repository specifies a Config persistence API.

--- a/certs/mocks/certs.go
+++ b/certs/mocks/certs.go
@@ -76,10 +76,8 @@ func (c *certsRepoMock) RetrieveAll(ctx context.Context, ownerID string, offset,
 	}
 
 	page := certs.Page{
-		Certs:  crts,
-		Total:  c.counter,
-		Offset: offset,
-		Limit:  limit,
+		Certs: crts,
+		Total: c.counter,
 	}
 	return page, nil
 }
@@ -116,10 +114,8 @@ func (c *certsRepoMock) RetrieveByThing(ctx context.Context, ownerID, thingID st
 	}
 
 	page := certs.Page{
-		Certs:  crts,
-		Total:  c.counter,
-		Offset: offset,
-		Limit:  limit,
+		Certs: crts,
+		Total: c.counter,
 	}
 	return page, nil
 }

--- a/certs/postgres/certs.go
+++ b/certs/postgres/certs.go
@@ -67,10 +67,8 @@ func (cr certsRepository) RetrieveAll(ctx context.Context, ownerID string, offse
 	}
 
 	return certs.Page{
-		Total:  total,
-		Limit:  limit,
-		Offset: offset,
-		Certs:  certificates,
+		Total: total,
+		Certs: certificates,
 	}, nil
 }
 
@@ -144,10 +142,8 @@ func (cr certsRepository) RetrieveByThing(ctx context.Context, ownerID, thingID 
 	}
 
 	return certs.Page{
-		Total:  total,
-		Limit:  limit,
-		Offset: offset,
-		Certs:  certificates,
+		Total: total,
+		Certs: certificates,
 	}, nil
 }
 

--- a/consumers/alarms/alarm.go
+++ b/consumers/alarms/alarm.go
@@ -17,7 +17,7 @@ type Alarm struct {
 }
 
 type AlarmsPage struct {
-	apiutil.PageMetadata
+	Total  uint64
 	Alarms []Alarm
 }
 

--- a/consumers/alarms/api/http/endpoint.go
+++ b/consumers/alarms/api/http/endpoint.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/MainfluxLabs/mainflux/consumers/alarms"
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/go-kit/kit/endpoint"
 )
 
@@ -22,7 +23,7 @@ func listAlarmsByGroupEndpoint(svc alarms.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildAlarmsResponse(page), nil
+		return buildAlarmsResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -38,7 +39,7 @@ func listAlarmsByThingEndpoint(svc alarms.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildAlarmsResponse(page), nil
+		return buildAlarmsResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -54,7 +55,7 @@ func listAlarmsByOrgEndpoint(svc alarms.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildAlarmsResponse(page), nil
+		return buildAlarmsResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -89,11 +90,11 @@ func removeAlarmsEndpoint(svc alarms.Service) endpoint.Endpoint {
 	}
 }
 
-func buildAlarmsResponse(ap alarms.AlarmsPage) AlarmsPageRes {
+func buildAlarmsResponse(ap alarms.AlarmsPage, pm apiutil.PageMetadata) AlarmsPageRes {
 	res := AlarmsPageRes{
 		Total:  ap.Total,
-		Offset: ap.Offset,
-		Limit:  ap.Limit,
+		Offset: pm.Offset,
+		Limit:  pm.Limit,
 		Alarms: []alarmResponse{},
 	}
 

--- a/consumers/alarms/postgres/alarms.go
+++ b/consumers/alarms/postgres/alarms.go
@@ -213,11 +213,7 @@ func (ar *alarmRepository) retrieve(ctx context.Context, query, cquery string, p
 
 	page := alarms.AlarmsPage{
 		Alarms: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: params["offset"].(uint64),
-			Limit:  params["limit"].(uint64),
-		},
+		Total:  total,
 	}
 
 	return page, nil

--- a/consumers/notifiers/api/http/endpoint.go
+++ b/consumers/notifiers/api/http/endpoint.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/MainfluxLabs/mainflux/consumers/notifiers"
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/go-kit/kit/endpoint"
 )
 
@@ -48,7 +49,7 @@ func listNotifiersByGroupEndpoint(svc notifiers.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildNotifiersByGroupResponse(nfs), nil
+		return buildNotifiersByGroupResponse(nfs, req.pageMetadata), nil
 	}
 }
 
@@ -105,12 +106,12 @@ func removeNotifiersEndpoint(svc notifiers.Service) endpoint.Endpoint {
 	}
 }
 
-func buildNotifiersByGroupResponse(nf notifiers.NotifiersPage) NotifiersPageRes {
+func buildNotifiersByGroupResponse(nf notifiers.NotifiersPage, pm apiutil.PageMetadata) NotifiersPageRes {
 	res := NotifiersPageRes{
 		pageRes: pageRes{
 			Total:  nf.Total,
-			Offset: nf.Offset,
-			Limit:  nf.Limit,
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
 		},
 		Notifiers: []notifierResponse{},
 	}

--- a/consumers/notifiers/mocks/notifier.go
+++ b/consumers/notifiers/mocks/notifier.go
@@ -108,11 +108,7 @@ func (nrm *notifierRepositoryMock) RetrieveByGroup(_ context.Context, groupID st
 
 	return notifiers.NotifiersPage{
 		Notifiers: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(items)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:     uint64(len(items)),
 	}, nil
 }
 

--- a/consumers/notifiers/notifier.go
+++ b/consumers/notifiers/notifier.go
@@ -23,7 +23,7 @@ type Notifier struct {
 }
 
 type NotifiersPage struct {
-	apiutil.PageMetadata
+	Total     uint64
 	Notifiers []Notifier
 }
 

--- a/consumers/notifiers/postgres/notifiers.go
+++ b/consumers/notifiers/postgres/notifiers.go
@@ -122,12 +122,7 @@ func (nr notifierRepository) RetrieveByGroup(ctx context.Context, groupID string
 
 	page := notifiers.NotifiersPage{
 		Notifiers: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-			Name:   pm.Name,
-		},
+		Total:     total,
 	}
 	return page, nil
 }

--- a/mqtt/api/http/endpoint.go
+++ b/mqtt/api/http/endpoint.go
@@ -25,8 +25,8 @@ func listSubscriptions(svc mqtt.Service) endpoint.Endpoint {
 		res := listSubscriptionsRes{
 			pageRes: pageRes{
 				Total:  subs.Total,
-				Offset: subs.Offset,
-				Limit:  subs.Limit,
+				Offset: req.pageMetadata.Offset,
+				Limit:  req.pageMetadata.Limit,
 			},
 			Subscriptions: []viewSubRes{},
 		}

--- a/mqtt/mocks/subscriptions.go
+++ b/mqtt/mocks/subscriptions.go
@@ -44,7 +44,7 @@ func (srm *subRepoMock) RetrieveByGroupID(_ context.Context, pm mqtt.PageMetadat
 	}
 
 	return mqtt.Page{
-		PageMetadata:  pm,
+		Total:         pm.Total,
 		Subscriptions: subs,
 	}, nil
 }

--- a/mqtt/postgres/subscriptions.go
+++ b/mqtt/postgres/subscriptions.go
@@ -128,11 +128,7 @@ func (mr *mqttRepository) RetrieveByGroupID(ctx context.Context, pm mqtt.PageMet
 	}
 
 	return mqtt.Page{
-		PageMetadata: mqtt.PageMetadata{
-			Total:  total,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:         total,
 		Subscriptions: items,
 	}, nil
 

--- a/mqtt/postgres/subscriptions_test.go
+++ b/mqtt/postgres/subscriptions_test.go
@@ -175,11 +175,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Limit:  10,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total:  numSubs,
-					Offset: 0,
-					Limit:  10,
-				},
+				Total:         numSubs,
 				Subscriptions: subs[0:10],
 			},
 			err: nil,
@@ -193,10 +189,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Limit: 0,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total: numSubs,
-					Limit: noLimit,
-				},
+				Total:         numSubs,
 				Subscriptions: subs,
 			},
 			err: nil,
@@ -211,11 +204,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Limit:  noLimit,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total:  0,
-					Offset: 0,
-					Limit:  noLimit,
-				},
+				Total:         0,
 				Subscriptions: nil,
 			},
 			err: nil,
@@ -226,11 +215,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 			groupID:  invalidID,
 			pageMeta: mqtt.PageMetadata{},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total:  0,
-					Offset: 0,
-					Limit:  noLimit,
-				},
+				Total:         0,
 				Subscriptions: nil,
 			},
 			err: dbutil.ErrRetrieveEntity,

--- a/mqtt/service_test.go
+++ b/mqtt/service_test.go
@@ -155,11 +155,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Limit:  10,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total:  total,
-					Offset: 0,
-					Limit:  10,
-				},
+				Total:         total,
 				Subscriptions: subs[:10],
 			},
 			err: nil,
@@ -174,11 +170,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Limit:  noLimit,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total:  total,
-					Offset: 0,
-					Limit:  noLimit,
-				},
+				Total:         total,
 				Subscriptions: subs,
 			},
 			err: nil,
@@ -191,9 +183,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Total: 0,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total: 0,
-				},
+				Total:         0,
 				Subscriptions: nil,
 			},
 			err: errors.ErrAuthentication,
@@ -206,9 +196,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Total: 0,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total: 0,
-				},
+				Total:         0,
 				Subscriptions: nil,
 			},
 			err: errors.ErrAuthentication,
@@ -223,11 +211,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Limit:  10,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total:  total,
-					Offset: 0,
-					Limit:  10,
-				},
+				Total:         total,
 				Subscriptions: subs[:10],
 			},
 			err: nil,
@@ -242,11 +226,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Limit:  noLimit,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total:  total,
-					Offset: 0,
-					Limit:  noLimit,
-				},
+				Total:         total,
 				Subscriptions: subs,
 			},
 			err: nil,
@@ -259,9 +239,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Total: 0,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total: 0,
-				},
+				Total:         0,
 				Subscriptions: nil,
 			},
 			err: dbutil.ErrNotFound,
@@ -273,9 +251,7 @@ func TestRetrieveByGroupID(t *testing.T) {
 				Total: 0,
 			},
 			page: mqtt.Page{
-				PageMetadata: mqtt.PageMetadata{
-					Total: 0,
-				},
+				Total:         0,
 				Subscriptions: nil,
 			},
 			err: errors.ErrAuthentication,

--- a/mqtt/subscriptions.go
+++ b/mqtt/subscriptions.go
@@ -14,7 +14,7 @@ type Subscription struct {
 
 // Page represents page metadata with content.
 type Page struct {
-	PageMetadata
+	Total         uint64
 	Subscriptions []Subscription
 }
 

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -44,7 +44,7 @@ func listJSONMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 		}
 
 		return listMessagesRes{
-			PageMetadata: page.PageMetadata,
+			PageMetadata: req.pageMeta,
 			Total:        page.Total,
 			Messages:     page.Messages,
 		}, nil
@@ -80,7 +80,7 @@ func listSenMLMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint 
 		}
 
 		return listMessagesRes{
-			PageMetadata: page.PageMetadata,
+			PageMetadata: req.pageMeta,
 			Total:        page.Total,
 			Messages:     page.Messages,
 		}, nil

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -53,7 +53,6 @@ type Message interface{}
 // MessagesPage contains page related metadata as well as list of messages that
 // belong to this page.
 type MessagesPage struct {
-	PageMetadata
 	Total    uint64
 	Messages []Message
 }

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -88,9 +88,8 @@ func (repo *messageRepositoryMock) readAll(profileID string, rpm readers.PageMet
 	}
 
 	return readers.MessagesPage{
-		PageMetadata: rpm,
-		Total:        uint64(len(msgs)),
-		Messages:     msgs[rpm.Offset:end],
+		Total:    uint64(len(msgs)),
+		Messages: msgs[rpm.Offset:end],
 	}, nil
 }
 

--- a/readers/mongodb/messages.go
+++ b/readers/mongodb/messages.go
@@ -120,9 +120,8 @@ func (repo mongoRepository) readAll(profileID string, rpm readers.PageMetadata) 
 	}
 
 	mp := readers.MessagesPage{
-		PageMetadata: rpm,
-		Total:        uint64(total),
-		Messages:     messages,
+		Total:    uint64(total),
+		Messages: messages,
 	}
 
 	return mp, nil

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -162,8 +162,7 @@ func (tr postgresRepository) restoreSenMLMessages(ctx context.Context, tx *sqlx.
 
 func (tr postgresRepository) readAll(rpm readers.PageMetadata) (readers.MessagesPage, error) {
 	page := readers.MessagesPage{
-		PageMetadata: rpm,
-		Messages:     []readers.Message{},
+		Messages: []readers.Message{},
 	}
 
 	order := tr.getOrder(rpm)

--- a/readers/timescale/messages.go
+++ b/readers/timescale/messages.go
@@ -136,8 +136,7 @@ func (tr timescaleRepository) readAll(rpm readers.PageMetadata) (readers.Message
 	defer rows.Close()
 
 	page := readers.MessagesPage{
-		PageMetadata: rpm,
-		Messages:     []readers.Message{},
+		Messages: []readers.Message{},
 	}
 	switch format {
 	case defTable:

--- a/rules/api/http/endpoint.go
+++ b/rules/api/http/endpoint.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/rules"
 	"github.com/go-kit/kit/endpoint"
 )
@@ -50,7 +51,7 @@ func listRulesByProfileEndpoint(svc rules.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildRulesPageResponse(page), nil
+		return buildRulesPageResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -66,7 +67,7 @@ func listRulesByGroupEndpoint(svc rules.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildRulesPageResponse(page), nil
+		return buildRulesPageResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -146,12 +147,12 @@ func buildRulesResponse(rules []rules.Rule, created bool) rulesRes {
 	return res
 }
 
-func buildRulesPageResponse(page rules.RulesPage) RulesPageRes {
+func buildRulesPageResponse(page rules.RulesPage, pm apiutil.PageMetadata) RulesPageRes {
 	res := RulesPageRes{
 		pageRes: pageRes{
 			Total:  page.Total,
-			Offset: page.Offset,
-			Limit:  page.Limit,
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
 		},
 		Rules: []ruleResponse{},
 	}

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -211,11 +211,7 @@ func (rr ruleRepository) retrieve(ctx context.Context, query, cquery string, par
 
 	page := rules.RulesPage{
 		Rules: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: params["offset"].(uint64),
-			Limit:  params["limit"].(uint64),
-		},
+		Total: total,
 	}
 
 	return page, nil

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -29,7 +29,7 @@ type Action struct {
 }
 
 type RulesPage struct {
-	apiutil.PageMetadata
+	Total uint64
 	Rules []Rule
 }
 

--- a/things/api/http/groups/endpoint.go
+++ b/things/api/http/groups/endpoint.go
@@ -145,7 +145,7 @@ func listGroupsEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildGroupsResponse(page), nil
+		return buildGroupsResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -161,7 +161,7 @@ func listGroupsByOrgEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildGroupsResponse(page), nil
+		return buildGroupsResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -253,12 +253,12 @@ func removeGroupsEndpoint(svc things.Service) endpoint.Endpoint {
 	}
 }
 
-func buildGroupsResponse(gp things.GroupPage) groupPageRes {
+func buildGroupsResponse(gp things.GroupPage, pm apiutil.PageMetadata) groupPageRes {
 	res := groupPageRes{
 		pageRes: pageRes{
 			Total:  gp.Total,
-			Limit:  gp.Limit,
-			Offset: gp.Offset,
+			Limit:  pm.Limit,
+			Offset: pm.Offset,
 		},
 		Groups: []viewGroupRes{},
 	}

--- a/things/api/http/memberships/endpoint.go
+++ b/things/api/http/memberships/endpoint.go
@@ -50,7 +50,7 @@ func listGroupMembershipsEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildGroupMembershipsResponse(gmp), nil
+		return buildGroupMembershipsResponse(gmp, req.pageMetadata), nil
 	}
 }
 
@@ -128,15 +128,15 @@ func restoreGroupMembershipsEndpoint(svc things.Service) endpoint.Endpoint {
 	}
 }
 
-func buildGroupMembershipsResponse(gpp things.GroupMembershipsPage) listGroupMembershipsRes {
+func buildGroupMembershipsResponse(gpp things.GroupMembershipsPage, pm apiutil.PageMetadata) listGroupMembershipsRes {
 	res := listGroupMembershipsRes{
 		pageRes: pageRes{
 			Total:  gpp.Total,
-			Limit:  gpp.Limit,
-			Offset: gpp.Offset,
-			Email:  gpp.Email,
-			Order:  gpp.Order,
-			Dir:    gpp.Dir,
+			Limit:  pm.Limit,
+			Offset: pm.Offset,
+			Email:  pm.Email,
+			Order:  pm.Order,
+			Dir:    pm.Dir,
 		},
 		GroupMemberships: []groupMembership{},
 	}

--- a/things/api/http/profiles/endpoint.go
+++ b/things/api/http/profiles/endpoint.go
@@ -120,7 +120,7 @@ func listProfilesEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildProfilesResponse(page), nil
+		return buildProfilesResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -136,7 +136,7 @@ func listProfilesByGroupEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildProfilesResponse(page), nil
+		return buildProfilesResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -152,7 +152,7 @@ func listProfilesByOrgEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildProfilesResponse(page), nil
+		return buildProfilesResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -282,15 +282,15 @@ func removeProfilesEndpoint(svc things.Service) endpoint.Endpoint {
 	}
 }
 
-func buildProfilesResponse(pp things.ProfilesPage) profilesPageRes {
+func buildProfilesResponse(pp things.ProfilesPage, pm apiutil.PageMetadata) profilesPageRes {
 	res := profilesPageRes{
 		pageRes: pageRes{
 			Total:  pp.Total,
-			Offset: pp.Offset,
-			Limit:  pp.Limit,
-			Order:  pp.Order,
-			Dir:    pp.Dir,
-			Name:   pp.Name,
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
+			Order:  pm.Order,
+			Dir:    pm.Dir,
+			Name:   pm.Name,
 		},
 		Profiles: []profileRes{},
 	}

--- a/things/api/http/things/endpoint.go
+++ b/things/api/http/things/endpoint.go
@@ -118,7 +118,7 @@ func listThingsEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildThingsResponse(page), nil
+		return buildThingsResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -135,7 +135,7 @@ func listThingsByProfileEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildThingsResponse(page), nil
+		return buildThingsResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -151,7 +151,7 @@ func listThingsByGroupEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildThingsResponse(page), nil
+		return buildThingsResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -167,7 +167,7 @@ func listThingsByOrgEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildThingsResponse(page), nil
+		return buildThingsResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -393,15 +393,15 @@ func restoreEndpoint(svc things.Service) endpoint.Endpoint {
 	}
 }
 
-func buildThingsResponse(tp things.ThingsPage) ThingsPageRes {
+func buildThingsResponse(tp things.ThingsPage, pm apiutil.PageMetadata) ThingsPageRes {
 	res := ThingsPageRes{
 		pageRes: pageRes{
 			Total:  tp.Total,
-			Offset: tp.Offset,
-			Limit:  tp.Limit,
-			Order:  tp.Order,
-			Dir:    tp.Dir,
-			Name:   tp.Name,
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
+			Order:  pm.Order,
+			Dir:    pm.Dir,
+			Name:   pm.Name,
 		},
 		Things: []thingRes{},
 	}

--- a/things/groups.go
+++ b/things/groups.go
@@ -30,7 +30,7 @@ type Group struct {
 // GroupPage contains page related metadata as well as list of groups that
 // belong to this page.
 type GroupPage struct {
-	apiutil.PageMetadata
+	Total  uint64
 	Groups []Group
 }
 

--- a/things/memberships.go
+++ b/things/memberships.go
@@ -19,7 +19,7 @@ type GroupMembership struct {
 }
 
 type GroupMembershipsPage struct {
-	apiutil.PageMetadata
+	Total            uint64
 	GroupMemberships []GroupMembership
 }
 
@@ -107,12 +107,7 @@ func (ts *thingsService) ListGroupMemberships(ctx context.Context, token, groupI
 	if len(memberships) == 0 {
 		return GroupMembershipsPage{
 			GroupMemberships: []GroupMembership{},
-			PageMetadata: apiutil.PageMetadata{
-				Total:  0,
-				Offset: pm.Offset,
-				Limit:  pm.Limit,
-				Email:  pm.Email,
-			},
+			Total:            0,
 		}, nil
 	}
 
@@ -149,14 +144,7 @@ func (ts *thingsService) ListGroupMemberships(ctx context.Context, token, groupI
 
 	return GroupMembershipsPage{
 		GroupMemberships: gms,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  res.PageMetadata.Total,
-			Offset: res.PageMetadata.Offset,
-			Limit:  res.PageMetadata.Limit,
-			Email:  res.PageMetadata.Email,
-			Order:  res.PageMetadata.Order,
-			Dir:    res.PageMetadata.Dir,
-		},
+		Total:            res.PageMetadata.Total,
 	}, nil
 }
 

--- a/things/mocks/groups.go
+++ b/things/mocks/groups.go
@@ -211,11 +211,7 @@ func (grm *groupRepositoryMock) RetrieveByIDs(_ context.Context, ids []string, p
 
 	page := things.GroupPage{
 		Groups: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(items)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:  uint64(len(items)),
 	}
 
 	return page, nil
@@ -257,11 +253,7 @@ func (grm *groupRepositoryMock) RetrieveAll(_ context.Context, pm apiutil.PageMe
 
 	page := things.GroupPage{
 		Groups: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(items)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:  uint64(len(items)),
 	}
 
 	return page, nil

--- a/things/mocks/memberships.go
+++ b/things/mocks/memberships.go
@@ -69,11 +69,7 @@ func (gmr *groupMembershipsRepositoryMock) RetrieveByGroup(_ context.Context, gr
 
 	return things.GroupMembershipsPage{
 		GroupMemberships: gms,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(gmr.groupMemberships[groupID])),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:            uint64(len(gmr.groupMemberships[groupID])),
 	}, nil
 
 }

--- a/things/mocks/profiles.go
+++ b/things/mocks/profiles.go
@@ -113,11 +113,7 @@ func (prm *profileRepositoryMock) RetrieveByGroups(_ context.Context, groupIDs [
 
 	page := things.ProfilesPage{
 		Profiles: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  prm.counter,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:    prm.counter,
 	}
 
 	return page, nil
@@ -138,11 +134,7 @@ func (prm *profileRepositoryMock) RetrieveAll(_ context.Context, pm apiutil.Page
 
 	page := things.ProfilesPage{
 		Profiles: prs,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  prm.counter,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:    prm.counter,
 	}
 
 	return page, nil

--- a/things/mocks/things.go
+++ b/things/mocks/things.go
@@ -142,11 +142,7 @@ func (trm *thingRepositoryMock) RetrieveByGroups(_ context.Context, groupIDs []s
 
 	page := things.ThingsPage{
 		Things: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  trm.counter,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:  trm.counter,
 	}
 
 	return page, nil
@@ -177,11 +173,7 @@ func (trm *thingRepositoryMock) RetrieveByProfile(_ context.Context, chID string
 
 	page := things.ThingsPage{
 		Things: ths,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(ths)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:  uint64(len(ths)),
 	}
 
 	return page, nil
@@ -241,11 +233,7 @@ func (trm *thingRepositoryMock) RetrieveAll(_ context.Context, pm apiutil.PageMe
 
 	page := things.ThingsPage{
 		Things: ths,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  trm.counter,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:  trm.counter,
 	}
 
 	return page, nil

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -325,11 +325,7 @@ func (gr groupRepository) retrieve(ctx context.Context, query, cquery string, pa
 
 	page := things.GroupPage{
 		Groups: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: params["offset"].(uint64),
-			Limit:  params["limit"].(uint64),
-		},
+		Total:  total,
 	}
 
 	return page, nil

--- a/things/postgres/memberships.go
+++ b/things/postgres/memberships.go
@@ -112,11 +112,7 @@ func (mr groupMembershipsRepository) RetrieveByGroup(ctx context.Context, groupI
 
 	page := things.GroupMembershipsPage{
 		GroupMemberships: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:            total,
 	}
 
 	return page, nil

--- a/things/postgres/profiles.go
+++ b/things/postgres/profiles.go
@@ -294,11 +294,7 @@ func (pr profileRepository) retrieve(ctx context.Context, query, cquery string, 
 
 	page := things.ProfilesPage{
 		Profiles: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: params["offset"].(uint64),
-			Limit:  params["limit"].(uint64),
-		},
+		Total:    total,
 	}
 
 	return page, nil

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -359,11 +359,7 @@ func (tr thingRepository) retrieve(ctx context.Context, query, cquery string, pa
 
 	page := things.ThingsPage{
 		Things: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: params["offset"].(uint64),
-			Limit:  params["limit"].(uint64),
-		},
+		Total:  total,
 	}
 
 	return page, nil

--- a/things/profiles.go
+++ b/things/profiles.go
@@ -36,7 +36,7 @@ type Transformer struct {
 // ProfilesPage contains page related metadata as well as list of profiles that
 // belong to this page.
 type ProfilesPage struct {
-	apiutil.PageMetadata
+	Total    uint64
 	Profiles []Profile
 }
 

--- a/things/things.go
+++ b/things/things.go
@@ -27,7 +27,7 @@ type Thing struct {
 // ThingsPage contains page related metadata as well as list of things that
 // belong to this page.
 type ThingsPage struct {
-	apiutil.PageMetadata
+	Total  uint64
 	Things []Thing
 }
 

--- a/users/api/grpc/endpoint.go
+++ b/users/api/grpc/endpoint.go
@@ -26,11 +26,11 @@ func listUsersByIDsEndpoint(svc users.Service) endpoint.Endpoint {
 		res := getUsersRes{
 			pageMetadata: &protomfx.PageMetadata{
 				Total:  up.Total,
-				Offset: up.Offset,
-				Limit:  up.Limit,
-				Email:  up.Email,
-				Order:  up.Order,
-				Dir:    up.Dir,
+				Offset: req.pageMetadata.Offset,
+				Limit:  req.pageMetadata.Limit,
+				Email:  req.pageMetadata.Email,
+				Order:  req.pageMetadata.Order,
+				Dir:    req.pageMetadata.Dir,
 			},
 		}
 

--- a/users/api/http/endpoint.go
+++ b/users/api/http/endpoint.go
@@ -174,7 +174,8 @@ func listUsersEndpoint(svc users.Service) endpoint.Endpoint {
 		if err != nil {
 			return users.UserPage{}, err
 		}
-		return buildUsersResponse(up), nil
+
+		return buildUsersResponse(up, pm), nil
 	}
 }
 
@@ -284,12 +285,12 @@ func restoreEndpoint(svc users.Service) endpoint.Endpoint {
 	}
 }
 
-func buildUsersResponse(up users.UserPage) userPageRes {
+func buildUsersResponse(up users.UserPage, pm users.PageMetadata) userPageRes {
 	res := userPageRes{
 		pageRes: pageRes{
 			Total:  up.Total,
-			Offset: up.Offset,
-			Limit:  up.Limit,
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
 		},
 		Users: []viewUserRes{},
 	}

--- a/users/mocks/users.go
+++ b/users/mocks/users.go
@@ -111,8 +111,6 @@ func (urm *userRepositoryMock) RetrieveByIDs(ctx context.Context, ids []string, 
 		if !ok {
 			return users.UserPage{}, dbutil.ErrNotFound
 		}
-		up.Offset = pm.Offset
-		up.Limit = pm.Limit
 		up.Total = uint64(i)
 		up.Users = []users.User{val}
 		return up, nil
@@ -142,8 +140,6 @@ func (urm *userRepositoryMock) RetrieveByIDs(ctx context.Context, ids []string, 
 		i++
 	}
 
-	up.Offset = pm.Offset
-	up.Limit = pm.Limit
 	up.Total = uint64(i)
 
 	return up, nil

--- a/users/postgres/users.go
+++ b/users/postgres/users.go
@@ -214,14 +214,7 @@ func (ur userRepository) RetrieveByIDs(ctx context.Context, userIDs []string, pm
 
 	page := users.UserPage{
 		Users: items,
-		PageMetadata: users.PageMetadata{
-			Total:  total,
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-			Email:  pm.Email,
-			Order:  pm.Order,
-			Dir:    pm.Dir,
-		},
+		Total: total,
 	}
 
 	return page, nil

--- a/users/service.go
+++ b/users/service.go
@@ -138,7 +138,7 @@ type PageMetadata struct {
 
 // UserPage contains a page of users.
 type UserPage struct {
-	PageMetadata
+	Total uint64
 	Users []User
 }
 

--- a/webhooks/api/http/endpoint.go
+++ b/webhooks/api/http/endpoint.go
@@ -6,6 +6,7 @@ package http
 import (
 	"context"
 
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/webhooks"
 	"github.com/go-kit/kit/endpoint"
 )
@@ -49,7 +50,7 @@ func listWebhooksByGroupEndpoint(svc webhooks.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildWebhooksByGroupResponse(page), nil
+		return buildWebhooksByGroupResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -65,7 +66,7 @@ func listWebhooksByThingEndpoint(svc webhooks.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildWebhooksByGroupResponse(page), nil
+		return buildWebhooksByGroupResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -123,12 +124,12 @@ func removeWebhooksEndpoint(svc webhooks.Service) endpoint.Endpoint {
 	}
 }
 
-func buildWebhooksByGroupResponse(wp webhooks.WebhooksPage) WebhooksPageRes {
+func buildWebhooksByGroupResponse(wp webhooks.WebhooksPage, pm apiutil.PageMetadata) WebhooksPageRes {
 	res := WebhooksPageRes{
 		pageRes: pageRes{
 			Total:  wp.Total,
-			Offset: wp.Offset,
-			Limit:  wp.Limit,
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
 		},
 		Webhooks: []webhookResponse{},
 	}

--- a/webhooks/mocks/webhooks.go
+++ b/webhooks/mocks/webhooks.go
@@ -59,11 +59,7 @@ func (wrm *webhookRepositoryMock) RetrieveByGroup(_ context.Context, groupID str
 
 	return webhooks.WebhooksPage{
 		Webhooks: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(items)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:    uint64(len(items)),
 	}, nil
 }
 
@@ -86,11 +82,7 @@ func (wrm *webhookRepositoryMock) RetrieveByThing(_ context.Context, thingID str
 
 	return webhooks.WebhooksPage{
 		Webhooks: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  uint64(len(items)),
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-		},
+		Total:    uint64(len(items)),
 	}, nil
 }
 

--- a/webhooks/postgres/webhooks.go
+++ b/webhooks/postgres/webhooks.go
@@ -221,11 +221,7 @@ func (wr webhookRepository) retrieve(ctx context.Context, query, cquery string, 
 
 	page := webhooks.WebhooksPage{
 		Webhooks: items,
-		PageMetadata: apiutil.PageMetadata{
-			Total:  total,
-			Offset: params["offset"].(uint64),
-			Limit:  params["limit"].(uint64),
-		},
+		Total:    total,
 	}
 
 	return page, nil

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -19,7 +19,7 @@ type Webhook struct {
 }
 
 type WebhooksPage struct {
-	apiutil.PageMetadata
+	Total    uint64
 	Webhooks []Webhook
 }
 


### PR DESCRIPTION
Closes #843. 

Also partially addresses #773. I say partially because that issue is present for different reasons in different services. In services such as `things` for example, where the issue was due to PageMetadata information being lost somewhere along the way from service method -> repository method call (because the repository method wasn't returning back all relevant PageMetadata fields), it is fixed by this PR - because from HTTP endpoints we now return an exact copy of query metadata that was supplied in the HTTP request.

In some other services (such as `users`), that issue is present because HTTP response structs don't encode all relevant PageMetadata fields - i.e. [here](https://github.com/MainfluxLabs/mainflux/blob/d966b6c5597db6636bd9fc6371f450299fc3faf0/users/api/http/responses.go#L25), and so it will have to be addressed separately. 