### PR TITLE
NOISSUE - Invalidate thing key from cache on key update

### DIFF
--- a/things/service.go
+++ b/things/service.go
@@ -354,7 +354,15 @@ func (ts *thingsService) UpdateKey(ctx context.Context, token, id, key string) e
 		return err
 	}
 
-	return ts.things.UpdateKey(ctx, id, key)
+	if err := ts.things.UpdateKey(ctx, id, key); err != nil {
+		return err
+	}
+
+	if err := ts.thingCache.Remove(ctx, id); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (ts *thingsService) ViewThing(ctx context.Context, token, id string) (Thing, error) {


### PR DESCRIPTION
When a Thing key is updated using the `.UpdateKey()` things service method, the previous key remains in the Redis cache and can still be used to authenticate the Thing.

This PR fixes that by invalidating the Thing keys from the cache after the key is updated.