### PR TITLE
MF-913 - Remove references to types from deprecated github.com/golang/protobuf module

### DIFF
--- a/auth/api/grpc/client.go
+++ b/auth/api/grpc/client.go
@@ -11,9 +11,9 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kitgrpc "github.com/go-kit/kit/transport/grpc"
-	"github.com/golang/protobuf/ptypes/empty"
 	opentracing "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const (
@@ -59,7 +59,7 @@ func NewClient(conn *grpc.ClientConn, tracer opentracing.Tracer, timeout time.Du
 			"Authorize",
 			encodeAuthorizeRequest,
 			decodeEmptyResponse,
-			empty.Empty{},
+			emptypb.Empty{},
 		).Endpoint()),
 		getOwnerIDByOrgID: kitot.TraceClient(tracer, "get_owner_id_by_org_id")(kitgrpc.NewClient(
 			conn,
@@ -83,7 +83,7 @@ func NewClient(conn *grpc.ClientConn, tracer opentracing.Tracer, timeout time.Du
 			"AssignRole",
 			encodeAssignRoleRequest,
 			decodeEmptyResponse,
-			empty.Empty{},
+			emptypb.Empty{},
 		).Endpoint()),
 		createDormantOrgInvite: kitot.TraceClient(tracer, "create_dormant_org_invite")(kitgrpc.NewClient(
 			conn,
@@ -91,7 +91,7 @@ func NewClient(conn *grpc.ClientConn, tracer opentracing.Tracer, timeout time.Du
 			"CreateDormantOrgInvite",
 			encodeCreateDormantOrgInviteRequest,
 			decodeEmptyResponse,
-			empty.Empty{},
+			emptypb.Empty{},
 		).Endpoint()),
 		activateOrgInvite: kitot.TraceClient(tracer, "activate_org_invite")(kitgrpc.NewClient(
 			conn,
@@ -99,7 +99,7 @@ func NewClient(conn *grpc.ClientConn, tracer opentracing.Tracer, timeout time.Du
 			"ActivateOrgInvite",
 			encodeActivateOrgInviteRequest,
 			decodeEmptyResponse,
-			empty.Empty{},
+			emptypb.Empty{},
 		).Endpoint()),
 
 		timeout: timeout,
@@ -152,17 +152,17 @@ func decodeIdentifyResponse(_ context.Context, grpcRes interface{}) (interface{}
 	return identityRes{id: res.GetId(), email: res.GetEmail()}, nil
 }
 
-func (client grpcClient) Authorize(ctx context.Context, req *protomfx.AuthorizeReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (client grpcClient) Authorize(ctx context.Context, req *protomfx.AuthorizeReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	ctx, close := context.WithTimeout(ctx, client.timeout)
 	defer close()
 
 	res, err := client.authorize(ctx, authReq{Token: req.GetToken(), Object: req.GetObject(), Subject: req.GetSubject(), Action: req.GetAction()})
 	if err != nil {
-		return &empty.Empty{}, err
+		return &emptypb.Empty{}, err
 	}
 
 	er := res.(emptyRes)
-	return &empty.Empty{}, er.err
+	return &emptypb.Empty{}, er.err
 }
 
 func encodeAuthorizeRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
@@ -198,17 +198,17 @@ func decodeGetOwnerIDByOrgIDResponse(_ context.Context, grpcRes interface{}) (in
 	return ownerIDByOrgIDRes{ownerID: res.GetValue()}, nil
 }
 
-func (client grpcClient) AssignRole(ctx context.Context, req *protomfx.AssignRoleReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (client grpcClient) AssignRole(ctx context.Context, req *protomfx.AssignRoleReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	ctx, close := context.WithTimeout(ctx, client.timeout)
 	defer close()
 
 	res, err := client.assignRole(ctx, assignRoleReq{ID: req.GetId(), Role: req.GetRole()})
 	if err != nil {
-		return &empty.Empty{}, err
+		return &emptypb.Empty{}, err
 	}
 
 	er := res.(emptyRes)
-	return &empty.Empty{}, er.err
+	return &emptypb.Empty{}, er.err
 }
 
 func encodeAssignRoleRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
@@ -244,7 +244,7 @@ func decodeRetrieveRoleResponse(_ context.Context, grpcRes interface{}) (interfa
 	return retrieveRoleRes{role: res.GetRole()}, nil
 }
 
-func (client grpcClient) CreateDormantOrgInvite(ctx context.Context, req *protomfx.CreateDormantOrgInviteReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (client grpcClient) CreateDormantOrgInvite(ctx context.Context, req *protomfx.CreateDormantOrgInviteReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	ctx, close := context.WithTimeout(ctx, client.timeout)
 	defer close()
 
@@ -256,11 +256,11 @@ func (client grpcClient) CreateDormantOrgInvite(ctx context.Context, req *protom
 	})
 
 	if err != nil {
-		return &empty.Empty{}, err
+		return &emptypb.Empty{}, err
 	}
 
 	er := res.(emptyRes)
-	return &empty.Empty{}, er.err
+	return &emptypb.Empty{}, er.err
 }
 
 func encodeCreateDormantOrgInviteRequest(_ context.Context, grpcReq any) (any, error) {
@@ -273,7 +273,7 @@ func encodeCreateDormantOrgInviteRequest(_ context.Context, grpcReq any) (any, e
 	}, nil
 }
 
-func (client grpcClient) ActivateOrgInvite(ctx context.Context, req *protomfx.ActivateOrgInviteReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (client grpcClient) ActivateOrgInvite(ctx context.Context, req *protomfx.ActivateOrgInviteReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	ctx, close := context.WithTimeout(ctx, client.timeout)
 	defer close()
 
@@ -284,11 +284,11 @@ func (client grpcClient) ActivateOrgInvite(ctx context.Context, req *protomfx.Ac
 	})
 
 	if err != nil {
-		return &empty.Empty{}, err
+		return &emptypb.Empty{}, err
 	}
 
 	er := res.(emptyRes)
-	return &empty.Empty{}, er.err
+	return &emptypb.Empty{}, er.err
 }
 
 func encodeActivateOrgInviteRequest(_ context.Context, grpcReq any) (any, error) {

--- a/auth/api/grpc/server.go
+++ b/auth/api/grpc/server.go
@@ -12,10 +12,10 @@ import (
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kitgrpc "github.com/go-kit/kit/transport/grpc"
-	"github.com/golang/protobuf/ptypes/empty"
 	opentracing "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 var _ protomfx.AuthServiceServer = (*grpcServer)(nil)
@@ -93,12 +93,12 @@ func (s *grpcServer) Identify(ctx context.Context, token *protomfx.Token) (*prot
 	return res.(*protomfx.UserIdentity), nil
 }
 
-func (s *grpcServer) Authorize(ctx context.Context, req *protomfx.AuthorizeReq) (*empty.Empty, error) {
+func (s *grpcServer) Authorize(ctx context.Context, req *protomfx.AuthorizeReq) (*emptypb.Empty, error) {
 	_, res, err := s.authorize.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}
-	return res.(*empty.Empty), nil
+	return res.(*emptypb.Empty), nil
 }
 
 func (s *grpcServer) GetOwnerIDByOrgID(ctx context.Context, req *protomfx.OrgID) (*protomfx.OwnerID, error) {
@@ -110,12 +110,12 @@ func (s *grpcServer) GetOwnerIDByOrgID(ctx context.Context, req *protomfx.OrgID)
 	return res.(*protomfx.OwnerID), nil
 }
 
-func (s *grpcServer) AssignRole(ctx context.Context, req *protomfx.AssignRoleReq) (*empty.Empty, error) {
+func (s *grpcServer) AssignRole(ctx context.Context, req *protomfx.AssignRoleReq) (*emptypb.Empty, error) {
 	_, res, err := s.assignRole.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}
-	return res.(*empty.Empty), nil
+	return res.(*emptypb.Empty), nil
 }
 
 func (s *grpcServer) RetrieveRole(ctx context.Context, req *protomfx.RetrieveRoleReq) (*protomfx.RetrieveRoleRes, error) {
@@ -126,22 +126,22 @@ func (s *grpcServer) RetrieveRole(ctx context.Context, req *protomfx.RetrieveRol
 	return res.(*protomfx.RetrieveRoleRes), nil
 }
 
-func (s *grpcServer) CreateDormantOrgInvite(ctx context.Context, req *protomfx.CreateDormantOrgInviteReq) (*empty.Empty, error) {
+func (s *grpcServer) CreateDormantOrgInvite(ctx context.Context, req *protomfx.CreateDormantOrgInviteReq) (*emptypb.Empty, error) {
 	_, res, err := s.createDormantOrgInvite.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}
 
-	return res.(*empty.Empty), nil
+	return res.(*emptypb.Empty), nil
 }
 
-func (s *grpcServer) ActivateOrgInvite(ctx context.Context, req *protomfx.ActivateOrgInviteReq) (*empty.Empty, error) {
+func (s *grpcServer) ActivateOrgInvite(ctx context.Context, req *protomfx.ActivateOrgInviteReq) (*emptypb.Empty, error) {
 	_, res, err := s.activateOrgInvite.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}
 
-	return res.(*empty.Empty), nil
+	return res.(*emptypb.Empty), nil
 }
 
 func decodeAssignRoleRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
@@ -215,7 +215,7 @@ func decodeActivateOrgInviteRequest(_ context.Context, grpcReq interface{}) (any
 
 func encodeEmptyResponse(_ context.Context, grpcRes interface{}) (interface{}, error) {
 	res := grpcRes.(emptyRes)
-	return &empty.Empty{}, encodeError(res.err)
+	return &emptypb.Empty{}, encodeError(res.err)
 }
 
 func encodeError(err error) error {

--- a/mqtt/mocks/auth.go
+++ b/mqtt/mocks/auth.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
-	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 var _ protomfx.AuthServiceClient = (*authServiceMock)(nil)
@@ -43,19 +43,19 @@ func (svc authServiceMock) Issue(_ context.Context, in *protomfx.IssueReq, _ ...
 	return nil, errors.ErrAuthentication
 }
 
-func (svc authServiceMock) Authorize(_ context.Context, req *protomfx.AuthorizeReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (svc authServiceMock) Authorize(_ context.Context, req *protomfx.AuthorizeReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	if req.GetToken() != "token" {
-		return &empty.Empty{}, errors.ErrAuthorization
+		return &emptypb.Empty{}, errors.ErrAuthorization
 	}
 
-	return &empty.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
 func (svc authServiceMock) GetOwnerIDByOrgID(_ context.Context, _ *protomfx.OrgID, _ ...grpc.CallOption) (*protomfx.OwnerID, error) {
 	panic("not implemented")
 }
 
-func (svc authServiceMock) AssignRole(_ context.Context, _ *protomfx.AssignRoleReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (svc authServiceMock) AssignRole(_ context.Context, _ *protomfx.AssignRoleReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	panic("not implemented")
 }
 
@@ -63,10 +63,10 @@ func (svc authServiceMock) RetrieveRole(_ context.Context, _ *protomfx.RetrieveR
 	panic("not implemented")
 }
 
-func (svc authServiceMock) CreateDormantOrgInvite(ctx context.Context, req *protomfx.CreateDormantOrgInviteReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (svc authServiceMock) CreateDormantOrgInvite(ctx context.Context, req *protomfx.CreateDormantOrgInviteReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	panic("not implemented")
 }
 
-func (svc authServiceMock) ActivateOrgInvite(ctx context.Context, req *protomfx.ActivateOrgInviteReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (svc authServiceMock) ActivateOrgInvite(ctx context.Context, req *protomfx.ActivateOrgInviteReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	panic("not implemented")
 }

--- a/pkg/mocks/auth.go
+++ b/pkg/mocks/auth.go
@@ -11,8 +11,8 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/users"
-	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 var _ protomfx.AuthServiceClient = (*authServiceMock)(nil)
@@ -62,26 +62,26 @@ func (svc authServiceMock) Issue(_ context.Context, in *protomfx.IssueReq, _ ...
 	return nil, errors.ErrAuthentication
 }
 
-func (svc authServiceMock) Authorize(_ context.Context, req *protomfx.AuthorizeReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (svc authServiceMock) Authorize(_ context.Context, req *protomfx.AuthorizeReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	u, ok := svc.usersByEmail[req.Token]
 	if !ok {
-		return &empty.Empty{}, errors.ErrAuthentication
+		return &emptypb.Empty{}, errors.ErrAuthentication
 	}
 
 	switch req.Subject {
 	case auth.RootSub:
 		if !contains(svc.roles[auth.RootSub], u.ID) {
-			return &empty.Empty{}, errors.ErrAuthorization
+			return &emptypb.Empty{}, errors.ErrAuthorization
 		}
 	case auth.OrgSub:
 		if err := svc.canAccessOrg(u.ID, req.Action); err != nil {
-			return &empty.Empty{}, err
+			return &emptypb.Empty{}, err
 		}
 	default:
-		return &empty.Empty{}, errors.ErrAuthorization
+		return &emptypb.Empty{}, errors.ErrAuthorization
 	}
 
-	return &empty.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
 func contains(ids []string, id string) bool {
@@ -134,7 +134,7 @@ func (svc authServiceMock) GetOwnerIDByOrgID(_ context.Context, req *protomfx.Or
 	return nil, dbutil.ErrNotFound
 }
 
-func (svc authServiceMock) AssignRole(_ context.Context, _ *protomfx.AssignRoleReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (svc authServiceMock) AssignRole(_ context.Context, _ *protomfx.AssignRoleReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	panic("not implemented")
 }
 
@@ -142,10 +142,10 @@ func (svc authServiceMock) RetrieveRole(_ context.Context, _ *protomfx.RetrieveR
 	panic("not implemented")
 }
 
-func (svc authServiceMock) CreateDormantOrgInvite(ctx context.Context, req *protomfx.CreateDormantOrgInviteReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (svc authServiceMock) CreateDormantOrgInvite(ctx context.Context, req *protomfx.CreateDormantOrgInviteReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	panic("not implemented")
 }
 
-func (svc authServiceMock) ActivateOrgInvite(ctx context.Context, req *protomfx.ActivateOrgInviteReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (svc authServiceMock) ActivateOrgInvite(ctx context.Context, req *protomfx.ActivateOrgInviteReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	panic("not implemented")
 }

--- a/pkg/mocks/thingsauth.go
+++ b/pkg/mocks/thingsauth.go
@@ -10,7 +10,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/things"
-	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -62,52 +61,52 @@ func (svc thingsServiceMock) GetConfigByThingID(context.Context, *protomfx.Thing
 func (svc thingsServiceMock) CanUserAccessThing(_ context.Context, req *protomfx.UserAccessReq, _ ...grpc.CallOption) (*emptypb.Empty, error) {
 	th, ok := svc.things[req.GetToken()]
 	if !ok {
-		return &empty.Empty{}, errors.ErrAuthentication
+		return &emptypb.Empty{}, errors.ErrAuthentication
 	}
 
 	if req.GetId() == th.ID {
-		return &empty.Empty{}, nil
+		return &emptypb.Empty{}, nil
 	}
 
-	return &empty.Empty{}, errors.ErrAuthorization
+	return &emptypb.Empty{}, errors.ErrAuthorization
 }
 
 func (svc thingsServiceMock) CanUserAccessProfile(_ context.Context, req *protomfx.UserAccessReq, _ ...grpc.CallOption) (*emptypb.Empty, error) {
 	gr, ok := svc.groups[req.GetToken()]
 	if !ok {
-		return &empty.Empty{}, errors.ErrAuthentication
+		return &emptypb.Empty{}, errors.ErrAuthentication
 	}
 
 	if pr, ok := svc.profiles[req.GetToken()]; ok {
 		if pr.GroupID == gr.ID {
-			return &empty.Empty{}, nil
+			return &emptypb.Empty{}, nil
 		}
 	}
 
-	return &empty.Empty{}, errors.ErrAuthorization
+	return &emptypb.Empty{}, errors.ErrAuthorization
 }
 
 func (svc thingsServiceMock) CanUserAccessGroup(_ context.Context, req *protomfx.UserAccessReq, _ ...grpc.CallOption) (*emptypb.Empty, error) {
 	gr, ok := svc.groups[req.GetToken()]
 	if !ok {
-		return &empty.Empty{}, errors.ErrAuthentication
+		return &emptypb.Empty{}, errors.ErrAuthentication
 	}
 
 	if req.GetId() == gr.ID {
-		return &empty.Empty{}, nil
+		return &emptypb.Empty{}, nil
 	}
 
-	return &empty.Empty{}, errors.ErrAuthorization
+	return &emptypb.Empty{}, errors.ErrAuthorization
 }
 
 func (svc thingsServiceMock) CanThingAccessGroup(_ context.Context, req *protomfx.ThingAccessReq, _ ...grpc.CallOption) (*emptypb.Empty, error) {
 	if th, ok := svc.things[req.GetKey()]; ok {
 		if th.GroupID == req.GetId() {
-			return &empty.Empty{}, nil
+			return &emptypb.Empty{}, nil
 		}
 	}
 
-	return &empty.Empty{}, errors.ErrAuthorization
+	return &emptypb.Empty{}, errors.ErrAuthorization
 }
 
 func (svc thingsServiceMock) Identify(_ context.Context, key *protomfx.ThingKey, _ ...grpc.CallOption) (*protomfx.ThingID, error) {

--- a/pkg/proto/mfx.pb.go
+++ b/pkg/proto/mfx.pb.go
@@ -6,14 +6,15 @@ package protomfx
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
-	io "io"
-	math "math"
-	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/rules/api/grpc/client.go
+++ b/rules/api/grpc/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kitgrpc "github.com/go-kit/kit/transport/grpc"
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -32,7 +31,7 @@ func NewClient(conn *grpc.ClientConn, tracer opentracing.Tracer, timeout time.Du
 			"Publish",
 			encodePublishRequest,
 			decodeEmptyResponse,
-			empty.Empty{},
+			emptypb.Empty{},
 		).Endpoint()),
 	}
 }
@@ -48,7 +47,7 @@ func (gc grpcClient) Publish(ctx context.Context, req *protomfx.PublishReq, _ ..
 	}
 
 	er := res.(emptyRes)
-	return &empty.Empty{}, er.err
+	return &emptypb.Empty{}, er.err
 }
 
 func encodePublishRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {

--- a/rules/api/grpc/server.go
+++ b/rules/api/grpc/server.go
@@ -9,7 +9,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/rules"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kitgrpc "github.com/go-kit/kit/transport/grpc"
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -38,7 +37,7 @@ func (gs grpcServer) Publish(ctx context.Context, message *protomfx.PublishReq) 
 		return nil, nil
 	}
 
-	return res.(*empty.Empty), nil
+	return res.(*emptypb.Empty), nil
 }
 
 func decodePublishRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
@@ -48,7 +47,7 @@ func decodePublishRequest(_ context.Context, grpcReq interface{}) (interface{}, 
 
 func encodeEmptyResponse(_ context.Context, grpcRes interface{}) (interface{}, error) {
 	res := grpcRes.(emptyRes)
-	return &empty.Empty{}, encodeError(res.err)
+	return &emptypb.Empty{}, encodeError(res.err)
 }
 
 func encodeError(err error) error {

--- a/things/api/grpc/client.go
+++ b/things/api/grpc/client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kitgrpc "github.com/go-kit/kit/transport/grpc"
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -62,7 +61,7 @@ func NewClient(conn *grpc.ClientConn, tracer opentracing.Tracer, timeout time.Du
 			"CanUserAccessThing",
 			encodeUserAccessThingRequest,
 			decodeEmptyResponse,
-			empty.Empty{},
+			emptypb.Empty{},
 		).Endpoint()),
 		canUserAccessProfile: kitot.TraceClient(tracer, "can_user_access_profile")(kitgrpc.NewClient(
 			conn,
@@ -70,7 +69,7 @@ func NewClient(conn *grpc.ClientConn, tracer opentracing.Tracer, timeout time.Du
 			"CanUserAccessProfile",
 			encodeUserAccessProfileRequest,
 			decodeEmptyResponse,
-			empty.Empty{},
+			emptypb.Empty{},
 		).Endpoint()),
 		canUserAccessGroup: kitot.TraceClient(tracer, "can_user_access_group")(kitgrpc.NewClient(
 			conn,
@@ -78,7 +77,7 @@ func NewClient(conn *grpc.ClientConn, tracer opentracing.Tracer, timeout time.Du
 			"CanUserAccessGroup",
 			encodeUserAccessGroupRequest,
 			decodeEmptyResponse,
-			empty.Empty{},
+			emptypb.Empty{},
 		).Endpoint()),
 		canThingAccessGroup: kitot.TraceClient(tracer, "can_thing_access_group")(kitgrpc.NewClient(
 			conn,
@@ -86,7 +85,7 @@ func NewClient(conn *grpc.ClientConn, tracer opentracing.Tracer, timeout time.Du
 			"CanThingAccessGroup",
 			encodeThingAccessGroupRequest,
 			decodeEmptyResponse,
-			empty.Empty{},
+			emptypb.Empty{},
 		).Endpoint()),
 		identify: kitot.TraceClient(tracer, "identify")(kitgrpc.NewClient(
 			conn,
@@ -168,7 +167,7 @@ func (client grpcClient) CanUserAccessThing(ctx context.Context, req *protomfx.U
 	}
 
 	er := res.(emptyRes)
-	return &empty.Empty{}, er.err
+	return &emptypb.Empty{}, er.err
 }
 
 func (client grpcClient) CanUserAccessProfile(ctx context.Context, req *protomfx.UserAccessReq, _ ...grpc.CallOption) (*emptypb.Empty, error) {
@@ -179,7 +178,7 @@ func (client grpcClient) CanUserAccessProfile(ctx context.Context, req *protomfx
 	}
 
 	er := res.(emptyRes)
-	return &empty.Empty{}, er.err
+	return &emptypb.Empty{}, er.err
 }
 
 func (client grpcClient) CanUserAccessGroup(ctx context.Context, req *protomfx.UserAccessReq, _ ...grpc.CallOption) (*emptypb.Empty, error) {
@@ -190,10 +189,10 @@ func (client grpcClient) CanUserAccessGroup(ctx context.Context, req *protomfx.U
 	}
 
 	er := res.(emptyRes)
-	return &empty.Empty{}, er.err
+	return &emptypb.Empty{}, er.err
 }
 
-func (client grpcClient) CanThingAccessGroup(ctx context.Context, req *protomfx.ThingAccessReq, _ ...grpc.CallOption) (*empty.Empty, error) {
+func (client grpcClient) CanThingAccessGroup(ctx context.Context, req *protomfx.ThingAccessReq, _ ...grpc.CallOption) (*emptypb.Empty, error) {
 	r := thingAccessGroupReq{thingKey: thingKey{value: req.GetKey()}, id: req.GetId()}
 	res, err := client.canThingAccessGroup(ctx, r)
 	if err != nil {
@@ -201,7 +200,7 @@ func (client grpcClient) CanThingAccessGroup(ctx context.Context, req *protomfx.
 	}
 
 	er := res.(emptyRes)
-	return &empty.Empty{}, er.err
+	return &emptypb.Empty{}, er.err
 }
 
 func (client grpcClient) Identify(ctx context.Context, req *protomfx.ThingKey, _ ...grpc.CallOption) (*protomfx.ThingID, error) {

--- a/things/api/grpc/server.go
+++ b/things/api/grpc/server.go
@@ -13,10 +13,10 @@ import (
 	"github.com/MainfluxLabs/mainflux/things"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kitgrpc "github.com/go-kit/kit/transport/grpc"
-	"github.com/golang/protobuf/ptypes/empty"
 	opentracing "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 var _ protomfx.ThingsServiceServer = (*grpcServer)(nil)
@@ -113,40 +113,40 @@ func (gs *grpcServer) GetConfigByThingID(ctx context.Context, req *protomfx.Thin
 	return res.(*protomfx.ConfigByThingIDRes), nil
 }
 
-func (gs *grpcServer) CanUserAccessThing(ctx context.Context, req *protomfx.UserAccessReq) (*empty.Empty, error) {
+func (gs *grpcServer) CanUserAccessThing(ctx context.Context, req *protomfx.UserAccessReq) (*emptypb.Empty, error) {
 	_, res, err := gs.canUserAccessThing.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}
 
-	return res.(*empty.Empty), nil
+	return res.(*emptypb.Empty), nil
 }
 
-func (gs *grpcServer) CanUserAccessProfile(ctx context.Context, req *protomfx.UserAccessReq) (*empty.Empty, error) {
+func (gs *grpcServer) CanUserAccessProfile(ctx context.Context, req *protomfx.UserAccessReq) (*emptypb.Empty, error) {
 	_, res, err := gs.canUserAccessProfile.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}
 
-	return res.(*empty.Empty), nil
+	return res.(*emptypb.Empty), nil
 }
 
-func (gs *grpcServer) CanUserAccessGroup(ctx context.Context, req *protomfx.UserAccessReq) (*empty.Empty, error) {
+func (gs *grpcServer) CanUserAccessGroup(ctx context.Context, req *protomfx.UserAccessReq) (*emptypb.Empty, error) {
 	_, res, err := gs.canUserAccessGroup.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}
 
-	return res.(*empty.Empty), nil
+	return res.(*emptypb.Empty), nil
 }
 
-func (gs *grpcServer) CanThingAccessGroup(ctx context.Context, req *protomfx.ThingAccessReq) (*empty.Empty, error) {
+func (gs *grpcServer) CanThingAccessGroup(ctx context.Context, req *protomfx.ThingAccessReq) (*emptypb.Empty, error) {
 	_, res, err := gs.canThingAccessGroup.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}
 
-	return res.(*empty.Empty), nil
+	return res.(*emptypb.Empty), nil
 }
 
 func (gs *grpcServer) Identify(ctx context.Context, req *protomfx.ThingKey) (*protomfx.ThingID, error) {
@@ -264,7 +264,7 @@ func encodeGetConfigByThingIDResponse(_ context.Context, grpcRes interface{}) (i
 
 func encodeEmptyResponse(_ context.Context, grpcRes interface{}) (interface{}, error) {
 	res := grpcRes.(emptyRes)
-	return &empty.Empty{}, encodeError(res.err)
+	return &emptypb.Empty{}, encodeError(res.err)
 }
 
 func encodeGetGroupIDByThingIDResponse(_ context.Context, grpcRes interface{}) (interface{}, error) {

--- a/things/standalone/standalone.go
+++ b/things/standalone/standalone.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
-	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 var errUnsupported = errors.New("not supported in standalone mode")
@@ -45,26 +45,26 @@ func (repo singleUserRepo) Identify(ctx context.Context, token *protomfx.Token, 
 	return &protomfx.UserIdentity{Id: repo.email, Email: repo.email}, nil
 }
 
-func (repo singleUserRepo) Authorize(ctx context.Context, req *protomfx.AuthorizeReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
-	return &empty.Empty{}, errUnsupported
+func (repo singleUserRepo) Authorize(ctx context.Context, req *protomfx.AuthorizeReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
+	return &emptypb.Empty{}, errUnsupported
 }
 
 func (repo singleUserRepo) GetOwnerIDByOrgID(ctx context.Context, in *protomfx.OrgID, opts ...grpc.CallOption) (*protomfx.OwnerID, error) {
 	return &protomfx.OwnerID{}, errUnsupported
 }
 
-func (repo singleUserRepo) AssignRole(ctx context.Context, req *protomfx.AssignRoleReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
-	return &empty.Empty{}, errUnsupported
+func (repo singleUserRepo) AssignRole(ctx context.Context, req *protomfx.AssignRoleReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
+	return &emptypb.Empty{}, errUnsupported
 }
 
 func (repo singleUserRepo) RetrieveRole(ctx context.Context, req *protomfx.RetrieveRoleReq, _ ...grpc.CallOption) (r *protomfx.RetrieveRoleRes, err error) {
 	return &protomfx.RetrieveRoleRes{}, errUnsupported
 }
 
-func (repo singleUserRepo) CreateDormantOrgInvite(ctx context.Context, req *protomfx.CreateDormantOrgInviteReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (repo singleUserRepo) CreateDormantOrgInvite(ctx context.Context, req *protomfx.CreateDormantOrgInviteReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	panic("not implemented")
 }
 
-func (repo singleUserRepo) ActivateOrgInvite(ctx context.Context, req *protomfx.ActivateOrgInviteReq, _ ...grpc.CallOption) (r *empty.Empty, err error) {
+func (repo singleUserRepo) ActivateOrgInvite(ctx context.Context, req *protomfx.ActivateOrgInviteReq, _ ...grpc.CallOption) (r *emptypb.Empty, err error) {
 	panic("not implemented")
 }


### PR DESCRIPTION
The references were mostly to the `empty.Empty` type in the gRPC client/server code. 

However, we still cannot remove the `github.com/golang/protobuf` module as a dependency because **the protobuf compiler we use ([`protoc-gen-gofast`](https://github.com/gogo/protobuf)) emits code that depends on it**. Though as the compiler itself is unmaintained since ~2021., we can think about moving to [`protoc-gen-go`](https://pkg.go.dev/google.golang.org/protobuf@v1.36.10/cmd/protoc-gen-go)?