### PR TITLE
MF-853 - Add rule_id in alarms

### DIFF
--- a/consumers/alarms/alarm.go
+++ b/consumers/alarms/alarm.go
@@ -10,6 +10,7 @@ type Alarm struct {
 	ID       string
 	ThingID  string
 	GroupID  string
+	RuleID   string
 	Subtopic string
 	Protocol string
 	Payload  map[string]interface{}

--- a/consumers/alarms/api/http/endpoint.go
+++ b/consumers/alarms/api/http/endpoint.go
@@ -23,7 +23,7 @@ func listAlarmsByGroupEndpoint(svc alarms.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildAlarmsResponse(page, req.pageMetadata), nil
+		return buildAlarmsPageResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -39,7 +39,7 @@ func listAlarmsByThingEndpoint(svc alarms.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildAlarmsResponse(page, req.pageMetadata), nil
+		return buildAlarmsPageResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -55,7 +55,7 @@ func listAlarmsByOrgEndpoint(svc alarms.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildAlarmsResponse(page, req.pageMetadata), nil
+		return buildAlarmsPageResponse(page, req.pageMetadata), nil
 	}
 }
 
@@ -90,7 +90,7 @@ func removeAlarmsEndpoint(svc alarms.Service) endpoint.Endpoint {
 	}
 }
 
-func buildAlarmsResponse(ap alarms.AlarmsPage, pm apiutil.PageMetadata) AlarmsPageRes {
+func buildAlarmsPageResponse(ap alarms.AlarmsPage, pm apiutil.PageMetadata) AlarmsPageRes {
 	res := AlarmsPageRes{
 		Total:  ap.Total,
 		Offset: pm.Offset,
@@ -101,16 +101,7 @@ func buildAlarmsResponse(ap alarms.AlarmsPage, pm apiutil.PageMetadata) AlarmsPa
 	}
 
 	for _, a := range ap.Alarms {
-		alarm := alarmResponse{
-			ID:       a.ID,
-			ThingID:  a.ThingID,
-			GroupID:  a.GroupID,
-			Subtopic: a.Subtopic,
-			Protocol: a.Protocol,
-			Payload:  a.Payload,
-			Created:  a.Created,
-		}
-		res.Alarms = append(res.Alarms, alarm)
+		res.Alarms = append(res.Alarms, buildAlarmResponse(a))
 	}
 
 	return res
@@ -121,6 +112,7 @@ func buildAlarmResponse(alarm alarms.Alarm) alarmResponse {
 		ID:       alarm.ID,
 		ThingID:  alarm.ThingID,
 		GroupID:  alarm.GroupID,
+		RuleID:   alarm.RuleID,
 		Subtopic: alarm.Subtopic,
 		Protocol: alarm.Protocol,
 		Payload:  alarm.Payload,

--- a/consumers/alarms/api/http/responses.go
+++ b/consumers/alarms/api/http/responses.go
@@ -11,6 +11,7 @@ type alarmResponse struct {
 	ID       string                 `json:"id"`
 	ThingID  string                 `json:"thing_id"`
 	GroupID  string                 `json:"group_id"`
+	RuleID   string                 `json:"rule_id"`
 	Subtopic string                 `json:"subtopic"`
 	Protocol string                 `json:"protocol"`
 	Payload  map[string]interface{} `json:"payload"`

--- a/consumers/alarms/postgres/alarms.go
+++ b/consumers/alarms/postgres/alarms.go
@@ -33,8 +33,8 @@ func (ar *alarmRepository) Save(ctx context.Context, alarms ...alarms.Alarm) err
 		return errors.Wrap(dbutil.ErrCreateEntity, err)
 	}
 
-	q := `INSERT INTO alarms (id, thing_id, group_id, subtopic, protocol, payload, created)
-	      VALUES (:id, :thing_id, :group_id, :subtopic, :protocol, :payload, :created);`
+	q := `INSERT INTO alarms (id, thing_id, group_id, rule_id, subtopic, protocol, payload, created)
+	      VALUES (:id, :thing_id, :group_id, :rule_id, :subtopic, :protocol, :payload, :created);`
 
 	for _, alarm := range alarms {
 		dbAlarm, err := toDBAlarm(alarm)
@@ -67,7 +67,7 @@ func (ar *alarmRepository) Save(ctx context.Context, alarms ...alarms.Alarm) err
 }
 
 func (ar *alarmRepository) RetrieveByID(ctx context.Context, id string) (alarms.Alarm, error) {
-	q := `SELECT id, thing_id, group_id, subtopic, protocol, payload, created FROM alarms WHERE id = $1;`
+	q := `SELECT id, thing_id, group_id, rule_id, subtopic, protocol, payload, created FROM alarms WHERE id = $1;`
 
 	var dba dbAlarm
 	if err := ar.db.QueryRowxContext(ctx, q, id).StructScan(&dba); err != nil {
@@ -97,7 +97,7 @@ func (ar *alarmRepository) RetrieveByThing(ctx context.Context, thingID string, 
 	thingFilter := "thing_id = :thing_id"
 	whereClause := dbutil.BuildWhereClause(thingFilter, pq)
 
-	q := fmt.Sprintf(`SELECT id, thing_id, group_id, subtopic, protocol, payload, created 
+	q := fmt.Sprintf(`SELECT id, thing_id, group_id, rule_id, subtopic, protocol, payload, created 
 	                  FROM alarms %s ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
 	qc := fmt.Sprintf(`SELECT COUNT(*) FROM alarms %s;`, whereClause)
 
@@ -128,7 +128,7 @@ func (ar *alarmRepository) RetrieveByGroup(ctx context.Context, groupID string, 
 	groupFilter := "group_id = :group_id"
 	whereClause := dbutil.BuildWhereClause(groupFilter, pq)
 
-	q := fmt.Sprintf(`SELECT id, thing_id, group_id, subtopic, protocol, payload, created 
+	q := fmt.Sprintf(`SELECT id, thing_id, group_id, rule_id, subtopic, protocol, payload, created 
 	                  FROM alarms %s ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
 	qc := fmt.Sprintf(`SELECT COUNT(*) FROM alarms %s;`, whereClause)
 
@@ -157,7 +157,7 @@ func (ar *alarmRepository) RetrieveByGroups(ctx context.Context, groupIDs []stri
 	}
 
 	whereClause := dbutil.BuildWhereClause(giq, pq)
-	query := fmt.Sprintf(`SELECT id, thing_id, group_id, subtopic, protocol, payload, created FROM alarms %s ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
+	query := fmt.Sprintf(`SELECT id, thing_id, group_id, rule_id, subtopic, protocol, payload, created FROM alarms %s ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
 	cquery := fmt.Sprintf(`SELECT COUNT(*) FROM alarms %s;`, whereClause)
 
 	params := map[string]interface{}{
@@ -223,6 +223,7 @@ type dbAlarm struct {
 	ID       string `db:"id"`
 	ThingID  string `db:"thing_id"`
 	GroupID  string `db:"group_id"`
+	RuleID   string `db:"rule_id"`
 	Subtopic string `db:"subtopic"`
 	Protocol string `db:"protocol"`
 	Payload  []byte `db:"payload"`
@@ -239,6 +240,7 @@ func toDBAlarm(alarm alarms.Alarm) (dbAlarm, error) {
 		ID:       alarm.ID,
 		ThingID:  alarm.ThingID,
 		GroupID:  alarm.GroupID,
+		RuleID:   alarm.RuleID,
 		Subtopic: alarm.Subtopic,
 		Protocol: alarm.Protocol,
 		Payload:  payload,
@@ -256,6 +258,7 @@ func toAlarm(dbAlarm dbAlarm) (alarms.Alarm, error) {
 		ID:       dbAlarm.ID,
 		ThingID:  dbAlarm.ThingID,
 		GroupID:  dbAlarm.GroupID,
+		RuleID:   dbAlarm.RuleID,
 		Subtopic: dbAlarm.Subtopic,
 		Protocol: dbAlarm.Protocol,
 		Payload:  payload,

--- a/consumers/alarms/postgres/init.go
+++ b/consumers/alarms/postgres/init.go
@@ -50,6 +50,7 @@ func migrateDB(db *sqlx.DB) error {
 						id          UUID PRIMARY KEY,
 						thing_id    UUID NOT NULL,
 						group_id    UUID NOT NULL,
+						rule_id     UUID NOT NULL,
 						subtopic    VARCHAR(254),
 						protocol    TEXT,
 						payload     JSONB,

--- a/pkg/messaging/nats/pubsub.go
+++ b/pkg/messaging/nats/pubsub.go
@@ -25,7 +25,7 @@ const (
 	// SubjectSmpp represents subject used to subscribe to SMPP notifications.
 	SubjectSmpp = "smpp.*"
 	// SubjectAlarms represents subject used to subscribe to alarm triggers.
-	SubjectAlarms = "alarms"
+	SubjectAlarms = "alarms.*"
 )
 
 var _ messaging.PubSub = (*pubsub)(nil)

--- a/rules/service.go
+++ b/rules/service.go
@@ -213,7 +213,7 @@ func (rs *rulesService) Publish(ctx context.Context, message protomfx.Message) e
 				case ActionTypeSMPP:
 					newMsg.Subject = fmt.Sprintf("%s.%s", subjectSMPP, action.ID)
 				case ActionTypeAlarm:
-					newMsg.Subject = subjectAlarms
+					newMsg.Subject = fmt.Sprintf("%s.%s", subjectAlarms, rule.ID)
 				default:
 					continue
 				}


### PR DESCRIPTION
Added `rule_id` in the alarms table as a reference to the rule that created the alarm.

Resolves #853 