### PR TITLE
MF-924 - Use a constistent format for all service method logger middleware messages

### DIFF
--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -59,7 +59,7 @@ func (lm *loggingMiddleware) Revoke(ctx context.Context, token, id string) (err 
 
 func (lm *loggingMiddleware) RetrieveKey(ctx context.Context, token, id string) (key auth.Key, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method retrieve for key id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method retrieve_key for key id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -416,7 +416,7 @@ func (lm *loggingMiddleware) SendOrgInviteEmail(ctx context.Context, invite auth
 
 func (lm *loggingMiddleware) ViewOrgInvite(ctx context.Context, token, inviteID string) (invite auth.OrgInvite, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_org_invite %s for invite id took %s to complete", inviteID, time.Since(begin))
+		message := fmt.Sprintf("Method view_org_invite for invite id %s took %s to complete", inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -416,7 +416,7 @@ func (lm *loggingMiddleware) SendOrgInviteEmail(ctx context.Context, invite auth
 
 func (lm *loggingMiddleware) ViewOrgInvite(ctx context.Context, token, inviteID string) (invite auth.OrgInvite, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_org_invite for invite id took %s to complete", inviteID, time.Since(begin))
+		message := fmt.Sprintf("Method view_org_invite %s for invite id took %s to complete", inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -46,7 +46,7 @@ func (lm *loggingMiddleware) Issue(ctx context.Context, token string, newKey aut
 
 func (lm *loggingMiddleware) Revoke(ctx context.Context, token, id string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method revoke for key %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method revoke for key id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -59,7 +59,7 @@ func (lm *loggingMiddleware) Revoke(ctx context.Context, token, id string) (err 
 
 func (lm *loggingMiddleware) RetrieveKey(ctx context.Context, token, id string) (key auth.Key, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method retrieve for key %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method retrieve for key id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -162,7 +162,7 @@ func (lm *loggingMiddleware) ListOrgs(ctx context.Context, token string, pm apiu
 
 func (lm *loggingMiddleware) GetOwnerIDByOrgID(ctx context.Context, orgID string) (ownerID string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method get_owner_id_by_org_id for id %s took %s to complete", orgID, time.Since(begin))
+		message := fmt.Sprintf("Method get_owner_id_by_org_id for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -316,7 +316,7 @@ func (lm *loggingMiddleware) RetrieveRole(ctx context.Context, id string) (role 
 
 func (lm *loggingMiddleware) CreateOrgInvite(ctx context.Context, token, email, role, orgID, invRedirectPath string) (invite auth.OrgInvite, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method create_org_invite took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method create_org_invite for org id %s, role %s and user email %s took %s to complete", orgID, role, email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -346,7 +346,7 @@ func (lm *loggingMiddleware) CreateDormantOrgInvite(ctx context.Context, token, 
 
 func (lm *loggingMiddleware) RevokeOrgInvite(ctx context.Context, token, inviteID string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method revoke_org_invite took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method revoke_org_invite for invite id %s took %s to complete", inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -360,7 +360,7 @@ func (lm *loggingMiddleware) RevokeOrgInvite(ctx context.Context, token, inviteI
 
 func (lm *loggingMiddleware) RespondOrgInvite(ctx context.Context, token, inviteID string, accept bool) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method respond_org_invite took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method respond_org_invite for invite id %s and accept %t took %s to complete", inviteID, accept, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -388,7 +388,7 @@ func (lm *loggingMiddleware) ListOrgInvitesByUser(ctx context.Context, token, us
 
 func (lm *loggingMiddleware) ListOrgInvitesByOrg(ctx context.Context, token string, orgID string, pm auth.PageMetadataInvites) (invPage auth.OrgInvitesPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_org_invites_by_org took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method list_org_invites_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -402,7 +402,7 @@ func (lm *loggingMiddleware) ListOrgInvitesByOrg(ctx context.Context, token stri
 
 func (lm *loggingMiddleware) SendOrgInviteEmail(ctx context.Context, invite auth.OrgInvite, email, orgName, invRedirectPath string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method send_org_invite_email took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method send_org_invite_email for invite id %s and user email %s took %s to complete", invite.ID, email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -416,7 +416,7 @@ func (lm *loggingMiddleware) SendOrgInviteEmail(ctx context.Context, invite auth
 
 func (lm *loggingMiddleware) ViewOrgInvite(ctx context.Context, token, inviteID string) (invite auth.OrgInvite, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_org_invite took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method view_org_invite for invite id took %s to complete", inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/certs/api/logging.go
+++ b/certs/api/logging.go
@@ -28,7 +28,7 @@ func NewLoggingMiddleware(svc certs.Service, logger log.Logger) certs.Service {
 
 func (lm *loggingMiddleware) IssueCert(ctx context.Context, token, thingID, ttl string, keyBits int, keyType string) (c certs.Cert, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method issue_cert for thing %s took %s to complete", thingID, time.Since(begin))
+		message := fmt.Sprintf("Method issue_cert for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -41,7 +41,7 @@ func (lm *loggingMiddleware) IssueCert(ctx context.Context, token, thingID, ttl 
 
 func (lm *loggingMiddleware) ListCerts(ctx context.Context, token, thingID string, offset, limit uint64) (cp certs.Page, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_certs for thing %s took %s to complete", thingID, time.Since(begin))
+		message := fmt.Sprintf("Method list_certs for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -54,7 +54,7 @@ func (lm *loggingMiddleware) ListCerts(ctx context.Context, token, thingID strin
 
 func (lm *loggingMiddleware) ListSerials(ctx context.Context, token, thingID string, offset, limit uint64) (cp certs.Page, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_serials for thing %s took %s to complete", thingID, time.Since(begin))
+		message := fmt.Sprintf("Method list_serials for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/coap/api/logging.go
+++ b/coap/api/logging.go
@@ -32,7 +32,7 @@ func (lm *loggingMiddleware) Publish(ctx context.Context, key things.ThingKey, m
 	defer func(begin time.Time) {
 		dest := ""
 		if msg.Subtopic != "" {
-			dest = fmt.Sprintf("to %s", msg.Subtopic)
+			dest = fmt.Sprintf("to subtopic %s", msg.Subtopic)
 		}
 		message := fmt.Sprintf("Method publish %s took %s to complete", dest, time.Since(begin))
 		if err != nil {
@@ -47,7 +47,7 @@ func (lm *loggingMiddleware) Publish(ctx context.Context, key things.ThingKey, m
 
 func (lm *loggingMiddleware) Subscribe(ctx context.Context, key things.ThingKey, subtopic string, c coap.Client) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method subscribe for client %s took %s to complete", c.Token(), time.Since(begin))
+		message := fmt.Sprintf("Method subscribe for client token %s took %s to complete", c.Token(), time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -60,7 +60,7 @@ func (lm *loggingMiddleware) Subscribe(ctx context.Context, key things.ThingKey,
 
 func (lm *loggingMiddleware) Unsubscribe(ctx context.Context, key things.ThingKey, subtopic, token string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method unsubscribe for the client %s took %s to complete", token, time.Since(begin))
+		message := fmt.Sprintf("Method unsubscribe for client token %s took %s to complete", token, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/consumers/alarms/api/logging.go
+++ b/consumers/alarms/api/logging.go
@@ -63,7 +63,7 @@ func (lm loggingMiddleware) ListAlarmsByOrg(ctx context.Context, token, orgID st
 
 func (lm loggingMiddleware) ViewAlarm(ctx context.Context, token, id string) (_ alarms.Alarm, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_alarm for id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method view_alarm for alarm id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -76,7 +76,7 @@ func (lm loggingMiddleware) ViewAlarm(ctx context.Context, token, id string) (_ 
 
 func (lm loggingMiddleware) RemoveAlarms(ctx context.Context, token string, id ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_alarms for id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method remove_alarms for alarm id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -89,7 +89,7 @@ func (lm loggingMiddleware) RemoveAlarms(ctx context.Context, token string, id .
 
 func (lm loggingMiddleware) RemoveAlarmsByThing(ctx context.Context, thingID string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_alarms_by_thing for id %s took %s to complete", thingID, time.Since(begin))
+		message := fmt.Sprintf("Method remove_alarms_by_thing for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -102,7 +102,7 @@ func (lm loggingMiddleware) RemoveAlarmsByThing(ctx context.Context, thingID str
 
 func (lm loggingMiddleware) RemoveAlarmsByGroup(ctx context.Context, groupID string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_alarms_by_group for id %s took %s to complete", groupID, time.Since(begin))
+		message := fmt.Sprintf("Method remove_alarms_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/consumers/notifiers/api/logging.go
+++ b/consumers/notifiers/api/logging.go
@@ -29,7 +29,7 @@ func LoggingMiddleware(svc notifiers.Service, logger log.Logger) notifiers.Servi
 
 func (lm *loggingMiddleware) CreateNotifiers(ctx context.Context, token, groupID string, notifiers ...notifiers.Notifier) (response []notifiers.Notifier, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method create_notifiers for notifiers %s took %s to complete", response, time.Since(begin))
+		message := fmt.Sprintf("Method create_notifiers for notifiers %v took %s to complete", response, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -42,7 +42,7 @@ func (lm *loggingMiddleware) CreateNotifiers(ctx context.Context, token, groupID
 
 func (lm *loggingMiddleware) ListNotifiersByGroup(ctx context.Context, token string, groupID string, pm apiutil.PageMetadata) (res notifiers.NotifiersPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_notifiers_by_group for id %s took %s to complete", groupID, time.Since(begin))
+		message := fmt.Sprintf("Method list_notifiers_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -55,7 +55,7 @@ func (lm *loggingMiddleware) ListNotifiersByGroup(ctx context.Context, token str
 
 func (lm *loggingMiddleware) ViewNotifier(ctx context.Context, token, id string) (response notifiers.Notifier, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_notifier for id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method view_notifier for notifier id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -68,7 +68,7 @@ func (lm *loggingMiddleware) ViewNotifier(ctx context.Context, token, id string)
 
 func (lm *loggingMiddleware) UpdateNotifier(ctx context.Context, token string, notifier notifiers.Notifier) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method update_notifier for id %s took %s to complete", notifier.ID, time.Since(begin))
+		message := fmt.Sprintf("Method update_notifier for notifier id %s took %s to complete", notifier.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -81,7 +81,7 @@ func (lm *loggingMiddleware) UpdateNotifier(ctx context.Context, token string, n
 
 func (lm *loggingMiddleware) RemoveNotifiers(ctx context.Context, token string, id ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_notifiers took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method remove_notifiers for notifier ids %v took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -94,7 +94,7 @@ func (lm *loggingMiddleware) RemoveNotifiers(ctx context.Context, token string, 
 
 func (lm *loggingMiddleware) RemoveNotifiersByGroup(ctx context.Context, groupID string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_notifiers_by_group for id %s took %s to complete", groupID, time.Since(begin))
+		message := fmt.Sprintf("Method remove_notifiers_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/mqtt/api/logging.go
+++ b/mqtt/api/logging.go
@@ -30,7 +30,7 @@ func LoggingMiddleware(svc mqtt.Service, logger log.Logger) mqtt.Service {
 
 func (lm *loggingMiddleware) ListSubscriptions(ctx context.Context, groupID, token string, key things.ThingKey, pm mqtt.PageMetadata) (page mqtt.Page, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_subscriptions took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method list_subscriptions for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -43,7 +43,8 @@ func (lm *loggingMiddleware) ListSubscriptions(ctx context.Context, groupID, tok
 
 func (lm *loggingMiddleware) CreateSubscription(ctx context.Context, sub mqtt.Subscription) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method create_subscription took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method create_subscription for thing id %s, group id %s, and subtopic %s took %s to complete",
+			sub.ThingID, sub.GroupID, sub.Subtopic, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -56,7 +57,8 @@ func (lm *loggingMiddleware) CreateSubscription(ctx context.Context, sub mqtt.Su
 
 func (lm *loggingMiddleware) RemoveSubscription(ctx context.Context, sub mqtt.Subscription) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_subscription took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method remove_subscription for thing id %s, group id %s, and subtopic %s took %s to complete",
+			sub.ThingID, sub.GroupID, sub.Subtopic, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -69,7 +71,7 @@ func (lm *loggingMiddleware) RemoveSubscription(ctx context.Context, sub mqtt.Su
 
 func (lm *loggingMiddleware) HasClientID(ctx context.Context, clientID string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method has_client_id took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method has_client_id for client id %s took %s to complete", clientID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -82,7 +84,8 @@ func (lm *loggingMiddleware) HasClientID(ctx context.Context, clientID string) (
 
 func (lm *loggingMiddleware) UpdateStatus(ctx context.Context, sub mqtt.Subscription) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method update_status took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method update_status for thing id %s, group id %s and subtopic %s took %s to complete",
+			sub.ThingID, sub.GroupID, sub.Subtopic, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/rules/api/logging.go
+++ b/rules/api/logging.go
@@ -38,7 +38,7 @@ func (lm loggingMiddleware) CreateRules(ctx context.Context, token, groupID stri
 
 func (lm loggingMiddleware) ListRulesByThing(ctx context.Context, token, thingID string, pm apiutil.PageMetadata) (_ rules.RulesPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_rules_by_thing for id %s took %s to complete", thingID, time.Since(begin))
+		message := fmt.Sprintf("Method list_rules_by_thing for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -51,7 +51,7 @@ func (lm loggingMiddleware) ListRulesByThing(ctx context.Context, token, thingID
 
 func (lm loggingMiddleware) ListRulesByGroup(ctx context.Context, token, groupID string, pm apiutil.PageMetadata) (_ rules.RulesPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_rules_by_group for id %s took %s to complete", groupID, time.Since(begin))
+		message := fmt.Sprintf("Method list_rules_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -64,7 +64,7 @@ func (lm loggingMiddleware) ListRulesByGroup(ctx context.Context, token, groupID
 
 func (lm loggingMiddleware) ListThingIDsByRule(ctx context.Context, token, ruleID string) (_ []string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_thing_ids_by_rule for id %s took %s to complete", ruleID, time.Since(begin))
+		message := fmt.Sprintf("Method list_thing_ids_by_rule for rule id %s took %s to complete", ruleID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -77,7 +77,7 @@ func (lm loggingMiddleware) ListThingIDsByRule(ctx context.Context, token, ruleI
 
 func (lm loggingMiddleware) ViewRule(ctx context.Context, token, id string) (_ rules.Rule, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_rule for id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method view_rule rule for id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -90,7 +90,7 @@ func (lm loggingMiddleware) ViewRule(ctx context.Context, token, id string) (_ r
 
 func (lm loggingMiddleware) UpdateRule(ctx context.Context, token string, rule rules.Rule) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method update_rule for id %s took %s to complete", rule.ID, time.Since(begin))
+		message := fmt.Sprintf("Method update_rule for rule id %s took %s to complete", rule.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -103,7 +103,7 @@ func (lm loggingMiddleware) UpdateRule(ctx context.Context, token string, rule r
 
 func (lm loggingMiddleware) RemoveRules(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_rules took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method remove_rules for rule ids %v took %s to complete", ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -116,7 +116,7 @@ func (lm loggingMiddleware) RemoveRules(ctx context.Context, token string, ids .
 
 func (lm loggingMiddleware) RemoveRulesByGroup(ctx context.Context, groupID string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_rules_by_group for id %s took %s to complete", groupID, time.Since(begin))
+		message := fmt.Sprintf("Method remove_rules_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -142,7 +142,7 @@ func (lm loggingMiddleware) AssignRules(ctx context.Context, token, thingID stri
 
 func (lm loggingMiddleware) UnassignRules(ctx context.Context, token, thingID string, ruleIDs ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method unassign_rules took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method unassign_rules for rule ids %v took %s to complete", ruleIDs, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -155,7 +155,7 @@ func (lm loggingMiddleware) UnassignRules(ctx context.Context, token, thingID st
 
 func (lm loggingMiddleware) UnassignRulesByThing(ctx context.Context, thingID string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method unassign_rules_by_thing for id %s took %s to complete", thingID, time.Since(begin))
+		message := fmt.Sprintf("Method unassign_rules_by_thing for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/rules/api/logging.go
+++ b/rules/api/logging.go
@@ -77,7 +77,7 @@ func (lm loggingMiddleware) ListThingIDsByRule(ctx context.Context, token, ruleI
 
 func (lm loggingMiddleware) ViewRule(ctx context.Context, token, id string) (_ rules.Rule, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_rule rule for id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method view_rule for rule id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/rules/api/logging.go
+++ b/rules/api/logging.go
@@ -142,7 +142,7 @@ func (lm loggingMiddleware) AssignRules(ctx context.Context, token, thingID stri
 
 func (lm loggingMiddleware) UnassignRules(ctx context.Context, token, thingID string, ruleIDs ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method unassign_rules for rule ids %v took %s to complete", ruleIDs, time.Since(begin))
+		message := fmt.Sprintf("Method unassign_rules for thing id %s and rule ids %v took %s to complete", thingID, ruleIDs, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -42,7 +42,7 @@ func (lm *loggingMiddleware) CreateThings(ctx context.Context, token, profileID 
 
 func (lm *loggingMiddleware) UpdateThing(ctx context.Context, token string, thing things.Thing) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method update_thing for id %s took %s to complete", thing.ID, time.Since(begin))
+		message := fmt.Sprintf("Method update_thing for thing id %s took %s to complete", thing.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -59,7 +59,7 @@ func (lm *loggingMiddleware) UpdateThingsMetadata(ctx context.Context, token str
 		for _, thing := range things {
 			ids = append(ids, thing.ID)
 		}
-		message := fmt.Sprintf("Method update_things_metadata for ids %s took %s to complete", ids, time.Since(begin))
+		message := fmt.Sprintf("Method update_things_metadata for thing ids %s took %s to complete", ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -72,7 +72,7 @@ func (lm *loggingMiddleware) UpdateThingsMetadata(ctx context.Context, token str
 
 func (lm *loggingMiddleware) UpdateThingGroupAndProfile(ctx context.Context, token string, thing things.Thing) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method update_thing_group_and_profile for id %s took %s to complete", thing.ID, time.Since(begin))
+		message := fmt.Sprintf("Method update_thing_group_and_profile for thing id %s took %s to complete", thing.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -85,7 +85,7 @@ func (lm *loggingMiddleware) UpdateThingGroupAndProfile(ctx context.Context, tok
 
 func (lm *loggingMiddleware) ViewThing(ctx context.Context, token, id string) (thing things.Thing, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_thing for id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method view_thing for thing id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -124,7 +124,7 @@ func (lm *loggingMiddleware) ListThings(ctx context.Context, token string, pm ap
 
 func (lm *loggingMiddleware) ListThingsByProfile(ctx context.Context, token, prID string, pm apiutil.PageMetadata) (_ things.ThingsPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_things_by_profile for id %s took %s to complete", prID, time.Since(begin))
+		message := fmt.Sprintf("Method list_things_by_profile for profile id %s took %s to complete", prID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s", message, err))
 		}
@@ -136,7 +136,7 @@ func (lm *loggingMiddleware) ListThingsByProfile(ctx context.Context, token, prI
 
 func (lm *loggingMiddleware) ListThingsByOrg(ctx context.Context, token string, orgID string, pm apiutil.PageMetadata) (tp things.ThingsPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_things_by_org for id %s took %s to complete", orgID, time.Since(begin))
+		message := fmt.Sprintf("Method list_things_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s", message, err))
 		}
@@ -148,7 +148,7 @@ func (lm *loggingMiddleware) ListThingsByOrg(ctx context.Context, token string, 
 
 func (lm *loggingMiddleware) BackupThingsByGroup(ctx context.Context, token string, groupID string) (tb things.ThingsBackup, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method backup_things_by_group took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method backup_things_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -161,7 +161,7 @@ func (lm *loggingMiddleware) BackupThingsByGroup(ctx context.Context, token stri
 
 func (lm *loggingMiddleware) RestoreThingsByGroup(ctx context.Context, token string, groupID string, backup things.ThingsBackup) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method restore_things_by_group took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method restore_things_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -174,7 +174,7 @@ func (lm *loggingMiddleware) RestoreThingsByGroup(ctx context.Context, token str
 
 func (lm *loggingMiddleware) BackupThingsByOrg(ctx context.Context, token string, orgID string) (tb things.ThingsBackup, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method backup_things_by_org took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method backup_things_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -187,7 +187,7 @@ func (lm *loggingMiddleware) BackupThingsByOrg(ctx context.Context, token string
 
 func (lm *loggingMiddleware) RestoreThingsByOrg(ctx context.Context, token string, orgID string, backup things.ThingsBackup) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method restore_things_by_org took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method restore_things_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -200,7 +200,7 @@ func (lm *loggingMiddleware) RestoreThingsByOrg(ctx context.Context, token strin
 
 func (lm *loggingMiddleware) RemoveThings(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_things took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method remove_things for thing ids %v took %s to complete", ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -226,7 +226,7 @@ func (lm *loggingMiddleware) CreateProfiles(ctx context.Context, token, grID str
 
 func (lm *loggingMiddleware) UpdateProfile(ctx context.Context, token string, profile things.Profile) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method update_profile for id %s took %s to complete", profile.ID, time.Since(begin))
+		message := fmt.Sprintf("Method update_profile for profile id %s took %s to complete", profile.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -239,7 +239,7 @@ func (lm *loggingMiddleware) UpdateProfile(ctx context.Context, token string, pr
 
 func (lm *loggingMiddleware) ViewProfile(ctx context.Context, token, id string) (profile things.Profile, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_profile for id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method view_profile for profile id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -265,7 +265,7 @@ func (lm *loggingMiddleware) ListProfiles(ctx context.Context, token string, pm 
 
 func (lm *loggingMiddleware) ListProfilesByOrg(ctx context.Context, token string, orgID string, pm apiutil.PageMetadata) (prs things.ProfilesPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_profiles_by_org for id %s took %s to complete", orgID, time.Since(begin))
+		message := fmt.Sprintf("Method list_profiles_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s", message, err))
 		}
@@ -289,7 +289,7 @@ func (lm *loggingMiddleware) ViewProfileByThing(ctx context.Context, token, thID
 
 func (lm *loggingMiddleware) RemoveProfiles(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_profiles took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method remove_profiles for profile ids %v took %s to complete", ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -327,7 +327,7 @@ func (lm *loggingMiddleware) GetConfigByThingID(ctx context.Context, thingID str
 
 func (lm *loggingMiddleware) CanUserAccessThing(ctx context.Context, req things.UserAccessReq) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method can_user_access_thing took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method can_user_access_thing for thing id %s took %s to complete", req.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -340,7 +340,7 @@ func (lm *loggingMiddleware) CanUserAccessThing(ctx context.Context, req things.
 
 func (lm *loggingMiddleware) CanUserAccessProfile(ctx context.Context, req things.UserAccessReq) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method can_user_access_profile took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method can_user_access_profile for profile id %s took %s to complete", req.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -353,7 +353,7 @@ func (lm *loggingMiddleware) CanUserAccessProfile(ctx context.Context, req thing
 
 func (lm *loggingMiddleware) CanUserAccessGroup(ctx context.Context, req things.UserAccessReq) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method can_user_access_group took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method can_user_access_group for group id %s took %s to complete", req.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -366,7 +366,7 @@ func (lm *loggingMiddleware) CanUserAccessGroup(ctx context.Context, req things.
 
 func (lm *loggingMiddleware) CanThingAccessGroup(ctx context.Context, req things.ThingAccessReq) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method can_thing_access_group took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method can_thing_access_group for group id %s took %s to complete", req.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -392,7 +392,7 @@ func (lm *loggingMiddleware) Identify(ctx context.Context, key things.ThingKey) 
 
 func (lm *loggingMiddleware) GetGroupIDByThingID(ctx context.Context, thingID string) (_ string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method get_group_id_by_thing_id for thing %s took %s to complete", thingID, time.Since(begin))
+		message := fmt.Sprintf("Method get_group_id_by_thing_id for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -405,7 +405,7 @@ func (lm *loggingMiddleware) GetGroupIDByThingID(ctx context.Context, thingID st
 
 func (lm *loggingMiddleware) GetGroupIDByProfileID(ctx context.Context, profileID string) (_ string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method get_group_id_by_profile_id for profile %s took %s to complete", profileID, time.Since(begin))
+		message := fmt.Sprintf("Method get_group_id_by_profile_id for profile id %s took %s to complete", profileID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -418,7 +418,7 @@ func (lm *loggingMiddleware) GetGroupIDByProfileID(ctx context.Context, profileI
 
 func (lm *loggingMiddleware) GetGroupIDsByOrg(ctx context.Context, orgID string, token string) (_ []string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method get_group_ids_by_org for org %s took %s to complete", orgID, time.Since(begin))
+		message := fmt.Sprintf("Method get_group_ids_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -444,7 +444,7 @@ func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (bk thing
 
 func (lm *loggingMiddleware) BackupGroupsByOrg(ctx context.Context, token string, orgID string) (bk things.GroupsBackup, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method backup_groups_by_org took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method backup_groups_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -457,7 +457,7 @@ func (lm *loggingMiddleware) BackupGroupsByOrg(ctx context.Context, token string
 
 func (lm *loggingMiddleware) RestoreGroupsByOrg(ctx context.Context, token string, orgID string, backup things.GroupsBackup) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method restore_groups_by_org took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method restore_groups_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -470,7 +470,7 @@ func (lm *loggingMiddleware) RestoreGroupsByOrg(ctx context.Context, token strin
 
 func (lm *loggingMiddleware) BackupGroupMemberships(ctx context.Context, token string, groupID string) (bk things.GroupMembershipsBackup, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method backup_group_memberships took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method backup_group_memberships for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -483,7 +483,7 @@ func (lm *loggingMiddleware) BackupGroupMemberships(ctx context.Context, token s
 
 func (lm *loggingMiddleware) RestoreGroupMemberships(ctx context.Context, token string, groupID string, backup things.GroupMembershipsBackup) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method restore_group_memberships took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method restore_group_memberships for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -496,7 +496,7 @@ func (lm *loggingMiddleware) RestoreGroupMemberships(ctx context.Context, token 
 
 func (lm *loggingMiddleware) BackupProfilesByOrg(ctx context.Context, token string, orgID string) (pb things.ProfilesBackup, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method backup_profiles_by_org took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method backup_profiles_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -509,7 +509,7 @@ func (lm *loggingMiddleware) BackupProfilesByOrg(ctx context.Context, token stri
 
 func (lm *loggingMiddleware) RestoreProfilesByOrg(ctx context.Context, token string, orgID string, backup things.ProfilesBackup) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method restore_profiles_by_org took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method restore_profiles_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -522,7 +522,7 @@ func (lm *loggingMiddleware) RestoreProfilesByOrg(ctx context.Context, token str
 
 func (lm *loggingMiddleware) BackupProfilesByGroup(ctx context.Context, token string, groupID string) (pb things.ProfilesBackup, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method backup_profiles_by_group took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method backup_profiles_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -535,7 +535,7 @@ func (lm *loggingMiddleware) BackupProfilesByGroup(ctx context.Context, token st
 
 func (lm *loggingMiddleware) RestoreProfilesByGroup(ctx context.Context, token string, groupID string, backup things.ProfilesBackup) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method restore_profiles_by_group took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method restore_profiles_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -574,7 +574,7 @@ func (lm *loggingMiddleware) CreateGroups(ctx context.Context, token, orgID stri
 
 func (lm *loggingMiddleware) UpdateGroup(ctx context.Context, token string, gr things.Group) (g things.Group, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method update_group for id %s took %s to complete", gr.ID, time.Since(begin))
+		message := fmt.Sprintf("Method update_group for group id %s took %s to complete", gr.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -587,7 +587,7 @@ func (lm *loggingMiddleware) UpdateGroup(ctx context.Context, token string, gr t
 
 func (lm *loggingMiddleware) ViewGroup(ctx context.Context, token, id string) (g things.Group, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_group for id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method view_group for group id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -613,7 +613,7 @@ func (lm *loggingMiddleware) ListGroups(ctx context.Context, token string, pm ap
 
 func (lm *loggingMiddleware) ListGroupsByOrg(ctx context.Context, token, orgID string, pm apiutil.PageMetadata) (g things.GroupPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_groups_by_org took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method list_groups_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -626,7 +626,7 @@ func (lm *loggingMiddleware) ListGroupsByOrg(ctx context.Context, token, orgID s
 
 func (lm *loggingMiddleware) ListThingsByGroup(ctx context.Context, token, groupID string, pm apiutil.PageMetadata) (mp things.ThingsPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_things_by_group for id %s took %s to complete", groupID, time.Since(begin))
+		message := fmt.Sprintf("Method list_things_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -639,7 +639,7 @@ func (lm *loggingMiddleware) ListThingsByGroup(ctx context.Context, token, group
 
 func (lm *loggingMiddleware) ViewGroupByThing(ctx context.Context, token, thingID string) (gr things.Group, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_group_by_thing for id %s took %s to complete", thingID, time.Since(begin))
+		message := fmt.Sprintf("Method view_group_by_thing for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -652,7 +652,7 @@ func (lm *loggingMiddleware) ViewGroupByThing(ctx context.Context, token, thingI
 
 func (lm *loggingMiddleware) RemoveGroups(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_groups took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method remove_groups for group ids %v took %s to complete", ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -665,7 +665,7 @@ func (lm *loggingMiddleware) RemoveGroups(ctx context.Context, token string, ids
 
 func (lm *loggingMiddleware) RemoveGroupsByOrg(ctx context.Context, orgID string) (_ []string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_groups_by_org for id %s took %s to complete", orgID, time.Since(begin))
+		message := fmt.Sprintf("Method remove_groups_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -678,7 +678,7 @@ func (lm *loggingMiddleware) RemoveGroupsByOrg(ctx context.Context, orgID string
 
 func (lm *loggingMiddleware) ViewGroupByProfile(ctx context.Context, token, profileID string) (gr things.Group, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_group_by_profile for id %s took %s to complete", profileID, time.Since(begin))
+		message := fmt.Sprintf("Method view_group_by_profile for profile id %s took %s to complete", profileID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -691,7 +691,7 @@ func (lm *loggingMiddleware) ViewGroupByProfile(ctx context.Context, token, prof
 
 func (lm *loggingMiddleware) ListProfilesByGroup(ctx context.Context, token, groupID string, pm apiutil.PageMetadata) (gprp things.ProfilesPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method list_profiles_by_group for id %s took %s to complete", groupID, time.Since(begin))
+		message := fmt.Sprintf("Method list_profiles_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -704,7 +704,7 @@ func (lm *loggingMiddleware) ListProfilesByGroup(ctx context.Context, token, gro
 
 func (lm *loggingMiddleware) CreateGroupMemberships(ctx context.Context, token string, gms ...things.GroupMembership) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method create_group_memberships took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method create_group_memberships for memberships %+v took %s to complete", gms, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -740,7 +740,7 @@ func (lm *loggingMiddleware) UpdateGroupMemberships(ctx context.Context, token s
 
 func (lm *loggingMiddleware) RemoveGroupMemberships(ctx context.Context, token, groupID string, memberIDs ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_group_memberships for group id %s took %s to complete", groupID, time.Since(begin))
+		message := fmt.Sprintf("Method remove_group_memberships for group id %s and member ids %v took %s to complete", groupID, memberIDs, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -764,7 +764,7 @@ func (lm *loggingMiddleware) UpdateExternalKey(ctx context.Context, token, key, 
 
 func (lm *loggingMiddleware) RemoveExternalKey(ctx context.Context, token, thingID string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_external_key for thing %s took %s to complete", thingID, time.Since(begin))
+		message := fmt.Sprintf("Method remove_external_key for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -776,7 +776,7 @@ func (lm *loggingMiddleware) RemoveExternalKey(ctx context.Context, token, thing
 
 func (lm *loggingMiddleware) GetThingIDsByProfile(ctx context.Context, profileID string) (_ []string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method get_thing_ids_by_profile for profile %s took %s to complete", profileID, time.Since(begin))
+		message := fmt.Sprintf("Method get_thing_ids_by_profile for profile id %s took %s to complete", profileID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -704,7 +704,7 @@ func (lm *loggingMiddleware) ListProfilesByGroup(ctx context.Context, token, gro
 
 func (lm *loggingMiddleware) CreateGroupMemberships(ctx context.Context, token string, gms ...things.GroupMembership) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method create_group_memberships for memberships %+v took %s to complete", gms, time.Since(begin))
+		message := fmt.Sprintf("Method create_group_memberships for memberships %v took %s to complete", gms, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/ws/api/logging.go
+++ b/ws/api/logging.go
@@ -32,7 +32,7 @@ func (lm *loggingMiddleware) Publish(ctx context.Context, key things.ThingKey, m
 	defer func(begin time.Time) {
 		dest := ""
 		if msg.Subtopic != "" {
-			dest = fmt.Sprintf("to %s", msg.Subtopic)
+			dest = fmt.Sprintf("to subtopic %s", msg.Subtopic)
 		}
 		message := fmt.Sprintf("Method publish %s took %s to complete", dest, time.Since(begin))
 		if err != nil {
@@ -47,7 +47,7 @@ func (lm *loggingMiddleware) Publish(ctx context.Context, key things.ThingKey, m
 
 func (lm *loggingMiddleware) Subscribe(ctx context.Context, key things.ThingKey, subtopic string, c *ws.Client) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method subscribe took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method subscribe for subtopic %s took %s to complete", subtopic, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s", message, err))
 			return
@@ -60,7 +60,7 @@ func (lm *loggingMiddleware) Subscribe(ctx context.Context, key things.ThingKey,
 
 func (lm *loggingMiddleware) Unsubscribe(ctx context.Context, key things.ThingKey, subtopic string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method unsubscribe took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method unsubscribe for subtopic %s took %s to complete", subtopic, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s", message, err))
 			return


### PR DESCRIPTION
Minor stuff, mostly related to clearly conveying the type of entity whose ID the call relates to, or adding it if it wasn't logged in the first place.

Closes #924