### PR TITLE
NOISSUE - auth: use proper protobuf type in gRPC client Issue method

### DIFF
--- a/auth/api/grpc/client.go
+++ b/auth/api/grpc/client.go
@@ -46,7 +46,7 @@ func NewClient(conn *grpc.ClientConn, tracer opentracing.Tracer, timeout time.Du
 			"Issue",
 			encodeIssueRequest,
 			decodeIssueResponse,
-			protomfx.UserIdentity{},
+			protomfx.Token{},
 		).Endpoint()),
 		identify: kitot.TraceClient(tracer, "identify")(kitgrpc.NewClient(
 			conn,
@@ -134,8 +134,8 @@ func (client grpcClient) Issue(ctx context.Context, req *protomfx.IssueReq, _ ..
 		return nil, err
 	}
 
-	ir := res.(identityRes)
-	return &protomfx.Token{Value: ir.id}, nil
+	ir := res.(issueRes)
+	return &protomfx.Token{Value: ir.value}, nil
 }
 
 func encodeIssueRequest(_ context.Context, grpcReq any) (any, error) {
@@ -144,8 +144,8 @@ func encodeIssueRequest(_ context.Context, grpcReq any) (any, error) {
 }
 
 func decodeIssueResponse(_ context.Context, grpcRes any) (any, error) {
-	res := grpcRes.(*protomfx.UserIdentity)
-	return identityRes{id: res.GetId(), email: res.GetEmail()}, nil
+	res := grpcRes.(*protomfx.Token)
+	return issueRes{value: res.GetValue()}, nil
 }
 
 func (client grpcClient) Identify(ctx context.Context, token *protomfx.Token, _ ...grpc.CallOption) (*protomfx.UserIdentity, error) {


### PR DESCRIPTION
For a pretty long time the `Issue` method of the `auth` service gRPC client seemed to decode the server response into the `UserIdentity` protobuf type, while the **server responds with the `Token` protobuf type**. 

This worked purely by coincidence, since the `Issue` client method only cared about the _first field of the response type_ (`id` in `UserIdentity`), which shares the field number and type with the first (and only) field of the actual response type returned by the server (`value` in `Token`).

This PR fixes the client side to decode the response into the proper `Token` protobuf type and then later into the `issueRes` gRPC response type.