### PR TITLE
MF-961 - Multi Field JSON Aggregation

### DIFF
--- a/pkg/apiutil/transport.go
+++ b/pkg/apiutil/transport.go
@@ -422,10 +422,6 @@ func ReadFloatQuery(r *http.Request, key string, def float64) (float64, error) {
 func ReadStringArrayQuery(r *http.Request, key string, def []string) ([]string, error) {
 	vals := bone.GetQuery(r, key)
 
-	if len(vals) == 0 {
-		return def, nil
-	}
-
 	if len(vals) > 10 {
 		return nil, ErrInvalidQueryParams
 	}

--- a/pkg/apiutil/transport.go
+++ b/pkg/apiutil/transport.go
@@ -426,6 +426,10 @@ func ReadStringArrayQuery(r *http.Request, key string, def []string) ([]string, 
 		return def, nil
 	}
 
+	if len(vals) > 10 {
+		return nil, ErrInvalidQueryParams
+	}
+
 	return vals, nil
 }
 

--- a/pkg/apiutil/transport.go
+++ b/pkg/apiutil/transport.go
@@ -419,6 +419,16 @@ func ReadFloatQuery(r *http.Request, key string, def float64) (float64, error) {
 	return val, nil
 }
 
+func ReadStringArrayQuery(r *http.Request, key string, def []string) ([]string, error) {
+	vals := bone.GetQuery(r, key)
+
+	if len(vals) == 0 {
+		return def, nil
+	}
+
+	return vals, nil
+}
+
 func BuildPageMetadata(r *http.Request) (PageMetadata, error) {
 	o, err := ReadUintQuery(r, OffsetKey, DefOffset)
 	if err != nil {

--- a/pkg/apiutil/transport.go
+++ b/pkg/apiutil/transport.go
@@ -419,7 +419,7 @@ func ReadFloatQuery(r *http.Request, key string, def float64) (float64, error) {
 	return val, nil
 }
 
-func ReadStringArrayQuery(r *http.Request, key string, def []string) ([]string, error) {
+func ReadStringArrayQuery(r *http.Request, key string) ([]string, error) {
 	vals := bone.GetQuery(r, key)
 
 	if len(vals) > 10 {

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -434,7 +434,7 @@ func BuildJSONPageMetadata(r *http.Request) (readers.JSONPageMetadata, error) {
 		AggInterval: ai,
 		AggValue:    av,
 		AggType:     at,
-		AggField:    af,
+		AggFields:   af,
 		Dir:         d,
 	}
 
@@ -507,7 +507,7 @@ func BuildSenMLPageMetadata(r *http.Request) (readers.SenMLPageMetadata, error) 
 		return readers.SenMLPageMetadata{}, err
 	}
 
-	af, err := apiutil.ReadStringQuery(r, aggFieldKey, "")
+	af, err := apiutil.ReadStringArrayQuery(r, aggFieldKey)
 	if err != nil {
 		return readers.SenMLPageMetadata{}, err
 	}
@@ -531,7 +531,7 @@ func BuildSenMLPageMetadata(r *http.Request) (readers.SenMLPageMetadata, error) 
 		AggInterval: ai,
 		AggValue:    av,
 		AggType:     at,
-		AggField:    af,
+		AggFields:   af,
 		Dir:         d,
 	}
 

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -416,7 +416,7 @@ func BuildJSONPageMetadata(r *http.Request) (readers.JSONPageMetadata, error) {
 		return readers.JSONPageMetadata{}, err
 	}
 
-	af, err := apiutil.ReadStringArrayQuery(r, aggFieldKey, nil)
+	af, err := apiutil.ReadStringArrayQuery(r, aggFieldKey)
 	if err != nil {
 		return readers.JSONPageMetadata{}, err
 	}

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -416,7 +416,7 @@ func BuildJSONPageMetadata(r *http.Request) (readers.JSONPageMetadata, error) {
 		return readers.JSONPageMetadata{}, err
 	}
 
-	af, err := apiutil.ReadStringQuery(r, aggFieldKey, "")
+	af, err := apiutil.ReadStringArrayQuery(r, aggFieldKey, nil)
 	if err != nil {
 		return readers.JSONPageMetadata{}, err
 	}

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -80,24 +80,24 @@ type SenMLMessagesPage struct {
 
 // SenMLPageMetadata represents the parameters used to create database queries
 type SenMLPageMetadata struct {
-	Offset      uint64  `json:"offset"`
-	Limit       uint64  `json:"limit"`
-	Subtopic    string  `json:"subtopic,omitempty"`
-	Publisher   string  `json:"publisher,omitempty"`
-	Protocol    string  `json:"protocol,omitempty"`
-	Name        string  `json:"name,omitempty"`
-	Value       float64 `json:"v,omitempty"`
-	Comparator  string  `json:"comparator,omitempty"`
-	BoolValue   bool    `json:"vb,omitempty"`
-	StringValue string  `json:"vs,omitempty"`
-	DataValue   string  `json:"vd,omitempty"`
-	From        int64   `json:"from,omitempty"`
-	To          int64   `json:"to,omitempty"`
-	AggInterval string  `json:"agg_interval,omitempty"`
-	AggValue    uint64  `json:"agg_value,omitempty"`
-	AggType     string  `json:"agg_type,omitempty"`
-	AggField    string  `json:"agg_field,omitempty"`
-	Dir         string  `json:"dir,omitempty"`
+	Offset      uint64   `json:"offset"`
+	Limit       uint64   `json:"limit"`
+	Subtopic    string   `json:"subtopic,omitempty"`
+	Publisher   string   `json:"publisher,omitempty"`
+	Protocol    string   `json:"protocol,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Value       float64  `json:"v,omitempty"`
+	Comparator  string   `json:"comparator,omitempty"`
+	BoolValue   bool     `json:"vb,omitempty"`
+	StringValue string   `json:"vs,omitempty"`
+	DataValue   string   `json:"vd,omitempty"`
+	From        int64    `json:"from,omitempty"`
+	To          int64    `json:"to,omitempty"`
+	AggInterval string   `json:"agg_interval,omitempty"`
+	AggValue    uint64   `json:"agg_value,omitempty"`
+	AggType     string   `json:"agg_type,omitempty"`
+	AggFields   []string `json:"agg_fields,omitempty"`
+	Dir         string   `json:"dir,omitempty"`
 }
 
 // JSONPageMetadata represents the parameters used to create database queries
@@ -113,7 +113,7 @@ type JSONPageMetadata struct {
 	AggInterval string   `json:"agg_interval,omitempty"`
 	AggValue    uint64   `json:"agg_value,omitempty"`
 	AggType     string   `json:"agg_type,omitempty"`
-	AggField    []string `json:"agg_field,omitempty"`
+	AggFields   []string `json:"agg_fields,omitempty"`
 	Dir         string   `json:"dir,omitempty"`
 }
 

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -102,19 +102,19 @@ type SenMLPageMetadata struct {
 
 // JSONPageMetadata represents the parameters used to create database queries
 type JSONPageMetadata struct {
-	Offset      uint64 `json:"offset"`
-	Limit       uint64 `json:"limit"`
-	Subtopic    string `json:"subtopic,omitempty"`
-	Publisher   string `json:"publisher,omitempty"`
-	Protocol    string `json:"protocol,omitempty"`
-	From        int64  `json:"from,omitempty"`
-	To          int64  `json:"to,omitempty"`
-	Filter      string `json:"filter,omitempty"`
-	AggInterval string `json:"agg_interval,omitempty"`
-	AggValue    uint64 `json:"agg_value,omitempty"`
-	AggType     string `json:"agg_type,omitempty"`
-	AggField    string `json:"agg_field,omitempty"`
-	Dir         string `json:"dir,omitempty"`
+	Offset      uint64   `json:"offset"`
+	Limit       uint64   `json:"limit"`
+	Subtopic    string   `json:"subtopic,omitempty"`
+	Publisher   string   `json:"publisher,omitempty"`
+	Protocol    string   `json:"protocol,omitempty"`
+	From        int64    `json:"from,omitempty"`
+	To          int64    `json:"to,omitempty"`
+	Filter      string   `json:"filter,omitempty"`
+	AggInterval string   `json:"agg_interval,omitempty"`
+	AggValue    uint64   `json:"agg_value,omitempty"`
+	AggType     string   `json:"agg_type,omitempty"`
+	AggField    []string `json:"agg_field,omitempty"`
+	Dir         string   `json:"dir,omitempty"`
 }
 
 // ParseValueComparator convert comparison operator keys into mathematic anotation

--- a/readers/postgres/aggregations.go
+++ b/readers/postgres/aggregations.go
@@ -194,9 +194,9 @@ func buildAggregationQuery(qp QueryParams, strategy AggStrategy) string {
 				ti.interval_time,
 				{{.AggExpression}},
 				MAX(m.{{.TimeColumn}}) as max_time,
-				MAX(m.subtopic) as subtopic,
-				MAX(m.publisher) as publisher,
-				MAX(m.protocol) as protocol
+				MAX(CAST(m.subtopic AS text)) as subtopic,
+				MAX(CAST(m.publisher AS text)) as publisher,
+				MAX(CAST(m.protocol AS text)) as protocol
 			FROM time_intervals ti
 			LEFT JOIN {{.Table}} m ON {{.TimeJoinCondition}}
 				{{.ConditionForJoin}}
@@ -234,7 +234,7 @@ func renderTemplate(templateStr string, qp QueryParams, strategy AggStrategy) st
 func buildAggregationCountQuery(qp QueryParams) string {
 	timeTrunc := buildTruncTimeExpression(qp.AggValue, qp.AggInterval, qp.TimeColumn)
 	havingCondition := buildHavingConditionForCount(qp.AggField, qp.Table)
-	timeTruncWithAlias := strings.Replace(timeTrunc, qp.TimeColumn, "m."+qp.TimeColumn, 1)
+	timeTruncWithAlias := buildTruncTimeExpression(qp.AggValue, qp.AggInterval, "m."+qp.TimeColumn)
 
 	dq := dbutil.GetDirQuery(qp.Dir)
 	lq := ""

--- a/readers/postgres/aggregations.go
+++ b/readers/postgres/aggregations.go
@@ -624,14 +624,12 @@ func buildHavingConditionForCount(aggFields []string, table string) string {
 
 func buildAggregatedJSONSelectMultipleFromIA(aggFields []string, aggPrefix string) string {
 	if len(aggFields) == 0 {
-		return "ia.max_time as created, ia.subtopic, ia.publisher, ia.protocol, '{}'::jsonb as payload"
+		return "ia.max_time as created, ia.subtopic, ia.publisher, ia.protocol, CAST('{}' AS jsonb) as payload"
 	}
 
 	var jsonbPairs []string
 	for i, field := range aggFields {
-		parts := strings.Split(field, ".")
-		key := parts[len(parts)-1]
-		jsonbPairs = append(jsonbPairs, fmt.Sprintf("'%s', ia.%s_%d", key, aggPrefix, i))
+		jsonbPairs = append(jsonbPairs, fmt.Sprintf("'%s', ia.%s_%d", field, aggPrefix, i))
 	}
 
 	return fmt.Sprintf(`ia.max_time as created, ia.subtopic, ia.publisher, ia.protocol,

--- a/readers/postgres/aggregations.go
+++ b/readers/postgres/aggregations.go
@@ -1,4 +1,4 @@
-// Copyright (c) Mainfluxaggregations
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
 
 package postgres

--- a/readers/postgres/aggregations.go
+++ b/readers/postgres/aggregations.go
@@ -85,7 +85,7 @@ func (as *aggregationService) readAggregatedJSONMessages(ctx context.Context, rp
 		qp.ConditionForJoin = "AND " + strings.Join(conditions, " AND ")
 	}
 
-	strategy := as.getAggregateStrategy(rpm.AggType)
+	strategy := as.getAggStrategy(rpm.AggType)
 	if strategy == nil {
 		return []readers.Message{}, 0, nil
 	}
@@ -151,7 +151,7 @@ func (as *aggregationService) readAggregatedSenMLMessages(ctx context.Context, r
 		qp.ConditionForJoin = "AND " + strings.Join(conditions, " AND ")
 	}
 
-	strategy := as.getAggregateStrategy(rpm.AggType)
+	strategy := as.getAggStrategy(rpm.AggType)
 	if strategy == nil {
 		return []readers.Message{}, 0, nil
 	}
@@ -249,7 +249,7 @@ func buildAggCountQuery(qp QueryParams) string {
 		timeIntervals, qp.Table, timeJoinCondition, qp.ConditionForJoin, havingCondition)
 }
 
-func (as aggregationService) getAggregateStrategy(aggType string) AggStrategy {
+func (as aggregationService) getAggStrategy(aggType string) AggStrategy {
 	switch aggType {
 	case readers.AggregationMax:
 		return MaxStrategy{}
@@ -272,7 +272,7 @@ func buildSenMLSelectFields() string {
 		0 as sum, ia.max_time as update_time`
 }
 
-func buildAggregateExpression(qp QueryParams, aggFunc string) string {
+func buildAggExpression(qp QueryParams, aggFunc string) string {
 	if len(qp.AggFields) == 0 {
 		return ""
 	}
@@ -306,7 +306,7 @@ func (MaxStrategy) GetSelectedFields(qp QueryParams) string {
 }
 
 func (MaxStrategy) GetAggregateExpression(qp QueryParams) string {
-	return buildAggregateExpression(qp, "MAX")
+	return buildAggExpression(qp, "MAX")
 }
 
 type MinStrategy struct{}
@@ -319,7 +319,7 @@ func (MinStrategy) GetSelectedFields(qp QueryParams) string {
 }
 
 func (MinStrategy) GetAggregateExpression(qp QueryParams) string {
-	return buildAggregateExpression(qp, "MIN")
+	return buildAggExpression(qp, "MIN")
 }
 
 type AvgStrategy struct{}
@@ -332,7 +332,7 @@ func (AvgStrategy) GetSelectedFields(qp QueryParams) string {
 }
 
 func (AvgStrategy) GetAggregateExpression(qp QueryParams) string {
-	return buildAggregateExpression(qp, "AVG")
+	return buildAggExpression(qp, "AVG")
 }
 
 type CountStrategy struct{}
@@ -345,7 +345,7 @@ func (CountStrategy) GetSelectedFields(qp QueryParams) string {
 }
 
 func (CountStrategy) GetAggregateExpression(qp QueryParams) string {
-	return buildAggregateExpression(qp, "COUNT")
+	return buildAggExpression(qp, "COUNT")
 }
 func buildTimeIntervals(qp QueryParams) string {
 	dq := dbutil.GetDirQuery(qp.Dir)

--- a/readers/postgres/aggregations.go
+++ b/readers/postgres/aggregations.go
@@ -71,7 +71,7 @@ func (as *aggregationService) readAggregatedJSONMessages(ctx context.Context, rp
 	qp := QueryParams{
 		Table:       jsonTable,
 		TimeColumn:  jsonOrder,
-		AggFields:   rpm.AggField,
+		AggFields:   rpm.AggFields,
 		AggInterval: rpm.AggInterval,
 		AggValue:    rpm.AggValue,
 		AggType:     rpm.AggType,
@@ -137,7 +137,7 @@ func (as *aggregationService) readAggregatedSenMLMessages(ctx context.Context, r
 	qp := QueryParams{
 		Table:       senmlTable,
 		TimeColumn:  senmlOrder,
-		AggFields:   []string{rpm.AggField},
+		AggFields:   rpm.AggFields,
 		AggInterval: rpm.AggInterval,
 		AggValue:    rpm.AggValue,
 		AggType:     rpm.AggType,

--- a/readers/postgres/aggregations.go
+++ b/readers/postgres/aggregations.go
@@ -290,7 +290,7 @@ func (maxStrt MaxStrategy) GetSelectedFields(qp QueryParams) string {
 				'' as string_value, false as bool_value, '' as data_value, 
 				0 as sum, ia.max_time as update_time`
 	default:
-		return buildAggregatedJSONSelectMultipleFromIA(qp.AggField, "agg_value")
+		return buildJSONSelect(qp.AggField, "agg_value")
 	}
 }
 
@@ -326,7 +326,7 @@ func (minStrt MinStrategy) GetSelectedFields(qp QueryParams) string {
 				'' as string_value, false as bool_value, '' as data_value, 
 				0 as sum, ia.max_time as update_time`
 	default:
-		return buildAggregatedJSONSelectMultipleFromIA(qp.AggField, "agg_value")
+		return buildJSONSelect(qp.AggField, "agg_value")
 	}
 }
 
@@ -360,7 +360,7 @@ func (avgStrt AvgStrategy) GetSelectedFields(qp QueryParams) string {
 				'' as string_value, false as bool_value, '' as data_value, 
 				0 as sum, ia.max_time as update_time`
 	default:
-		return buildAggregatedJSONSelectMultipleFromIA(qp.AggField, "avg_value")
+		return buildJSONSelect(qp.AggField, "avg_value")
 	}
 }
 
@@ -394,7 +394,7 @@ func (countStrt CountStrategy) GetSelectedFields(qp QueryParams) string {
 				'' as string_value, false as bool_value, '' as data_value, 
 				0 as sum, ia.max_time as update_time`
 	default:
-		return buildAggregatedJSONSelectMultipleFromIA(qp.AggField, "sum_value")
+		return buildJSONSelect(qp.AggField, "sum_value")
 	}
 }
 
@@ -622,7 +622,7 @@ func buildConditionForCount(aggFields []string, table string) string {
 	return strings.Join(conditions, " OR ")
 }
 
-func buildAggregatedJSONSelectMultipleFromIA(aggFields []string, aggPrefix string) string {
+func buildJSONSelect(aggFields []string, aggPrefix string) string {
 	if len(aggFields) == 0 {
 		return "ia.max_time as created, ia.subtopic, ia.publisher, ia.protocol, CAST('{}' AS jsonb) as payload"
 	}

--- a/readers/postgres/aggregations.go
+++ b/readers/postgres/aggregations.go
@@ -233,7 +233,7 @@ func renderTemplate(templateStr string, qp QueryParams, strategy AggStrategy) st
 
 func buildAggregationCountQuery(qp QueryParams) string {
 	timeTrunc := buildTruncTimeExpression(qp.AggValue, qp.AggInterval, qp.TimeColumn)
-	havingCondition := buildHavingConditionForCount(qp.AggField, qp.Table)
+	havingCondition := buildConditionForCount(qp.AggField, qp.Table)
 	timeTruncWithAlias := buildTruncTimeExpression(qp.AggValue, qp.AggInterval, "m."+qp.TimeColumn)
 
 	dq := dbutil.GetDirQuery(qp.Dir)
@@ -602,7 +602,7 @@ func buildHavingCondition(qp QueryParams) string {
 	return strings.Join(conditions, " OR ")
 }
 
-func buildHavingConditionForCount(aggFields []string, table string) string {
+func buildConditionForCount(aggFields []string, table string) string {
 	if len(aggFields) == 0 {
 		return "1=1"
 	}

--- a/readers/postgres/senml_test.go
+++ b/readers/postgres/senml_test.go
@@ -397,10 +397,10 @@ func TestListSenMLMessages(t *testing.T) {
 		},
 		"avg aggregation on sum field": {
 			pageMeta: readers.SenMLPageMetadata{
-				Limit:    noLimit,
-				Name:     msgName,
-				AggType:  avgAgg,
-				AggField: "sum",
+				Limit:     noLimit,
+				Name:      msgName,
+				AggType:   avgAgg,
+				AggFields: []string{"sum"},
 			},
 			page: readers.SenMLMessagesPage{
 				MessagesPage: readers.MessagesPage{


### PR DESCRIPTION
Resolves #961 

This adds support for multiple fields for aggregation. It also restricts the returned aggregated fields to only those which are used as a query parameter. 

Here's an example request:

`http://localhost/reader/json?agg_type=min&agg_interval=day&agg_value=1&limit=1&agg_field=humidity&agg_field=temperature`

Maximum number of `agg_field` query parameters is 10.