### PR TITLE
MF-1085 - Remove mongo and timescale readers and writers from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 
 MF_DOCKER_IMAGE_NAME_PREFIX ?= mainfluxlabs
 BUILD_DIR = build
-SERVICES = users things http coap ws mongodb-writer \
-	mongodb-reader postgres-writer postgres-reader timescale-writer timescale-reader cli \
+SERVICES = users things http coap ws postgres-writer postgres-reader cli \
 	auth mqtt certs smtp-notifier smpp-notifier alarms rules filestore downlinks modbus \
 	uiconfigs converters webhooks
 DOCKERS = $(addprefix docker_,$(SERVICES))


### PR DESCRIPTION
Related to #1085 