### PR TITLE
MF-875 - Improve Makefile with new commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ endef
 
 all: $(SERVICES)
 
-.PHONY: all $(SERVICES) dockers dockers_dev latest release
+.PHONY: all $(SERVICES) dockers dockers_dev latest release logs_%
 
 clean:
 	rm -rf ${BUILD_DIR}
@@ -118,4 +118,13 @@ rundev:
 	cd scripts && ./run.sh
 
 run:
-	docker-compose -f docker/docker-compose.yml up
+	docker compose -f docker/docker-compose.yml up -d
+
+down:
+	docker compose -f docker/docker-compose.yml down
+
+logs:
+	docker compose -f docker/docker-compose.yml logs -f
+
+logs_%:
+	docker compose -f docker/docker-compose.yml logs -f $* 


### PR DESCRIPTION
This is a very small PR that improves the usage of Makefile by introducing a few new commands:

- `make run` - runs the containers in detached mode (`-d`), keeping the terminal usable (previously, make run blocked the terminal)
- `make down` - stops and removes all containers
- `make logs` - displays logs for all  services, (similar to how make run worked before detached mode)
- `make logs_[svc-name]` - display logs for a single service, useful when there's a lot going on in normal logs. Replace `[svc-name]` with the service name from `docker-compose.yml`. For example: `make logs_http-adapter` 

Resolves #875 