### PR TITLE
MF-964 - Correct Redis event subscriber lifecycle management

### DIFF
--- a/pkg/events/subscriber.go
+++ b/pkg/events/subscriber.go
@@ -66,8 +66,6 @@ func NewSubscriber(url, stream, group, consumer string, logger logger.Logger) (S
 }
 
 func (es *subEventStore) Subscribe(ctx context.Context, handler EventHandler) error {
-	defer es.client.Close()
-
 	err := es.client.XGroupCreateMkStream(ctx, es.stream, es.group, "$").Err()
 	if err != nil && err.Error() != exists {
 		return err


### PR DESCRIPTION
Fixes the Redis events subscriber's `.Subscribe()` method to function in a blocking manner and properly react to context cancellation instead of silently spawning a goroutine and exiting.