### PR TITLE
MF-897 - Add group check to CanUserAccessGroup

### DIFF
--- a/things/service.go
+++ b/things/service.go
@@ -712,6 +712,9 @@ func (ts *thingsService) CanUserAccessProfile(ctx context.Context, req UserAcces
 }
 
 func (ts *thingsService) CanUserAccessGroup(ctx context.Context, req UserAccessReq) error {
+	if _, err := ts.groups.RetrieveByID(ctx, req.ID); err != nil {
+		return err
+	}
 	return ts.canAccessGroup(ctx, req.Token, req.ID, req.Action)
 }
 


### PR DESCRIPTION
Resolves #897

`isAdmin` check moved from the top of the function to avoid unnecessary gRPC calls for regular users.