### PR TITLE
MF-969 - Fix HTTP 500 when listing Org invites with a dormant invite present

### DIFF
--- a/auth/invites.go
+++ b/auth/invites.go
@@ -445,19 +445,12 @@ func (svc service) populateInviteInfo(ctx context.Context, invite *OrgInvite) er
 		return err
 	}
 
-	users := usersRes.GetUsers()
-
-	if len(users) == 1 {
-		invite.InviterEmail = users[0].GetEmail()
-	} else {
-		// Order of results from gRPC call isn't guaranteed to match order of IDs in request
-		switch users[0].Id {
+	for _, user := range usersRes.GetUsers() {
+		switch user.GetId() {
 		case invite.InviterID:
-			invite.InviterEmail = users[0].GetEmail()
-			invite.InviteeEmail = users[1].GetEmail()
-		default:
-			invite.InviterEmail = users[1].GetEmail()
-			invite.InviteeEmail = users[0].GetEmail()
+			invite.InviterEmail = user.GetEmail()
+		case invite.InviteeID:
+			invite.InviteeEmail = user.GetEmail()
 		}
 	}
 

--- a/auth/invites.go
+++ b/auth/invites.go
@@ -435,22 +435,30 @@ func (svc service) populateInviteInfo(ctx context.Context, invite *OrgInvite) er
 
 	invite.OrgName = org.Name
 
-	usersReq := &protomfx.UsersByIDsReq{Ids: []string{invite.InviterID, invite.InviteeID}}
-	usersRes, err := svc.users.GetUsersByIDs(ctx, usersReq)
+	userIDs := []string{invite.InviterID}
+	if invite.InviteeID != "" {
+		userIDs = append(userIDs, invite.InviteeID)
+	}
+
+	usersRes, err := svc.users.GetUsersByIDs(ctx, &protomfx.UsersByIDsReq{Ids: userIDs})
 	if err != nil {
 		return err
 	}
 
-	// Order of results from gRPC call isn't guaranteed to match order of IDs in request
 	users := usersRes.GetUsers()
 
-	switch users[0].Id {
-	case invite.InviterID:
+	if len(users) == 1 {
 		invite.InviterEmail = users[0].GetEmail()
-		invite.InviteeEmail = users[1].GetEmail()
-	default:
-		invite.InviterEmail = users[1].GetEmail()
-		invite.InviteeEmail = users[0].GetEmail()
+	} else {
+		// Order of results from gRPC call isn't guaranteed to match order of IDs in request
+		switch users[0].Id {
+		case invite.InviterID:
+			invite.InviterEmail = users[0].GetEmail()
+			invite.InviteeEmail = users[1].GetEmail()
+		default:
+			invite.InviterEmail = users[1].GetEmail()
+			invite.InviteeEmail = users[0].GetEmail()
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Resolves #969 by not requesting the invitee user's email address for dormant invites in `populateInviteInfo`, as dormant invites aren't directed to a specific invitee.