### PR TITLE
MF-902 - Add org_name and inviter_email fields to Org-Invite API response objects

### DIFF
--- a/api/openapi/auth.yml
+++ b/api/openapi/auth.yml
@@ -878,10 +878,17 @@ components:
           type: string
           format: uuid
           description: The sending Inviter's unique user identifier
+        inviter_email:
+          type: string
+          format: email
+          description: The inviter user's e-mail address.
         org_id:
           type: string
           format: uuid
           description: The organization's unique identifier
+        org_name:
+          type: string
+          description: The organization's name.
         invitee_role:
           type: string
           description: The invitee's proposed role within the organization.

--- a/auth/api/http/invites/endpoint.go
+++ b/auth/api/http/invites/endpoint.go
@@ -132,13 +132,15 @@ func buildOrgInvitesPageRes(page auth.OrgInvitesPage, pm auth.PageMetadataInvite
 
 func buildOrgInviteRes(inv auth.OrgInvite) orgInviteRes {
 	return orgInviteRes{
-		ID:          inv.ID,
-		InviteeID:   inv.InviteeID,
-		InviteeRole: inv.InviteeRole,
-		InviterID:   inv.InviterID,
-		OrgID:       inv.OrgID,
-		CreatedAt:   inv.CreatedAt,
-		ExpiresAt:   inv.ExpiresAt,
-		State:       inv.State,
+		ID:           inv.ID,
+		InviteeID:    inv.InviteeID,
+		InviteeRole:  inv.InviteeRole,
+		InviterID:    inv.InviterID,
+		InviterEmail: inv.InviterEmail,
+		OrgID:        inv.OrgID,
+		OrgName:      inv.OrgName,
+		CreatedAt:    inv.CreatedAt,
+		ExpiresAt:    inv.ExpiresAt,
+		State:        inv.State,
 	}
 }

--- a/auth/api/http/invites/responses.go
+++ b/auth/api/http/invites/responses.go
@@ -68,14 +68,16 @@ func (res respondOrgInviteRes) Empty() bool {
 }
 
 type orgInviteRes struct {
-	ID          string    `json:"id"`
-	InviteeID   string    `json:"invitee_id"`
-	InviterID   string    `json:"inviter_id"`
-	OrgID       string    `json:"org_id"`
-	InviteeRole string    `json:"invitee_role"`
-	CreatedAt   time.Time `json:"created_at"`
-	ExpiresAt   time.Time `json:"expires_at"`
-	State       string    `json:"state"`
+	ID           string    `json:"id"`
+	InviteeID    string    `json:"invitee_id"`
+	InviterID    string    `json:"inviter_id"`
+	InviterEmail string    `json:"inviter_email"`
+	OrgID        string    `json:"org_id"`
+	OrgName      string    `json:"org_name"`
+	InviteeRole  string    `json:"invitee_role"`
+	CreatedAt    time.Time `json:"created_at"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	State        string    `json:"state"`
 }
 
 func (res orgInviteRes) Code() int {

--- a/auth/invites.go
+++ b/auth/invites.go
@@ -16,14 +16,16 @@ import (
 var ErrInvalidInviteResponse = errors.New("invalid invite response action")
 
 type OrgInvite struct {
-	ID          string
-	InviteeID   string
-	InviterID   string
-	OrgID       string
-	InviteeRole string
-	CreatedAt   time.Time
-	ExpiresAt   time.Time
-	State       string
+	ID           string
+	InviteeID    string
+	InviterID    string
+	InviterEmail string
+	OrgID        string
+	OrgName      string
+	InviteeRole  string
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+	State        string
 }
 
 type OrgInvitesPage struct {
@@ -210,6 +212,10 @@ func (svc service) ViewOrgInvite(ctx context.Context, token, inviteID string) (O
 		return OrgInvite{}, err
 	}
 
+	if err := svc.setInviteInfo(ctx, &invite); err != nil {
+		return OrgInvite{}, err
+	}
+
 	if err := svc.isAdmin(ctx, token); err == nil {
 		return invite, nil
 	}
@@ -292,6 +298,12 @@ func (svc service) ListOrgInvitesByOrg(ctx context.Context, token, orgID string,
 		return OrgInvitesPage{}, err
 	}
 
+	for idx := range page.Invites {
+		if err := svc.setInviteInfo(ctx, &page.Invites[idx]); err != nil {
+			return OrgInvitesPage{}, err
+		}
+	}
+
 	return page, nil
 }
 
@@ -317,7 +329,34 @@ func (svc service) ListOrgInvitesByUser(ctx context.Context, token, userType, us
 		return OrgInvitesPage{}, err
 	}
 
+	for idx := range invitesPage.Invites {
+		if err := svc.setInviteInfo(ctx, &invitesPage.Invites[idx]); err != nil {
+			return OrgInvitesPage{}, err
+		}
+	}
+
 	return invitesPage, nil
+}
+
+// Sets invite.InviterEmail and invite.OrgName fields of the passed invite.
+func (svc service) setInviteInfo(ctx context.Context, invite *OrgInvite) error {
+	org, err := svc.orgs.RetrieveByID(ctx, invite.OrgID)
+	if err != nil {
+		return err
+	}
+
+	invite.OrgName = org.Name
+
+	usersReq := &protomfx.UsersByIDsReq{Ids: []string{invite.InviterID}}
+	usersRes, err := svc.users.GetUsersByIDs(ctx, usersReq)
+	if err != nil {
+		return err
+	}
+
+	userInviter := usersRes.GetUsers()[0]
+	invite.InviterEmail = userInviter.GetEmail()
+
+	return nil
 }
 
 func (svc service) SendOrgInviteEmail(ctx context.Context, invite OrgInvite, email, orgName, invRedirectPath string) error {

--- a/auth/invites.go
+++ b/auth/invites.go
@@ -212,7 +212,7 @@ func (svc service) ViewOrgInvite(ctx context.Context, token, inviteID string) (O
 		return OrgInvite{}, err
 	}
 
-	if err := svc.setInviteInfo(ctx, &invite); err != nil {
+	if err := svc.populateInviteInfo(ctx, &invite); err != nil {
 		return OrgInvite{}, err
 	}
 
@@ -299,7 +299,7 @@ func (svc service) ListOrgInvitesByOrg(ctx context.Context, token, orgID string,
 	}
 
 	for idx := range page.Invites {
-		if err := svc.setInviteInfo(ctx, &page.Invites[idx]); err != nil {
+		if err := svc.populateInviteInfo(ctx, &page.Invites[idx]); err != nil {
 			return OrgInvitesPage{}, err
 		}
 	}
@@ -330,7 +330,7 @@ func (svc service) ListOrgInvitesByUser(ctx context.Context, token, userType, us
 	}
 
 	for idx := range invitesPage.Invites {
-		if err := svc.setInviteInfo(ctx, &invitesPage.Invites[idx]); err != nil {
+		if err := svc.populateInviteInfo(ctx, &invitesPage.Invites[idx]); err != nil {
 			return OrgInvitesPage{}, err
 		}
 	}
@@ -339,7 +339,7 @@ func (svc service) ListOrgInvitesByUser(ctx context.Context, token, userType, us
 }
 
 // Sets invite.InviterEmail and invite.OrgName fields of the passed invite.
-func (svc service) setInviteInfo(ctx context.Context, invite *OrgInvite) error {
+func (svc service) populateInviteInfo(ctx context.Context, invite *OrgInvite) error {
 	org, err := svc.orgs.RetrieveByID(ctx, invite.OrgID)
 	if err != nil {
 		return err
@@ -353,8 +353,8 @@ func (svc service) setInviteInfo(ctx context.Context, invite *OrgInvite) error {
 		return err
 	}
 
-	userInviter := usersRes.GetUsers()[0]
-	invite.InviterEmail = userInviter.GetEmail()
+	inviter := usersRes.GetUsers()[0]
+	invite.InviterEmail = inviter.GetEmail()
 
 	return nil
 }


### PR DESCRIPTION
Both fields are added to the `auth.OrgInvite` type and are populated by service methods for retrieving org invites.