### PR TITLE
NOISSUE - Update logging middleware method signatures

### DIFF
--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -27,7 +27,7 @@ func LoggingMiddleware(svc auth.Service, logger log.Logger) auth.Service {
 	return &loggingMiddleware{logger, svc}
 }
 
-func (lm *loggingMiddleware) Issue(ctx context.Context, token string, newKey auth.Key) (key auth.Key, secret string, err error) {
+func (lm *loggingMiddleware) Issue(ctx context.Context, token string, newKey auth.Key) (key auth.Key, _ string, err error) {
 	defer func(begin time.Time) {
 		d := "infinite duration"
 		if !key.ExpiresAt.IsZero() {
@@ -302,7 +302,7 @@ func (lm *loggingMiddleware) AssignRole(ctx context.Context, id, role string) (e
 	return lm.svc.AssignRole(ctx, id, role)
 }
 
-func (lm *loggingMiddleware) RetrieveRole(ctx context.Context, id string) (role string, err error) {
+func (lm *loggingMiddleware) RetrieveRole(ctx context.Context, id string) (_ string, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method retrieve_role for id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
@@ -386,7 +386,7 @@ func (lm *loggingMiddleware) ListOrgInvitesByUser(ctx context.Context, token, us
 	return lm.svc.ListOrgInvitesByUser(ctx, token, userType, userID, pm)
 }
 
-func (lm *loggingMiddleware) ListOrgInvitesByOrg(ctx context.Context, token string, orgID string, pm auth.PageMetadataInvites) (invPage auth.OrgInvitesPage, err error) {
+func (lm *loggingMiddleware) ListOrgInvitesByOrg(ctx context.Context, token string, orgID string, pm auth.PageMetadataInvites) (_ auth.OrgInvitesPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_org_invites_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
@@ -414,7 +414,7 @@ func (lm *loggingMiddleware) SendOrgInviteEmail(ctx context.Context, invite auth
 	return lm.svc.SendOrgInviteEmail(ctx, invite, email, orgName, invRedirectPath)
 }
 
-func (lm *loggingMiddleware) ViewOrgInvite(ctx context.Context, token, inviteID string) (invite auth.OrgInvite, err error) {
+func (lm *loggingMiddleware) ViewOrgInvite(ctx context.Context, token, inviteID string) (_ auth.OrgInvite, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_org_invite for invite id %s took %s to complete", inviteID, time.Since(begin))
 		if err != nil {

--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -46,7 +46,7 @@ func (lm *loggingMiddleware) Issue(ctx context.Context, token string, newKey aut
 
 func (lm *loggingMiddleware) Revoke(ctx context.Context, token, id string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method revoke for key id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method revoke for id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -57,9 +57,9 @@ func (lm *loggingMiddleware) Revoke(ctx context.Context, token, id string) (err 
 	return lm.svc.Revoke(ctx, token, id)
 }
 
-func (lm *loggingMiddleware) RetrieveKey(ctx context.Context, token, id string) (key auth.Key, err error) {
+func (lm *loggingMiddleware) RetrieveKey(ctx context.Context, token, id string) (_ auth.Key, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method retrieve_key for key id %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method retrieve_key for id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -70,7 +70,7 @@ func (lm *loggingMiddleware) RetrieveKey(ctx context.Context, token, id string) 
 	return lm.svc.RetrieveKey(ctx, token, id)
 }
 
-func (lm *loggingMiddleware) Identify(ctx context.Context, key string) (id auth.Identity, err error) {
+func (lm *loggingMiddleware) Identify(ctx context.Context, key string) (_ auth.Identity, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method identify took %s to complete", time.Since(begin))
 		if err != nil {
@@ -95,7 +95,7 @@ func (lm *loggingMiddleware) Authorize(ctx context.Context, ar auth.AuthzReq) (e
 	return lm.svc.Authorize(ctx, ar)
 }
 
-func (lm *loggingMiddleware) CreateOrg(ctx context.Context, token string, org auth.Org) (o auth.Org, err error) {
+func (lm *loggingMiddleware) CreateOrg(ctx context.Context, token string, org auth.Org) (_ auth.Org, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method create_org for name %s took %s to complete", org.Name, time.Since(begin))
 		if err != nil {
@@ -108,7 +108,7 @@ func (lm *loggingMiddleware) CreateOrg(ctx context.Context, token string, org au
 	return lm.svc.CreateOrg(ctx, token, org)
 }
 
-func (lm *loggingMiddleware) UpdateOrg(ctx context.Context, token string, org auth.Org) (o auth.Org, err error) {
+func (lm *loggingMiddleware) UpdateOrg(ctx context.Context, token string, org auth.Org) (_ auth.Org, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method update_org for name %s took %s to complete", org.Name, time.Since(begin))
 		if err != nil {
@@ -134,7 +134,7 @@ func (lm *loggingMiddleware) RemoveOrgs(ctx context.Context, token string, ids .
 	return lm.svc.RemoveOrgs(ctx, token, ids...)
 }
 
-func (lm *loggingMiddleware) ViewOrg(ctx context.Context, token, id string) (o auth.Org, err error) {
+func (lm *loggingMiddleware) ViewOrg(ctx context.Context, token, id string) (_ auth.Org, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_org for id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
@@ -147,7 +147,7 @@ func (lm *loggingMiddleware) ViewOrg(ctx context.Context, token, id string) (o a
 	return lm.svc.ViewOrg(ctx, token, id)
 }
 
-func (lm *loggingMiddleware) ListOrgs(ctx context.Context, token string, pm apiutil.PageMetadata) (gp auth.OrgsPage, err error) {
+func (lm *loggingMiddleware) ListOrgs(ctx context.Context, token string, pm apiutil.PageMetadata) (_ auth.OrgsPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_orgs took %s to complete", time.Since(begin))
 		if err != nil {
@@ -160,7 +160,7 @@ func (lm *loggingMiddleware) ListOrgs(ctx context.Context, token string, pm apiu
 	return lm.svc.ListOrgs(ctx, token, pm)
 }
 
-func (lm *loggingMiddleware) GetOwnerIDByOrgID(ctx context.Context, orgID string) (ownerID string, err error) {
+func (lm *loggingMiddleware) GetOwnerIDByOrgID(ctx context.Context, orgID string) (_ string, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method get_owner_id_by_org_id for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
@@ -186,7 +186,7 @@ func (lm *loggingMiddleware) CreateOrgMemberships(ctx context.Context, token, or
 	return lm.svc.CreateOrgMemberships(ctx, token, orgID, oms...)
 }
 
-func (lm *loggingMiddleware) ViewOrgMembership(ctx context.Context, token, orgID, memberID string) (om auth.OrgMembership, err error) {
+func (lm *loggingMiddleware) ViewOrgMembership(ctx context.Context, token, orgID, memberID string) (_ auth.OrgMembership, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_org_membership for org id %s and member id %s took %s to complete", orgID, memberID, time.Since(begin))
 		if err != nil {
@@ -199,7 +199,7 @@ func (lm *loggingMiddleware) ViewOrgMembership(ctx context.Context, token, orgID
 	return lm.svc.ViewOrgMembership(ctx, token, orgID, memberID)
 }
 
-func (lm *loggingMiddleware) ListOrgMemberships(ctx context.Context, token, orgID string, pm apiutil.PageMetadata) (op auth.OrgMembershipsPage, err error) {
+func (lm *loggingMiddleware) ListOrgMemberships(ctx context.Context, token, orgID string, pm apiutil.PageMetadata) (_ auth.OrgMembershipsPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_org_memberships for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
@@ -251,7 +251,7 @@ func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (backup a
 	return lm.svc.Backup(ctx, token)
 }
 
-func (lm *loggingMiddleware) BackupOrgMemberships(ctx context.Context, token string, orgID string) (backup auth.OrgMembershipsBackup, err error) {
+func (lm *loggingMiddleware) BackupOrgMemberships(ctx context.Context, token string, orgID string) (_ auth.OrgMembershipsBackup, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup_org_memberships took %s to complete", time.Since(begin))
 		if err != nil {
@@ -314,7 +314,7 @@ func (lm *loggingMiddleware) RetrieveRole(ctx context.Context, id string) (role 
 	return lm.svc.RetrieveRole(ctx, id)
 }
 
-func (lm *loggingMiddleware) CreateOrgInvite(ctx context.Context, token string, oi auth.OrgInvite, invRedirectPath string) (invite auth.OrgInvite, err error) {
+func (lm *loggingMiddleware) CreateOrgInvite(ctx context.Context, token string, oi auth.OrgInvite, invRedirectPath string) (_ auth.OrgInvite, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method create_org_invite for org id %s, role %s and user email %s took %s to complete", oi.OrgID, oi.InviteeRole, oi.InviteeEmail, time.Since(begin))
 		if err != nil {
@@ -328,7 +328,7 @@ func (lm *loggingMiddleware) CreateOrgInvite(ctx context.Context, token string, 
 	return lm.svc.CreateOrgInvite(ctx, token, oi, invRedirectPath)
 }
 
-func (lm *loggingMiddleware) CreateDormantOrgInvite(ctx context.Context, token string, oi auth.OrgInvite, platformInviteID string) (invite auth.OrgInvite, err error) {
+func (lm *loggingMiddleware) CreateDormantOrgInvite(ctx context.Context, token string, oi auth.OrgInvite, platformInviteID string) (_ auth.OrgInvite, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method create_dormant_org_invite for org id %s, role %s and platform invite id %s took %s to complete",
 			oi.OrgID, oi.InviteeRole, platformInviteID, time.Since(begin))
@@ -372,7 +372,7 @@ func (lm *loggingMiddleware) RespondOrgInvite(ctx context.Context, token, invite
 	return lm.svc.RespondOrgInvite(ctx, token, inviteID, accept)
 }
 
-func (lm *loggingMiddleware) ListOrgInvitesByUser(ctx context.Context, token, userType, userID string, pm auth.PageMetadataInvites) (invPage auth.OrgInvitesPage, err error) {
+func (lm *loggingMiddleware) ListOrgInvitesByUser(ctx context.Context, token, userType, userID string, pm auth.PageMetadataInvites) (_ auth.OrgInvitesPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_org_invites_by_user for type %s and user id %s took %s to complete", userType, userID, time.Since(begin))
 		if err != nil {

--- a/certs/api/logging.go
+++ b/certs/api/logging.go
@@ -26,7 +26,7 @@ func NewLoggingMiddleware(svc certs.Service, logger log.Logger) certs.Service {
 	return &loggingMiddleware{logger, svc}
 }
 
-func (lm *loggingMiddleware) IssueCert(ctx context.Context, token, thingID, ttl string, keyBits int, keyType string) (c certs.Cert, err error) {
+func (lm *loggingMiddleware) IssueCert(ctx context.Context, token, thingID, ttl string, keyBits int, keyType string) (_ certs.Cert, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method issue_cert for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
@@ -39,7 +39,7 @@ func (lm *loggingMiddleware) IssueCert(ctx context.Context, token, thingID, ttl 
 	return lm.svc.IssueCert(ctx, token, thingID, ttl, keyBits, keyType)
 }
 
-func (lm *loggingMiddleware) ListCerts(ctx context.Context, token, thingID string, offset, limit uint64) (cp certs.Page, err error) {
+func (lm *loggingMiddleware) ListCerts(ctx context.Context, token, thingID string, offset, limit uint64) (_ certs.Page, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_certs for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
@@ -52,7 +52,7 @@ func (lm *loggingMiddleware) ListCerts(ctx context.Context, token, thingID strin
 	return lm.svc.ListCerts(ctx, token, thingID, offset, limit)
 }
 
-func (lm *loggingMiddleware) ListSerials(ctx context.Context, token, thingID string, offset, limit uint64) (cp certs.Page, err error) {
+func (lm *loggingMiddleware) ListSerials(ctx context.Context, token, thingID string, offset, limit uint64) (_ certs.Page, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_serials for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
@@ -65,7 +65,7 @@ func (lm *loggingMiddleware) ListSerials(ctx context.Context, token, thingID str
 	return lm.svc.ListSerials(ctx, token, thingID, offset, limit)
 }
 
-func (lm *loggingMiddleware) ViewCert(ctx context.Context, token, serial string) (c certs.Cert, err error) {
+func (lm *loggingMiddleware) ViewCert(ctx context.Context, token, serial string) (_ certs.Cert, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_cert for serial %s took %s to complete", serial, time.Since(begin))
 		if err != nil {
@@ -78,7 +78,7 @@ func (lm *loggingMiddleware) ViewCert(ctx context.Context, token, serial string)
 	return lm.svc.ViewCert(ctx, token, serial)
 }
 
-func (lm *loggingMiddleware) RevokeCert(ctx context.Context, token, serial string) (c certs.Revoke, err error) {
+func (lm *loggingMiddleware) RevokeCert(ctx context.Context, token, serial string) (_ certs.Revoke, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method revoke_cert for serial %s took %s to complete", serial, time.Since(begin))
 		if err != nil {
@@ -91,7 +91,7 @@ func (lm *loggingMiddleware) RevokeCert(ctx context.Context, token, serial strin
 	return lm.svc.RevokeCert(ctx, token, serial)
 }
 
-func (lm *loggingMiddleware) RenewCert(ctx context.Context, token, serial string) (c certs.Cert, err error) {
+func (lm *loggingMiddleware) RenewCert(ctx context.Context, token, serial string) (_ certs.Cert, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method renew_cert for serial %s took %s to complete", serial, time.Since(begin))
 		if err != nil {

--- a/consumers/notifiers/api/logging.go
+++ b/consumers/notifiers/api/logging.go
@@ -40,7 +40,7 @@ func (lm *loggingMiddleware) CreateNotifiers(ctx context.Context, token, groupID
 	return lm.svc.CreateNotifiers(ctx, token, groupID, notifiers...)
 }
 
-func (lm *loggingMiddleware) ListNotifiersByGroup(ctx context.Context, token string, groupID string, pm apiutil.PageMetadata) (res notifiers.NotifiersPage, err error) {
+func (lm *loggingMiddleware) ListNotifiersByGroup(ctx context.Context, token string, groupID string, pm apiutil.PageMetadata) (_ notifiers.NotifiersPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_notifiers_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
@@ -53,7 +53,7 @@ func (lm *loggingMiddleware) ListNotifiersByGroup(ctx context.Context, token str
 	return lm.svc.ListNotifiersByGroup(ctx, token, groupID, pm)
 }
 
-func (lm *loggingMiddleware) ViewNotifier(ctx context.Context, token, id string) (response notifiers.Notifier, err error) {
+func (lm *loggingMiddleware) ViewNotifier(ctx context.Context, token, id string) (_ notifiers.Notifier, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_notifier for notifier id %s took %s to complete", id, time.Since(begin))
 		if err != nil {

--- a/mqtt/api/logging.go
+++ b/mqtt/api/logging.go
@@ -27,7 +27,7 @@ func LoggingMiddleware(svc mqtt.Service, logger log.Logger) mqtt.Service {
 	return &loggingMiddleware{logger, svc}
 }
 
-func (lm *loggingMiddleware) ListSubscriptions(ctx context.Context, groupID, token string, pm mqtt.PageMetadata) (page mqtt.Page, err error) {
+func (lm *loggingMiddleware) ListSubscriptions(ctx context.Context, groupID, token string, pm mqtt.PageMetadata) (_ mqtt.Page, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_subscriptions for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {

--- a/readers/api/logging.go
+++ b/readers/api/logging.go
@@ -30,7 +30,7 @@ func LoggingMiddleware(svc readers.Service, logger logger.Logger) readers.Servic
 	}
 }
 
-func (lm *loggingMiddleware) ListJSONMessages(ctx context.Context, token string, key things.ThingKey, rpm readers.JSONPageMetadata) (page readers.JSONMessagesPage, err error) {
+func (lm *loggingMiddleware) ListJSONMessages(ctx context.Context, token string, key things.ThingKey, rpm readers.JSONPageMetadata) (_ readers.JSONMessagesPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_json_messages took %s to complete", time.Since(begin))
 		if err != nil {
@@ -43,7 +43,7 @@ func (lm *loggingMiddleware) ListJSONMessages(ctx context.Context, token string,
 	return lm.svc.ListJSONMessages(ctx, token, key, rpm)
 }
 
-func (lm *loggingMiddleware) ListSenMLMessages(ctx context.Context, token string, key things.ThingKey, rpm readers.SenMLPageMetadata) (page readers.SenMLMessagesPage, err error) {
+func (lm *loggingMiddleware) ListSenMLMessages(ctx context.Context, token string, key things.ThingKey, rpm readers.SenMLPageMetadata) (_ readers.SenMLMessagesPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_senml_messages took %s to complete", time.Since(begin))
 		if err != nil {
@@ -56,7 +56,7 @@ func (lm *loggingMiddleware) ListSenMLMessages(ctx context.Context, token string
 	return lm.svc.ListSenMLMessages(ctx, token, key, rpm)
 }
 
-func (lm *loggingMiddleware) BackupJSONMessages(ctx context.Context, token string, rpm readers.JSONPageMetadata) (page readers.JSONMessagesPage, err error) {
+func (lm *loggingMiddleware) BackupJSONMessages(ctx context.Context, token string, rpm readers.JSONPageMetadata) (_ readers.JSONMessagesPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup_json_messages took %s to complete", time.Since(begin))
 		if err != nil {
@@ -69,7 +69,7 @@ func (lm *loggingMiddleware) BackupJSONMessages(ctx context.Context, token strin
 	return lm.svc.BackupJSONMessages(ctx, token, rpm)
 }
 
-func (lm *loggingMiddleware) BackupSenMLMessages(ctx context.Context, token string, rpm readers.SenMLPageMetadata) (page readers.SenMLMessagesPage, err error) {
+func (lm *loggingMiddleware) BackupSenMLMessages(ctx context.Context, token string, rpm readers.SenMLPageMetadata) (_ readers.SenMLMessagesPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup_senml_messages took %s to complete", time.Since(begin))
 		if err != nil {

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -83,7 +83,7 @@ func (lm *loggingMiddleware) UpdateThingGroupAndProfile(ctx context.Context, tok
 	return lm.svc.UpdateThingGroupAndProfile(ctx, token, thing)
 }
 
-func (lm *loggingMiddleware) ViewThing(ctx context.Context, token, id string) (thing things.Thing, err error) {
+func (lm *loggingMiddleware) ViewThing(ctx context.Context, token, id string) (_ things.Thing, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_thing for thing id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
@@ -96,7 +96,7 @@ func (lm *loggingMiddleware) ViewThing(ctx context.Context, token, id string) (t
 	return lm.svc.ViewThing(ctx, token, id)
 }
 
-func (lm *loggingMiddleware) ViewMetadataByKey(ctx context.Context, key things.ThingKey) (metadata things.Metadata, err error) {
+func (lm *loggingMiddleware) ViewMetadataByKey(ctx context.Context, key things.ThingKey) (_ things.Metadata, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_metadata_by_key took %s to complete", time.Since(begin))
 		if err != nil {
@@ -134,7 +134,7 @@ func (lm *loggingMiddleware) ListThingsByProfile(ctx context.Context, token, prI
 	return lm.svc.ListThingsByProfile(ctx, token, prID, pm)
 }
 
-func (lm *loggingMiddleware) ListThingsByOrg(ctx context.Context, token string, orgID string, pm apiutil.PageMetadata) (tp things.ThingsPage, err error) {
+func (lm *loggingMiddleware) ListThingsByOrg(ctx context.Context, token string, orgID string, pm apiutil.PageMetadata) (_ things.ThingsPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_things_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
@@ -146,7 +146,7 @@ func (lm *loggingMiddleware) ListThingsByOrg(ctx context.Context, token string, 
 	return lm.svc.ListThingsByOrg(ctx, token, orgID, pm)
 }
 
-func (lm *loggingMiddleware) BackupThingsByGroup(ctx context.Context, token string, groupID string) (tb things.ThingsBackup, err error) {
+func (lm *loggingMiddleware) BackupThingsByGroup(ctx context.Context, token string, groupID string) (_ things.ThingsBackup, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup_things_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
@@ -172,7 +172,7 @@ func (lm *loggingMiddleware) RestoreThingsByGroup(ctx context.Context, token str
 	return lm.svc.RestoreThingsByGroup(ctx, token, groupID, backup)
 }
 
-func (lm *loggingMiddleware) BackupThingsByOrg(ctx context.Context, token string, orgID string) (tb things.ThingsBackup, err error) {
+func (lm *loggingMiddleware) BackupThingsByOrg(ctx context.Context, token string, orgID string) (_ things.ThingsBackup, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup_things_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
@@ -237,7 +237,7 @@ func (lm *loggingMiddleware) UpdateProfile(ctx context.Context, token string, pr
 	return lm.svc.UpdateProfile(ctx, token, profile)
 }
 
-func (lm *loggingMiddleware) ViewProfile(ctx context.Context, token, id string) (profile things.Profile, err error) {
+func (lm *loggingMiddleware) ViewProfile(ctx context.Context, token, id string) (_ things.Profile, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_profile for profile id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
@@ -263,7 +263,7 @@ func (lm *loggingMiddleware) ListProfiles(ctx context.Context, token string, pm 
 	return lm.svc.ListProfiles(ctx, token, pm)
 }
 
-func (lm *loggingMiddleware) ListProfilesByOrg(ctx context.Context, token string, orgID string, pm apiutil.PageMetadata) (prs things.ProfilesPage, err error) {
+func (lm *loggingMiddleware) ListProfilesByOrg(ctx context.Context, token string, orgID string, pm apiutil.PageMetadata) (_ things.ProfilesPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_profiles_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
@@ -313,7 +313,7 @@ func (lm *loggingMiddleware) GetPubConfByKey(ctx context.Context, key things.Thi
 	return lm.svc.GetPubConfByKey(ctx, key)
 }
 
-func (lm *loggingMiddleware) GetConfigByThingID(ctx context.Context, thingID string) (config map[string]any, err error) {
+func (lm *loggingMiddleware) GetConfigByThingID(ctx context.Context, thingID string) (_ map[string]any, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method get_config_by_thing_id for thing %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
@@ -429,7 +429,7 @@ func (lm *loggingMiddleware) GetGroupIDsByOrg(ctx context.Context, orgID string,
 	return lm.svc.GetGroupIDsByOrg(ctx, orgID, token)
 }
 
-func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (bk things.Backup, err error) {
+func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (_ things.Backup, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup took %s to complete", time.Since(begin))
 		if err != nil {
@@ -442,7 +442,7 @@ func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (bk thing
 	return lm.svc.Backup(ctx, token)
 }
 
-func (lm *loggingMiddleware) BackupGroupsByOrg(ctx context.Context, token string, orgID string) (bk things.GroupsBackup, err error) {
+func (lm *loggingMiddleware) BackupGroupsByOrg(ctx context.Context, token string, orgID string) (_ things.GroupsBackup, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup_groups_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
@@ -468,7 +468,7 @@ func (lm *loggingMiddleware) RestoreGroupsByOrg(ctx context.Context, token strin
 	return lm.svc.RestoreGroupsByOrg(ctx, token, orgID, backup)
 }
 
-func (lm *loggingMiddleware) BackupGroupMemberships(ctx context.Context, token string, groupID string) (bk things.GroupMembershipsBackup, err error) {
+func (lm *loggingMiddleware) BackupGroupMemberships(ctx context.Context, token string, groupID string) (_ things.GroupMembershipsBackup, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup_group_memberships for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
@@ -494,7 +494,7 @@ func (lm *loggingMiddleware) RestoreGroupMemberships(ctx context.Context, token 
 	return lm.svc.RestoreGroupMemberships(ctx, token, groupID, backup)
 }
 
-func (lm *loggingMiddleware) BackupProfilesByOrg(ctx context.Context, token string, orgID string) (pb things.ProfilesBackup, err error) {
+func (lm *loggingMiddleware) BackupProfilesByOrg(ctx context.Context, token string, orgID string) (_ things.ProfilesBackup, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup_profiles_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
@@ -520,7 +520,7 @@ func (lm *loggingMiddleware) RestoreProfilesByOrg(ctx context.Context, token str
 	return lm.svc.RestoreProfilesByOrg(ctx, token, orgID, backup)
 }
 
-func (lm *loggingMiddleware) BackupProfilesByGroup(ctx context.Context, token string, groupID string) (pb things.ProfilesBackup, err error) {
+func (lm *loggingMiddleware) BackupProfilesByGroup(ctx context.Context, token string, groupID string) (_ things.ProfilesBackup, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method backup_profiles_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
@@ -572,7 +572,7 @@ func (lm *loggingMiddleware) CreateGroups(ctx context.Context, token, orgID stri
 	return lm.svc.CreateGroups(ctx, token, orgID, grs...)
 }
 
-func (lm *loggingMiddleware) UpdateGroup(ctx context.Context, token string, gr things.Group) (g things.Group, err error) {
+func (lm *loggingMiddleware) UpdateGroup(ctx context.Context, token string, gr things.Group) (_ things.Group, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method update_group for group id %s took %s to complete", gr.ID, time.Since(begin))
 		if err != nil {
@@ -585,7 +585,7 @@ func (lm *loggingMiddleware) UpdateGroup(ctx context.Context, token string, gr t
 	return lm.svc.UpdateGroup(ctx, token, gr)
 }
 
-func (lm *loggingMiddleware) ViewGroup(ctx context.Context, token, id string) (g things.Group, err error) {
+func (lm *loggingMiddleware) ViewGroup(ctx context.Context, token, id string) (_ things.Group, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_group for group id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
@@ -598,7 +598,7 @@ func (lm *loggingMiddleware) ViewGroup(ctx context.Context, token, id string) (g
 	return lm.svc.ViewGroup(ctx, token, id)
 }
 
-func (lm *loggingMiddleware) ViewGroupInternal(ctx context.Context, id string) (g things.Group, err error) {
+func (lm *loggingMiddleware) ViewGroupInternal(ctx context.Context, id string) (_ things.Group, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_group_internal for id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
@@ -611,7 +611,7 @@ func (lm *loggingMiddleware) ViewGroupInternal(ctx context.Context, id string) (
 	return lm.svc.ViewGroupInternal(ctx, id)
 }
 
-func (lm *loggingMiddleware) ListGroups(ctx context.Context, token string, pm apiutil.PageMetadata) (g things.GroupPage, err error) {
+func (lm *loggingMiddleware) ListGroups(ctx context.Context, token string, pm apiutil.PageMetadata) (_ things.GroupPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_groups took %s to complete", time.Since(begin))
 		if err != nil {
@@ -624,7 +624,7 @@ func (lm *loggingMiddleware) ListGroups(ctx context.Context, token string, pm ap
 	return lm.svc.ListGroups(ctx, token, pm)
 }
 
-func (lm *loggingMiddleware) ListGroupsByOrg(ctx context.Context, token, orgID string, pm apiutil.PageMetadata) (g things.GroupPage, err error) {
+func (lm *loggingMiddleware) ListGroupsByOrg(ctx context.Context, token, orgID string, pm apiutil.PageMetadata) (_ things.GroupPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_groups_by_org for org id %s took %s to complete", orgID, time.Since(begin))
 		if err != nil {
@@ -637,7 +637,7 @@ func (lm *loggingMiddleware) ListGroupsByOrg(ctx context.Context, token, orgID s
 	return lm.svc.ListGroupsByOrg(ctx, token, orgID, pm)
 }
 
-func (lm *loggingMiddleware) ListThingsByGroup(ctx context.Context, token, groupID string, pm apiutil.PageMetadata) (mp things.ThingsPage, err error) {
+func (lm *loggingMiddleware) ListThingsByGroup(ctx context.Context, token, groupID string, pm apiutil.PageMetadata) (_ things.ThingsPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_things_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
@@ -650,7 +650,7 @@ func (lm *loggingMiddleware) ListThingsByGroup(ctx context.Context, token, group
 	return lm.svc.ListThingsByGroup(ctx, token, groupID, pm)
 }
 
-func (lm *loggingMiddleware) ViewGroupByThing(ctx context.Context, token, thingID string) (gr things.Group, err error) {
+func (lm *loggingMiddleware) ViewGroupByThing(ctx context.Context, token, thingID string) (_ things.Group, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_group_by_thing for thing id %s took %s to complete", thingID, time.Since(begin))
 		if err != nil {
@@ -702,7 +702,7 @@ func (lm *loggingMiddleware) ViewGroupByProfile(ctx context.Context, token, prof
 	return lm.svc.ViewGroupByProfile(ctx, token, profileID)
 }
 
-func (lm *loggingMiddleware) ListProfilesByGroup(ctx context.Context, token, groupID string, pm apiutil.PageMetadata) (gprp things.ProfilesPage, err error) {
+func (lm *loggingMiddleware) ListProfilesByGroup(ctx context.Context, token, groupID string, pm apiutil.PageMetadata) (_ things.ProfilesPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_profiles_by_group for group id %s took %s to complete", groupID, time.Since(begin))
 		if err != nil {
@@ -739,7 +739,7 @@ func (lm *loggingMiddleware) CreateGroupMembershipsInternal(ctx context.Context,
 	return lm.svc.CreateGroupMembershipsInternal(ctx, gms...)
 }
 
-func (lm *loggingMiddleware) ListGroupMemberships(ctx context.Context, token, groupID string, pm apiutil.PageMetadata) (gpp things.GroupMembershipsPage, err error) {
+func (lm *loggingMiddleware) ListGroupMemberships(ctx context.Context, token, groupID string, pm apiutil.PageMetadata) (_ things.GroupMembershipsPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_group_memberships for group id %s and email %s took %s to complete", groupID, pm.Email, time.Since(begin))
 		if err != nil {

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -689,7 +689,7 @@ func (lm *loggingMiddleware) RemoveGroupsByOrg(ctx context.Context, orgID string
 	return lm.svc.RemoveGroupsByOrg(ctx, orgID)
 }
 
-func (lm *loggingMiddleware) ViewGroupByProfile(ctx context.Context, token, profileID string) (gr things.Group, err error) {
+func (lm *loggingMiddleware) ViewGroupByProfile(ctx context.Context, token, profileID string) (_ things.Group, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_group_by_profile for profile id %s took %s to complete", profileID, time.Since(begin))
 		if err != nil {

--- a/users/api/http/logging.go
+++ b/users/api/http/logging.go
@@ -57,7 +57,7 @@ func (lm *loggingMiddleware) VerifyEmail(ctx context.Context, confirmationToken 
 
 func (lm *loggingMiddleware) RegisterByInvite(ctx context.Context, user users.User, inviteID, orgInviteRedirectPath string) (_ string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method register_by_invite for user %s and inviteID %s took %s to complete", user.Email, inviteID, time.Since(begin))
+		message := fmt.Sprintf("Method register_by_invite for user %s and invite id %s took %s to complete", user.Email, inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/users/api/http/logging.go
+++ b/users/api/http/logging.go
@@ -27,7 +27,7 @@ func LoggingMiddleware(svc users.Service, logger log.Logger) users.Service {
 	return &loggingMiddleware{logger, svc}
 }
 
-func (lm *loggingMiddleware) SelfRegister(ctx context.Context, user users.User, redirectPath string) (id string, err error) {
+func (lm *loggingMiddleware) SelfRegister(ctx context.Context, user users.User, redirectPath string) (_ string, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method self_register for user %s took %s to complete", user.Email, time.Since(begin))
 		if err != nil {
@@ -41,9 +41,9 @@ func (lm *loggingMiddleware) SelfRegister(ctx context.Context, user users.User, 
 	return lm.svc.SelfRegister(ctx, user, redirectPath)
 }
 
-func (lm *loggingMiddleware) VerifyEmail(ctx context.Context, confirmationToken string) (userID string, err error) {
+func (lm *loggingMiddleware) VerifyEmail(ctx context.Context, confirmationToken string) (_ string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method verify_email for token %s took %s to complete", confirmationToken, time.Since(begin))
+		message := fmt.Sprintf("Method verify_email took %s to complete", time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -55,9 +55,9 @@ func (lm *loggingMiddleware) VerifyEmail(ctx context.Context, confirmationToken 
 	return lm.svc.VerifyEmail(ctx, confirmationToken)
 }
 
-func (lm *loggingMiddleware) RegisterByInvite(ctx context.Context, user users.User, inviteID, orgInviteRedirectPath string) (id string, err error) {
+func (lm *loggingMiddleware) RegisterByInvite(ctx context.Context, user users.User, inviteID, orgInviteRedirectPath string) (_ string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method register_by_invite for user: %s, inviteID: %s took %s to complete", user.Email, inviteID, time.Since(begin))
+		message := fmt.Sprintf("Method register_by_invite for user %s and inviteID %s took %s to complete", user.Email, inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -83,7 +83,7 @@ func (lm *loggingMiddleware) RegisterAdmin(ctx context.Context, user users.User)
 	return lm.svc.RegisterAdmin(ctx, user)
 }
 
-func (lm *loggingMiddleware) Register(ctx context.Context, token string, user users.User) (uid string, err error) {
+func (lm *loggingMiddleware) Register(ctx context.Context, token string, user users.User) (_ string, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method register for user %s took %s to complete", user.Email, time.Since(begin))
 		if err != nil {
@@ -136,7 +136,7 @@ func (lm *loggingMiddleware) ViewProfile(ctx context.Context, token string) (u u
 	return lm.svc.ViewProfile(ctx, token)
 }
 
-func (lm *loggingMiddleware) ListUsers(ctx context.Context, token string, pm users.PageMetadata) (e users.UserPage, err error) {
+func (lm *loggingMiddleware) ListUsers(ctx context.Context, token string, pm users.PageMetadata) (_ users.UserPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_users took %s to complete", time.Since(begin))
 		if err != nil {
@@ -149,7 +149,7 @@ func (lm *loggingMiddleware) ListUsers(ctx context.Context, token string, pm use
 	return lm.svc.ListUsers(ctx, token, pm)
 }
 
-func (lm *loggingMiddleware) ListUsersByIDs(ctx context.Context, ids []string, pm users.PageMetadata) (u users.UserPage, err error) {
+func (lm *loggingMiddleware) ListUsersByIDs(ctx context.Context, ids []string, pm users.PageMetadata) (_ users.UserPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_users_by_ids for ids %s and email %s took %s to complete", ids, pm.Email, time.Since(begin))
 		if err != nil {
@@ -162,7 +162,7 @@ func (lm *loggingMiddleware) ListUsersByIDs(ctx context.Context, ids []string, p
 	return lm.svc.ListUsersByIDs(ctx, ids, pm)
 }
 
-func (lm *loggingMiddleware) ListUsersByEmails(ctx context.Context, emails []string) (u []users.User, err error) {
+func (lm *loggingMiddleware) ListUsersByEmails(ctx context.Context, emails []string) (_ []users.User, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_users_by_emails for emails %s took %s to complete", emails, time.Since(begin))
 		if err != nil {
@@ -242,7 +242,7 @@ func (lm *loggingMiddleware) SendPasswordReset(ctx context.Context, redirectPath
 
 func (lm *loggingMiddleware) EnableUser(ctx context.Context, token string, id string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method enable_user for user %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method enable_user for user id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -255,7 +255,7 @@ func (lm *loggingMiddleware) EnableUser(ctx context.Context, token string, id st
 
 func (lm *loggingMiddleware) DisableUser(ctx context.Context, token string, id string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method disable_user for user %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method disable_user for user id %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -284,9 +284,9 @@ func (lm *loggingMiddleware) Restore(ctx context.Context, token string, admin us
 	return lm.svc.Restore(ctx, token, admin, users)
 }
 
-func (lm *loggingMiddleware) CreatePlatformInvite(ctx context.Context, token, redirectPath, email string, orgInvite auth.OrgInvite) (invite users.PlatformInvite, err error) {
+func (lm *loggingMiddleware) CreatePlatformInvite(ctx context.Context, token, redirectPath, email string, orgInvite auth.OrgInvite) (_ users.PlatformInvite, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method create_platform_invite took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method create_platform_invite for email %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -300,7 +300,7 @@ func (lm *loggingMiddleware) CreatePlatformInvite(ctx context.Context, token, re
 
 func (lm *loggingMiddleware) RevokePlatformInvite(ctx context.Context, token, inviteID string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method revoke_platform_invite took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method revoke_platform_invite for invite id %s took %s to complete", inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -312,9 +312,9 @@ func (lm *loggingMiddleware) RevokePlatformInvite(ctx context.Context, token, in
 	return lm.svc.RevokePlatformInvite(ctx, token, inviteID)
 }
 
-func (lm *loggingMiddleware) ViewPlatformInvite(ctx context.Context, token, inviteID string) (invite users.PlatformInvite, err error) {
+func (lm *loggingMiddleware) ViewPlatformInvite(ctx context.Context, token, inviteID string) (_ users.PlatformInvite, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_platform_invite took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method view_platform_invite for invite id %s took %s to complete", inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -326,7 +326,7 @@ func (lm *loggingMiddleware) ViewPlatformInvite(ctx context.Context, token, invi
 	return lm.svc.ViewPlatformInvite(ctx, token, inviteID)
 }
 
-func (lm *loggingMiddleware) ListPlatformInvites(ctx context.Context, token string, pm users.PageMetadataInvites) (invitesPage users.PlatformInvitesPage, err error) {
+func (lm *loggingMiddleware) ListPlatformInvites(ctx context.Context, token string, pm users.PageMetadataInvites) (_ users.PlatformInvitesPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list_platform_invites took %s to complete", time.Since(begin))
 		if err != nil {
@@ -342,7 +342,7 @@ func (lm *loggingMiddleware) ListPlatformInvites(ctx context.Context, token stri
 
 func (lm *loggingMiddleware) ValidatePlatformInvite(ctx context.Context, inviteID string, email string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method validate_platform_invite took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method validate_platform_invite for invite id %s and email %s took %s to complete", inviteID, email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -356,7 +356,7 @@ func (lm *loggingMiddleware) ValidatePlatformInvite(ctx context.Context, inviteI
 
 func (lm *loggingMiddleware) SendPlatformInviteEmail(ctx context.Context, invite users.PlatformInvite, redirectPath string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method send_platform_invite_email took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method send_platform_invite_email for invite id %s took %s to complete", invite.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return


### PR DESCRIPTION
* Use `_` as identifier for named returned values which aren't referenced in the body of the corresponding logger middleware methods
* Update log messages for platform invite-related service methods in the `users` service