### PR TITLE
MF-1197 - Introduce Input field and refactor assign/unassign endpoints

### DIFF
--- a/api/openapi/rules.yml
+++ b/api/openapi/rules.yml
@@ -16,7 +16,7 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/CreateRulesReq"
       responses:
-        '201':
+        '201': 
           $ref: "#/components/responses/CreateRulesRes"
         '400':
           description: Failed due to malformed JSON.
@@ -35,6 +35,12 @@ paths:
         - rules
       parameters:
         - $ref: "#/components/parameters/GroupId"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/Order"
+        - $ref: "#/components/parameters/Dir"
+        - $ref: "#/components/parameters/Name"
+        - $ref: "#/components/parameters/InputType"
       responses:
         '200':
           $ref: "#/components/responses/ListRulesRes"
@@ -56,6 +62,12 @@ paths:
         - rules
       parameters:
         - $ref: "#/components/parameters/ThingId"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/Order"
+        - $ref: "#/components/parameters/Dir"
+        - $ref: "#/components/parameters/Name"
+        - $ref: "#/components/parameters/InputType"
       responses:
         '200':
           $ref: "#/components/responses/ListRulesRes"
@@ -67,54 +79,6 @@ paths:
           description: Failed to perform authorization over the entity.
         '422':
           description: Database can't process request.
-        '500':
-          $ref: "#/components/responses/ServiceError"
-    post:
-      summary: Assigns rules to a thing
-      description: Assigns rules to a specific thing identified by the provided ID.
-      tags:
-        - rules
-      parameters:
-        - $ref: "#/components/parameters/ThingId"
-      requestBody:
-        $ref: "#/components/requestBodies/ThingRulesReq"
-      responses:
-        '200':
-          description: Rules assigned successfully.
-        '400':
-          description: Failed due to malformed JSON.
-        '401':
-          description: Missing or invalid access token provided.
-        '403':
-          description: Failed to perform authorization over the entity.
-        '404':
-          description: Thing or one of the rules does not exist.
-        '415':
-          description: Missing or invalid content type.
-        '500':
-          $ref: "#/components/responses/ServiceError"
-    patch:
-      summary: Unassigns rules from a thing
-      description: Unassigns rules from a specific thing identified by the provided ID.
-      tags:
-        - rules
-      parameters:
-        - $ref: "#/components/parameters/ThingId"
-      requestBody:
-        $ref: "#/components/requestBodies/ThingRulesReq"
-      responses:
-        '200':
-          description: Rules unassigned successfully.
-        '400':
-          description: Failed due to malformed JSON.
-        '401':
-          description: Missing or invalid access token provided.
-        '403':
-          description: Failed to perform authorization over the entity.
-        '404':
-          description: Thing or one of the rules does not exist.
-        '415':
-          description: Missing or invalid content type.
         '500':
           $ref: "#/components/responses/ServiceError"
   /rules/{ruleId}/things:
@@ -132,12 +96,54 @@ paths:
           description: Failed due to malformed query parameters.
         '401':
           description: Missing or invalid access token provided.
-        '403':
-          description: Failed to perform authorization over the entity.
         '404':
           description: Rule does not exist.
         '422':
           description: Database can't process request.
+        '500':
+          $ref: "#/components/responses/ServiceError"
+    post:
+      summary: Assigns things to a rule
+      description: Assigns one or more things to a specific rule identified by the provided ID.
+      tags:
+        - rules
+      parameters:
+        - $ref: "#/components/parameters/RuleId"
+      requestBody:
+        $ref: "#/components/requestBodies/RuleThingsReq"
+      responses:
+        '200':
+          description: Things assigned successfully.
+        '400':
+          description: Failed due to malformed JSON.
+        '401':
+          description: Missing or invalid access token provided.
+        '404':
+          description: Rule does not exist.
+        '409':
+          description: One or more things are already assigned to this rule.
+        '415':
+          description: Missing or invalid content type.
+        '500':
+          $ref: "#/components/responses/ServiceError"
+    patch:
+      summary: Unassigns things from a rule
+      description: Unassigns one or more things from a specific rule identified by the provided ID.
+      tags:
+        - rules
+      parameters:
+        - $ref: "#/components/parameters/RuleId"
+      requestBody:
+        $ref: "#/components/requestBodies/RuleThingsReq"
+      responses:
+        '204':
+          description: Things unassigned successfully.
+        '400':
+          description: Failed due to malformed JSON.
+        '401':
+          description: Missing or invalid access token provided.
+        '415':
+          description: Missing or invalid content type.
         '500':
           $ref: "#/components/responses/ServiceError"
   /rules/{ruleId}:
@@ -150,6 +156,8 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/RuleRes"
+        '400':
+          description: Failed due to malformed query parameters.
         '401':
           description: Missing or invalid access token provided.
         '404':
@@ -195,6 +203,8 @@ paths:
           description: Failed due to malformed JSON.
         '401':
           description: Missing or invalid access token provided.
+        '404':
+          description: One or more rules do not exist.
         '500':
           $ref: "#/components/responses/ServiceError"
   /groups/{groupId}/scripts:
@@ -430,6 +440,31 @@ paths:
 
 components:
   schemas:
+    Input:
+      type: object
+      description: Defines what triggers the rule evaluation.
+      properties:
+        type:
+          type: string
+          enum: [message, alarm, schedule, command]
+          example: "message"
+        thing_ids:
+          type: array
+          description: IDs of things to which this rule applies.
+          items:
+            type: string
+            format: uuid
+          example: ["123e4567-e89b-12d3-a456-426614174000"]
+      required: [type]
+    UpdateRuleInput:
+      type: object
+      description: Input configuration for rule update. Thing assignments are managed separately via the assign/unassign endpoints.
+      properties:
+        type:
+          type: string
+          enum: [message, alarm, schedule, command]
+          example: "message"
+      required: [type]
     Condition:
       type: object
       properties:
@@ -471,6 +506,8 @@ components:
         description:
           type: string
           example: "Triggers when temperature exceeds 45°C and humidity drops below 20%"
+        input:
+          $ref: "#/components/schemas/Input"
         conditions:
           type: array
           items:
@@ -478,12 +515,38 @@ components:
         operator:
           type: string
           enum: [AND, OR]
+          description: Required when more than one condition is defined.
           example: "AND"
         actions:
           type: array
           items:
             $ref: "#/components/schemas/Action"
-      required: [name, conditions, actions]
+      required: [name, input, conditions, actions]
+    UpdateRuleReqSchema:
+      type: object
+      properties:
+        name:
+          type: string
+          example: "Temperature Alert"
+        description:
+          type: string
+          example: "Triggers when temperature exceeds 50°C"
+        input:
+          $ref: "#/components/schemas/UpdateRuleInput"
+        conditions:
+          type: array
+          items:
+            $ref: "#/components/schemas/Condition"
+        operator:
+          type: string
+          enum: [AND, OR]
+          description: Required when more than one condition is defined.
+          example: "AND"
+        actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/Action"
+      required: [name, input, conditions, actions]
     RuleResSchema:
       type: object
       properties:
@@ -499,6 +562,8 @@ components:
         description:
           type: string
           example: "Triggers when temperature exceeds 45°C and humidity drops below 20%"
+        input:
+          $ref: "#/components/schemas/Input"
         conditions:
           type: array
           items:
@@ -510,7 +575,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Action"
-      required: [ id, group_id, name, conditions, actions ]
+      required: [ id, group_id, name, input, conditions, actions ]
     ThingIDsRes:
       type: object
       properties:
@@ -530,7 +595,7 @@ components:
           type: string
           example: "Creates alarm and executes SMTP notifier on low temperature reading"
         script:
-          $ref: "#/components/schemas/ExampleScript" 
+          $ref: "#/components/schemas/ExampleScript"
       required: [name, script]
     ScriptResSchema:
       type: object
@@ -550,10 +615,9 @@ components:
           type: string
           example: "Creates alarm and executes SMTP notifier on low temperature reading"
         script:
-          $ref: "#/components/schemas/ExampleScript" 
+          $ref: "#/components/schemas/ExampleScript"
       required: [id, group_id, name, script]
     ScriptRunResSchema:
-
       type: object
       properties:
         id:
@@ -654,6 +718,56 @@ components:
         format: uuid
       example: "456e4567-e89b-12d3-a456-426614174abc"
       required: true
+    Limit:
+      name: limit
+      description: Maximum number of results to return (1–200).
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 100
+      example: 10
+    Offset:
+      name: offset
+      description: Number of results to skip.
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      example: 0
+    Order:
+      name: order
+      description: Field to sort results by.
+      in: query
+      schema:
+        type: string
+        enum: [name]
+      example: "name"
+    Dir:
+      name: dir
+      description: Sort direction. Required when order is specified.
+      in: query
+      schema:
+        type: string
+        enum: [asc, desc]
+      example: "asc"
+    Name:
+      name: name
+      description: Filter results by name (partial match).
+      in: query
+      schema:
+        type: string
+      example: "Temperature"
+    InputType:
+      name: input_type
+      description: Filter results by input type.
+      in: query
+      schema:
+        type: string
+        enum: [message, alarm, schedule, command]
+      example: "message"
 
   requestBodies:
     CreateRulesReq:
@@ -674,6 +788,10 @@ components:
             rules:
               - name: "Temperature and Humidity Alert"
                 description: "Triggers when temperature exceeds 45°C and humidity drops below 20%"
+                input:
+                  type: "message"
+                  thing_ids:
+                    - "123e4567-e89b-12d3-a456-426614174000"
                 conditions:
                   - field: "temperature"
                     comparator: ">"
@@ -686,22 +804,26 @@ components:
                   - type: "smtp"
                     id: "513e2557-e09b-42d3-s456-425614175403"
                   - type: "alarm"
+                    level: 3
     UpdateRuleReq:
-      description: JSON-formatted document describing the updated rule.
+      description: JSON-formatted document describing the updated rule. Thing assignments are not affected — use POST/PATCH /rules/{ruleId}/things instead.
       required: true
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/RuleReqSchema"
+            $ref: "#/components/schemas/UpdateRuleReqSchema"
           example:
             name: "Temperature Alert"
             description: "Triggers when temperature exceeds 50°C"
+            input:
+              type: "message"
             conditions:
               - field: "temperature"
                 comparator: ">"
                 threshold: 50
             actions:
               - type: "alarm"
+                level: 3
     RemoveRulesReq:
       description: JSON-formatted document describing the identifiers of rules for deleting.
       required: true
@@ -721,25 +843,25 @@ components:
             rule_ids:
               - "789e4567-e89b-12d3-a456-426614174abc"
               - "654e4567-e89b-12d3-a456-426614174999"
-    ThingRulesReq:
-      description: JSON-formatted document describing the rule identifiers to assign/unassign.
+    RuleThingsReq:
+      description: JSON-formatted document describing the thing identifiers to assign/unassign.
       required: true
       content:
         application/json:
           schema:
             type: object
             properties:
-              rule_ids:
+              thing_ids:
                 type: array
                 items:
                   type: string
                   format: uuid
             required:
-              - rule_ids
+              - thing_ids
           example:
-            rule_ids:
-              - "789e4567-e89b-12d3-a456-426614174abc"
-              - "654e4567-e89b-12d3-a456-426614174999"
+            thing_ids:
+              - "123e4567-e89b-12d3-a456-426614174000"
+              - "123e4567-e89b-12d3-a456-426614174001"
     CreateScriptsReq:
       description: JSON-formatted document describing the new Lua scripts.
       required: true
@@ -759,7 +881,7 @@ components:
               - name: "Low temperature notifier"
                 description: "Create alarm and send SMTP notification on low temperature."
                 script:
-                  $ref: "#/components/schemas/ExampleScript" 
+                  $ref: "#/components/schemas/ExampleScript"
     UpdateScriptReq:
       description: JSON-formatted document describing the updated Lua script.
       required: true
@@ -771,7 +893,7 @@ components:
             name: "Enhanced Temperature Transformation"
             description: "Low temperature notifier"
             script:
-              $ref: "#/components/schemas/ExampleScript" 
+              $ref: "#/components/schemas/ExampleScript"
     RemoveScriptsReq:
       description: JSON-formatted document describing the IDs of scripts for deleting.
       required: true
@@ -836,26 +958,37 @@ components:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: "#/components/schemas/RuleResSchema"
+            type: object
+            properties:
+              rules:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RuleResSchema"
+            required:
+              - rules
           example:
-            - id: "84d1be5e-3511-4d15-aafa-b1bb4c20bca4"
-              group_id: "fc1e40aa-c5af-4a1d-b1e4-37f2e4bb50d1"
-              name: "Temperature and Humidity Alert"
-              description: "Triggers when temperature exceeds 45°C and humidity drops below 20%"
-              conditions:
-                - field: "temperature"
-                  comparator: ">"
-                  threshold: 45
-                - field: "humidity"
-                  comparator: "<"
-                  threshold: 20
-              operator: "AND"
-              actions:
-                - type: "smtp"
-                  id: "513e2557-e09b-42d3-s456-425614175403"
-                - type: "alarm"
+            rules:
+              - id: "84d1be5e-3511-4d15-aafa-b1bb4c20bca4"
+                group_id: "fc1e40aa-c5af-4a1d-b1e4-37f2e4bb50d1"
+                name: "Temperature and Humidity Alert"
+                description: "Triggers when temperature exceeds 45°C and humidity drops below 20%"
+                input:
+                  type: "message"
+                  thing_ids:
+                    - "123e4567-e89b-12d3-a456-426614174000"
+                conditions:
+                  - field: "temperature"
+                    comparator: ">"
+                    threshold: 45
+                  - field: "humidity"
+                    comparator: "<"
+                    threshold: 20
+                operator: "AND"
+                actions:
+                  - type: "smtp"
+                    id: "513e2557-e09b-42d3-s456-425614175403"
+                  - type: "alarm"
+                    level: 3
     RuleRes:
       description: Data retrieved.
       content:
@@ -867,6 +1000,10 @@ components:
             group_id: "321e4567-e89b-12d3-a456-426614174def"
             name: "Temperature Alert"
             description: "Triggers when temperature exceeds 45°C"
+            input:
+              type: "message"
+              thing_ids:
+                - "123e4567-e89b-12d3-a456-426614174000"
             conditions:
               - field: "temperature"
                 comparator: ">"
@@ -905,6 +1042,8 @@ components:
                 group_id: "321e4567-e89b-12d3-a456-426614174def"
                 name: "Temperature Alert"
                 description: "Triggers when temperature exceeds 45°C"
+                input:
+                  type: "message"
                 conditions:
                   - field: "temperature"
                     comparator: ">"
@@ -942,7 +1081,7 @@ components:
                 name: "Temperature Data Transformation"
                 description: "Low temperature notifier"
                 script:
-                  $ref: "#/components/schemas/ExampleScript" 
+                  $ref: "#/components/schemas/ExampleScript"
     ScriptRes:
       description: Script data retrieved.
       content:
@@ -955,7 +1094,7 @@ components:
             name: "Low temperature notifier"
             description: "Low temperature notifier"
             script:
-              $ref: "#/components/schemas/ExampleScript" 
+              $ref: "#/components/schemas/ExampleScript"
     ListScriptsRes:
       description: Scripts retrieved.
       content:
@@ -988,7 +1127,7 @@ components:
                 name: "Low temperature notifier"
                 description: "Create alarm and send SMTP notifier on low temperature value"
                 script:
-                  $ref: "#/components/schemas/ExampleScript" 
+                  $ref: "#/components/schemas/ExampleScript"
     ListScriptRunsRes:
       description: Script runs retrieved.
       content:

--- a/api/openapi/rules.yml
+++ b/api/openapi/rules.yml
@@ -1044,6 +1044,8 @@ components:
                 description: "Triggers when temperature exceeds 45°C"
                 input:
                   type: "message"
+                  thing_ids:
+                    - "123e4567-e89b-12d3-a456-426614174000"
                 conditions:
                   - field: "temperature"
                     comparator: ">"

--- a/api/openapi/rules.yml
+++ b/api/openapi/rules.yml
@@ -16,7 +16,7 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/CreateRulesReq"
       responses:
-        '201': 
+        '201':
           $ref: "#/components/responses/CreateRulesRes"
         '400':
           description: Failed due to malformed JSON.

--- a/api/openapi/rules.yml
+++ b/api/openapi/rules.yml
@@ -446,7 +446,7 @@ components:
       properties:
         type:
           type: string
-          enum: [message, alarm, schedule, command]
+          enum: [message, alarm, command]
           example: "message"
         thing_ids:
           type: array
@@ -462,7 +462,7 @@ components:
       properties:
         type:
           type: string
-          enum: [message, alarm, schedule, command]
+          enum: [message, alarm, command]
           example: "message"
       required: [type]
     Condition:
@@ -766,7 +766,7 @@ components:
       in: query
       schema:
         type: string
-        enum: [message, alarm, schedule, command]
+        enum: [message, alarm, command]
       example: "message"
 
   requestBodies:

--- a/pkg/apiutil/errors.go
+++ b/pkg/apiutil/errors.go
@@ -183,6 +183,9 @@ var (
 	// ErrInvalidOperator indicates an invalid logical operator
 	ErrInvalidOperator = errors.New("missing or invalid logical operator")
 
+	// ErrInvalidInputType indicates an invalid rule input type
+	ErrInvalidInputType = errors.New("missing or invalid input type")
+
 	// ErrInviteExpired indicates that an invite has expired
 	ErrInviteExpired = errors.New("invite expired")
 

--- a/pkg/apiutil/errors.go
+++ b/pkg/apiutil/errors.go
@@ -78,7 +78,7 @@ var (
 	// ErrInvalidIDFormat indicates an invalid ID format.
 	ErrInvalidIDFormat = errors.New("invalid id format provided")
 
-	// ErrThingIDsSize indicates an invalid thing IDs size.
+	// ErrThingIDsSize indicates that the number of thing IDs is outside the allowed range.
 	ErrThingIDsSize = errors.New("invalid thing ids size")
 
 	// ErrNameSize indicates that name size exceeds the max.

--- a/pkg/apiutil/errors.go
+++ b/pkg/apiutil/errors.go
@@ -78,6 +78,9 @@ var (
 	// ErrInvalidIDFormat indicates an invalid ID format.
 	ErrInvalidIDFormat = errors.New("invalid id format provided")
 
+	// ErrThingIDsSize indicates an invalid thing IDs size.
+	ErrThingIDsSize = errors.New("invalid thing ids size")
+
 	// ErrNameSize indicates that name size exceeds the max.
 	ErrNameSize = errors.New("invalid name size")
 

--- a/pkg/apiutil/transport.go
+++ b/pkg/apiutil/transport.go
@@ -33,6 +33,7 @@ const (
 	SerialKey              = "serial"
 	EmailKey               = "email"
 	PayloadKey             = "payload"
+	InputTypeKey           = "input_type"
 	IDOrder                = "id"
 	AscDir                 = "asc"
 	DescDir                = "desc"
@@ -105,6 +106,7 @@ func LoggingErrorEncoder(logger logger.Logger, enc kithttp.ErrorEncoder) kithttp
 			errors.Contains(err, ErrInvalidAlarmStatus),
 			errors.Contains(err, ErrInvalidOperator),
 			errors.Contains(err, ErrInvalidInputType),
+			errors.Contains(err, ErrThingIDsSize),
 			errors.Contains(err, ErrInvalidThingType),
 			errors.Contains(err, ErrMissingAuth):
 			logger.Error(err.Error())
@@ -218,7 +220,8 @@ func EncodeError(err error, w http.ResponseWriter) {
 		errors.Contains(err, ErrInvalidThingType),
 		errors.Contains(err, ErrInvalidAlarmLevel),
 		errors.Contains(err, ErrInvalidAlarmStatus),
-		errors.Contains(err, ErrInvalidInputType):
+		errors.Contains(err, ErrInvalidInputType),
+		errors.Contains(err, ErrThingIDsSize):
 		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, errors.ErrAuthorization),
 		errors.Contains(err, ErrInviteExpired),

--- a/pkg/apiutil/transport.go
+++ b/pkg/apiutil/transport.go
@@ -104,6 +104,7 @@ func LoggingErrorEncoder(logger logger.Logger, enc kithttp.ErrorEncoder) kithttp
 			errors.Contains(err, ErrInvalidAlarmLevel),
 			errors.Contains(err, ErrInvalidAlarmStatus),
 			errors.Contains(err, ErrInvalidOperator),
+			errors.Contains(err, ErrInvalidInputType),
 			errors.Contains(err, ErrInvalidThingType),
 			errors.Contains(err, ErrMissingAuth):
 			logger.Error(err.Error())
@@ -216,7 +217,8 @@ func EncodeError(err error, w http.ResponseWriter) {
 		errors.Contains(err, ErrInvalidState),
 		errors.Contains(err, ErrInvalidThingType),
 		errors.Contains(err, ErrInvalidAlarmLevel),
-		errors.Contains(err, ErrInvalidAlarmStatus):
+		errors.Contains(err, ErrInvalidAlarmStatus),
+		errors.Contains(err, ErrInvalidInputType):
 		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, errors.ErrAuthorization),
 		errors.Contains(err, ErrInviteExpired),

--- a/rules/README.md
+++ b/rules/README.md
@@ -16,7 +16,7 @@ Rules and scripts are created within a group and then assigned to individual thi
 
 ## Rules
 
-A rule evaluates a set of conditions against an incoming message payload. When all conditions are met (using AND or OR logic), the rule triggers one or more actions.
+A rule evaluates a set of conditions against an incoming payload. When conditions are met according to the configured operator (AND or OR), the rule triggers one or more actions.
 
 | Field         | Description                                                                                                      |
 | ------------- | ---------------------------------------------------------------------------------------------------------------- |
@@ -24,9 +24,19 @@ A rule evaluates a set of conditions against an incoming message payload. When a
 | `group_id`    | ID of the group the rule belongs to                                                                              |
 | `name`        | Human-readable rule name                                                                                         |
 | `description` | Optional free-form description                                                                                   |
+| `input`       | Defines what triggers rule evaluation (see below)                                                                |
 | `conditions`  | List of conditions to evaluate (see below)                                                                       |
 | `operator`    | Logical operator applied across all conditions: `AND` or `OR`. Required when more than one condition is defined. |
 | `actions`     | List of actions to trigger when conditions are met (see below)                                                   |
+
+### Input
+
+The `input` field defines what triggers rule evaluation.
+
+| Field       | Description                                                |
+| ----------- | ---------------------------------------------------------- |
+| `type`      | Trigger type: `message`, `alarm`, `schedule`, or `command` |
+| `thing_ids` | IDs of things to which this rule applies.                  |
 
 ### Conditions
 

--- a/rules/README.md
+++ b/rules/README.md
@@ -33,10 +33,10 @@ A rule evaluates a set of conditions against an incoming payload. When condition
 
 The `input` field defines what triggers rule evaluation.
 
-| Field       | Description                                                |
-| ----------- | ---------------------------------------------------------- |
-| `type`      | Trigger type: `message`, `alarm`, `schedule`, or `command` |
-| `thing_ids` | IDs of things to which this rule applies.                  |
+| Field       | Description                                    |
+| ----------- | ---------------------------------------------- |
+| `type`      | Trigger type: `message`, `alarm`, or `command` |
+| `thing_ids` | IDs of things to which this rule applies.      |
 
 ### Conditions
 

--- a/rules/api/http/rules/endpoint.go
+++ b/rules/api/http/rules/endpoint.go
@@ -104,16 +104,7 @@ func viewRuleEndpoint(svc rules.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return ruleResponse{
-			ID:          rule.ID,
-			GroupID:     rule.GroupID,
-			Name:        rule.Name,
-			Description: rule.Description,
-			Input:       input{Type: rule.Input.Type, ThingIDs: rule.Input.ThingIDs},
-			Conditions:  rule.Conditions,
-			Operator:    rule.Operator,
-			Actions:     rule.Actions,
-		}, nil
+		return toRuleResponse(rule), nil
 	}
 }
 
@@ -163,7 +154,7 @@ func toRuleResponse(r rules.Rule) ruleResponse {
 		GroupID:     r.GroupID,
 		Name:        r.Name,
 		Description: r.Description,
-		Input:       input{Type: r.Input.Type},
+		Input:       input{Type: r.Input.Type, ThingIDs: r.Input.ThingIDs},
 		Conditions:  r.Conditions,
 		Operator:    r.Operator,
 		Actions:     r.Actions,

--- a/rules/api/http/rules/endpoint.go
+++ b/rules/api/http/rules/endpoint.go
@@ -154,7 +154,7 @@ func toRuleResponse(r rules.Rule) ruleResponse {
 		GroupID:     r.GroupID,
 		Name:        r.Name,
 		Description: r.Description,
-		Input:       input{Type: r.Input.Type, ThingIDs: r.Input.ThingIDs},
+		Input:       r.Input,
 		Conditions:  r.Conditions,
 		Operator:    r.Operator,
 		Actions:     r.Actions,

--- a/rules/api/http/rules/endpoint.go
+++ b/rules/api/http/rules/endpoint.go
@@ -21,10 +21,11 @@ func createRulesEndpoint(svc rules.Service) endpoint.Endpoint {
 		for _, rReq := range req.Rules {
 			r := rules.Rule{
 				Name:        rReq.Name,
+				Description: rReq.Description,
+				Input:       rReq.Input,
 				Conditions:  rReq.Conditions,
 				Operator:    rReq.Operator,
 				Actions:     rReq.Actions,
-				Description: rReq.Description,
 			}
 			rulesList = append(rulesList, r)
 		}
@@ -114,6 +115,7 @@ func updateRuleEndpoint(svc rules.Service) endpoint.Endpoint {
 			ID:          req.id,
 			Name:        req.Name,
 			Description: req.Description,
+			Input:       req.Input,
 			Conditions:  req.Conditions,
 			Operator:    req.Operator,
 			Actions:     req.Actions,
@@ -142,36 +144,6 @@ func removeRulesEndpoint(svc rules.Service) endpoint.Endpoint {
 	}
 }
 
-func assignRulesEndpoint(svc rules.Service) endpoint.Endpoint {
-	return func(ctx context.Context, request any) (any, error) {
-		req := request.(thingRulesReq)
-		if err := req.validate(); err != nil {
-			return nil, err
-		}
-
-		if err := svc.AssignRules(ctx, req.token, req.thingID, req.RuleIDs...); err != nil {
-			return nil, err
-		}
-
-		return thingRulesRes{}, nil
-	}
-}
-
-func unassignRulesEndpoint(svc rules.Service) endpoint.Endpoint {
-	return func(ctx context.Context, request any) (any, error) {
-		req := request.(thingRulesReq)
-		if err := req.validate(); err != nil {
-			return nil, err
-		}
-
-		if err := svc.UnassignRules(ctx, req.token, req.thingID, req.RuleIDs...); err != nil {
-			return nil, err
-		}
-
-		return thingRulesRes{}, nil
-	}
-}
-
 func buildRulesResponse(rules []rules.Rule, created bool) rulesRes {
 	res := rulesRes{Rules: []ruleResponse{}, created: created}
 
@@ -181,6 +153,7 @@ func buildRulesResponse(rules []rules.Rule, created bool) rulesRes {
 			GroupID:     r.GroupID,
 			Name:        r.Name,
 			Description: r.Description,
+			Input:       r.Input,
 			Conditions:  r.Conditions,
 			Operator:    r.Operator,
 			Actions:     r.Actions,
@@ -210,6 +183,7 @@ func buildRulesPageResponse(page rules.RulesPage, pm rules.PageMetadata) RulesPa
 			GroupID:     r.GroupID,
 			Name:        r.Name,
 			Description: r.Description,
+			Input:       r.Input,
 			Conditions:  r.Conditions,
 			Operator:    r.Operator,
 			Actions:     r.Actions,
@@ -226,6 +200,7 @@ func buildRuleResponse(rule rules.Rule, updated bool) ruleResponse {
 		GroupID:     rule.GroupID,
 		Name:        rule.Name,
 		Description: rule.Description,
+		Input:       rule.Input,
 		Conditions:  rule.Conditions,
 		Operator:    rule.Operator,
 		Actions:     rule.Actions,

--- a/rules/api/http/rules/endpoint.go
+++ b/rules/api/http/rules/endpoint.go
@@ -35,7 +35,11 @@ func createRulesEndpoint(svc rules.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildRulesResponse(rules, true), nil
+		res := rulesRes{Rules: []ruleResponse{}, created: true}
+		for _, r := range rules {
+			res.Rules = append(res.Rules, toRuleResponse(r))
+		}
+		return res, nil
 	}
 }
 
@@ -100,7 +104,16 @@ func viewRuleEndpoint(svc rules.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return buildRuleResponse(rule, false), nil
+		return ruleResponse{
+			ID:          rule.ID,
+			GroupID:     rule.GroupID,
+			Name:        rule.Name,
+			Description: rule.Description,
+			Input:       input{Type: rule.Input.Type, ThingIDs: rule.Input.ThingIDs},
+			Conditions:  rule.Conditions,
+			Operator:    rule.Operator,
+			Actions:     rule.Actions,
+		}, nil
 	}
 }
 
@@ -144,24 +157,17 @@ func removeRulesEndpoint(svc rules.Service) endpoint.Endpoint {
 	}
 }
 
-func buildRulesResponse(rules []rules.Rule, created bool) rulesRes {
-	res := rulesRes{Rules: []ruleResponse{}, created: created}
-
-	for _, r := range rules {
-		rule := ruleResponse{
-			ID:          r.ID,
-			GroupID:     r.GroupID,
-			Name:        r.Name,
-			Description: r.Description,
-			Input:       r.Input,
-			Conditions:  r.Conditions,
-			Operator:    r.Operator,
-			Actions:     r.Actions,
-		}
-		res.Rules = append(res.Rules, rule)
+func toRuleResponse(r rules.Rule) ruleResponse {
+	return ruleResponse{
+		ID:          r.ID,
+		GroupID:     r.GroupID,
+		Name:        r.Name,
+		Description: r.Description,
+		Input:       input{Type: r.Input.Type},
+		Conditions:  r.Conditions,
+		Operator:    r.Operator,
+		Actions:     r.Actions,
 	}
-
-	return res
 }
 
 func buildRulesPageResponse(page rules.RulesPage, pm rules.PageMetadata) RulesPageRes {
@@ -178,32 +184,8 @@ func buildRulesPageResponse(page rules.RulesPage, pm rules.PageMetadata) RulesPa
 	}
 
 	for _, r := range page.Rules {
-		rule := ruleResponse{
-			ID:          r.ID,
-			GroupID:     r.GroupID,
-			Name:        r.Name,
-			Description: r.Description,
-			Input:       r.Input,
-			Conditions:  r.Conditions,
-			Operator:    r.Operator,
-			Actions:     r.Actions,
-		}
-		res.Rules = append(res.Rules, rule)
+		res.Rules = append(res.Rules, toRuleResponse(r))
 	}
 
 	return res
-}
-
-func buildRuleResponse(rule rules.Rule, updated bool) ruleResponse {
-	return ruleResponse{
-		ID:          rule.ID,
-		GroupID:     rule.GroupID,
-		Name:        rule.Name,
-		Description: rule.Description,
-		Input:       rule.Input,
-		Conditions:  rule.Conditions,
-		Operator:    rule.Operator,
-		Actions:     rule.Actions,
-		updated:     updated,
-	}
 }

--- a/rules/api/http/rules/endpoint.go
+++ b/rules/api/http/rules/endpoint.go
@@ -119,7 +119,7 @@ func updateRuleEndpoint(svc rules.Service) endpoint.Endpoint {
 			ID:          req.id,
 			Name:        req.Name,
 			Description: req.Description,
-			Input:       req.Input,
+			Input:       rules.Input{Type: req.Input.Type},
 			Conditions:  req.Conditions,
 			Operator:    req.Operator,
 			Actions:     req.Actions,
@@ -130,6 +130,36 @@ func updateRuleEndpoint(svc rules.Service) endpoint.Endpoint {
 		}
 
 		return ruleResponse{updated: true}, nil
+	}
+}
+
+func assignThingsEndpoint(svc rules.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request any) (any, error) {
+		req := request.(ruleThingsReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		if err := svc.AssignThings(ctx, req.token, req.ruleID, req.ThingIDs...); err != nil {
+			return nil, err
+		}
+
+		return assignRes{}, nil
+	}
+}
+
+func unassignThingsEndpoint(svc rules.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request any) (any, error) {
+		req := request.(ruleThingsReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		if err := svc.UnassignThings(ctx, req.token, req.ruleID, req.ThingIDs...); err != nil {
+			return nil, err
+		}
+
+		return removeRes{}, nil
 	}
 }
 

--- a/rules/api/http/rules/endpoint_test.go
+++ b/rules/api/http/rules/endpoint_test.go
@@ -50,6 +50,7 @@ type rule struct {
 	GroupID     string            `json:"group_id,omitempty"`
 	Name        string            `json:"name,omitempty"`
 	Description string            `json:"description,omitempty"`
+	Input       rules.Input       `json:"input"`
 	Conditions  []rules.Condition `json:"conditions,omitempty"`
 	Operator    string            `json:"operator,omitempty"`
 	Actions     []rules.Action    `json:"actions,omitempty"`
@@ -130,6 +131,7 @@ func saveRules(t *testing.T, svc rules.Service, n int) []rules.Rule {
 		r := rules.Rule{
 			ID:         fmt.Sprintf("%s%012d", prefixID, i+1),
 			Name:       fmt.Sprintf("%s%012d", prefixName, i+1),
+			Input:      rules.Input{Type: rules.InputTypeMessage, ThingIDs: []string{thingID}},
 			Conditions: []rules.Condition{condTemp},
 			Actions:    []rules.Action{action},
 		}
@@ -145,8 +147,10 @@ func TestCreateRules(t *testing.T) {
 	ts := newHTTPServer(svc)
 	defer ts.Close()
 
+	validInput := rules.Input{Type: rules.InputTypeMessage, ThingIDs: []string{thingID}}
+
 	validReq := rulesReq{Rules: []rule{
-		{Name: ruleName, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{action}},
+		{Name: ruleName, Input: validInput, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{action}},
 	}}
 
 	cases := []struct {
@@ -173,8 +177,8 @@ func TestCreateRules(t *testing.T) {
 			groupID:     groupID,
 			contentType: contentType,
 			body: rulesReq{Rules: []rule{
-				{Name: "rule-1", Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{action}},
-				{Name: "rule-2", Conditions: []rules.Condition{condHum}, Actions: []rules.Action{action}},
+				{Name: "rule-1", Input: validInput, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{action}},
+				{Name: "rule-2", Input: validInput, Conditions: []rules.Condition{condHum}, Actions: []rules.Action{action}},
 			}},
 			status: http.StatusCreated,
 			size:   2,
@@ -185,7 +189,7 @@ func TestCreateRules(t *testing.T) {
 			groupID:     groupID,
 			contentType: contentType,
 			body: rulesReq{Rules: []rule{
-				{Name: ruleName, Conditions: []rules.Condition{condTemp, condHum}, Operator: rules.OperatorAND, Actions: []rules.Action{action}},
+				{Name: ruleName, Input: validInput, Conditions: []rules.Condition{condTemp, condHum}, Operator: rules.OperatorAND, Actions: []rules.Action{action}},
 			}},
 			status: http.StatusCreated,
 			size:   1,
@@ -196,7 +200,7 @@ func TestCreateRules(t *testing.T) {
 			groupID:     groupID,
 			contentType: contentType,
 			body: rulesReq{Rules: []rule{
-				{Name: ruleName, Conditions: []rules.Condition{condTemp, condHum}, Operator: rules.OperatorOR, Actions: []rules.Action{action}},
+				{Name: ruleName, Input: validInput, Conditions: []rules.Condition{condTemp, condHum}, Operator: rules.OperatorOR, Actions: []rules.Action{action}},
 			}},
 			status: http.StatusCreated,
 			size:   1,
@@ -207,7 +211,7 @@ func TestCreateRules(t *testing.T) {
 			groupID:     groupID,
 			contentType: contentType,
 			body: rulesReq{Rules: []rule{
-				{Name: ruleName, Conditions: []rules.Condition{condTemp, condHum}, Actions: []rules.Action{action}},
+				{Name: ruleName, Input: validInput, Conditions: []rules.Condition{condTemp, condHum}, Actions: []rules.Action{action}},
 			}},
 			status: http.StatusBadRequest,
 			size:   0,
@@ -218,7 +222,51 @@ func TestCreateRules(t *testing.T) {
 			groupID:     groupID,
 			contentType: contentType,
 			body: rulesReq{Rules: []rule{
-				{Name: ruleName, Conditions: []rules.Condition{condTemp, condHum}, Operator: "XOR", Actions: []rules.Action{action}},
+				{Name: ruleName, Input: validInput, Conditions: []rules.Condition{condTemp, condHum}, Operator: "XOR", Actions: []rules.Action{action}},
+			}},
+			status: http.StatusBadRequest,
+			size:   0,
+		},
+		{
+			desc:        "create rule with missing input type",
+			auth:        token,
+			groupID:     groupID,
+			contentType: contentType,
+			body: rulesReq{Rules: []rule{
+				{Name: ruleName, Input: rules.Input{ThingIDs: []string{thingID}}, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{action}},
+			}},
+			status: http.StatusBadRequest,
+			size:   0,
+		},
+		{
+			desc:        "create rule with invalid input type",
+			auth:        token,
+			groupID:     groupID,
+			contentType: contentType,
+			body: rulesReq{Rules: []rule{
+				{Name: ruleName, Input: rules.Input{Type: "invalid", ThingIDs: []string{thingID}}, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{action}},
+			}},
+			status: http.StatusBadRequest,
+			size:   0,
+		},
+		{
+			desc:        "create rule with missing thing IDs",
+			auth:        token,
+			groupID:     groupID,
+			contentType: contentType,
+			body: rulesReq{Rules: []rule{
+				{Name: ruleName, Input: rules.Input{Type: rules.InputTypeMessage}, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{action}},
+			}},
+			status: http.StatusBadRequest,
+			size:   0,
+		},
+		{
+			desc:        "create rule with invalid thing ID format",
+			auth:        token,
+			groupID:     groupID,
+			contentType: contentType,
+			body: rulesReq{Rules: []rule{
+				{Name: ruleName, Input: rules.Input{Type: rules.InputTypeMessage, ThingIDs: []string{"not-a-uuid"}}, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{action}},
 			}},
 			status: http.StatusBadRequest,
 			size:   0,
@@ -292,7 +340,7 @@ func TestCreateRules(t *testing.T) {
 			groupID:     groupID,
 			contentType: contentType,
 			body: rulesReq{Rules: []rule{
-				{Name: ruleName, Actions: []rules.Action{{Type: rules.ActionTypeAlarm}}},
+				{Name: ruleName, Input: validInput, Actions: []rules.Action{{Type: rules.ActionTypeAlarm}}},
 			}},
 			status: http.StatusBadRequest,
 			size:   0,
@@ -303,7 +351,7 @@ func TestCreateRules(t *testing.T) {
 			groupID:     groupID,
 			contentType: contentType,
 			body: rulesReq{Rules: []rule{
-				{Name: ruleName, Conditions: []rules.Condition{condTemp}},
+				{Name: ruleName, Input: validInput, Conditions: []rules.Condition{condTemp}},
 			}},
 			status: http.StatusBadRequest,
 			size:   0,
@@ -314,7 +362,7 @@ func TestCreateRules(t *testing.T) {
 			groupID:     groupID,
 			contentType: contentType,
 			body: rulesReq{Rules: []rule{
-				{Name: ruleName, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{{Type: "unknown"}}},
+				{Name: ruleName, Input: validInput, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{{Type: "unknown"}}},
 			}},
 			status: http.StatusBadRequest,
 			size:   0,
@@ -325,7 +373,7 @@ func TestCreateRules(t *testing.T) {
 			groupID:     groupID,
 			contentType: contentType,
 			body: rulesReq{Rules: []rule{
-				{Name: ruleName, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{{Type: rules.ActionTypeAlarm, Level: 0}}},
+				{Name: ruleName, Input: validInput, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{{Type: rules.ActionTypeAlarm, Level: 0}}},
 			}},
 			status: http.StatusBadRequest,
 			size:   0,
@@ -547,14 +595,7 @@ func TestListRulesByThing(t *testing.T) {
 	defer ts.Close()
 
 	n := 5
-	saved := saveRules(t, svc, n)
-
-	var ruleIDs []string
-	for _, r := range saved {
-		ruleIDs = append(ruleIDs, r.ID)
-	}
-	err := svc.AssignRules(context.Background(), token, thingID, ruleIDs...)
-	require.Nil(t, err, fmt.Sprintf("unexpected error assigning rules: %s", err))
+	saveRules(t, svc, n)
 
 	cases := []struct {
 		desc   string
@@ -625,9 +666,6 @@ func TestListThingIDsByRule(t *testing.T) {
 	saved := saveRules(t, svc, 1)
 	ruleID := saved[0].ID
 
-	err := svc.AssignRules(context.Background(), token, thingID, ruleID)
-	require.Nil(t, err, fmt.Sprintf("unexpected error assigning rule: %s", err))
-
 	cases := []struct {
 		desc   string
 		auth   string
@@ -693,6 +731,7 @@ func TestUpdateRule(t *testing.T) {
 	updThreshold := 35.0
 	updatedRule := rule{
 		Name:       "updated-rule",
+		Input:      rules.Input{Type: rules.InputTypeMessage, ThingIDs: []string{thingID}},
 		Conditions: []rules.Condition{{Field: "temperature", Comparator: ">", Threshold: &updThreshold}},
 		Actions:    []rules.Action{action},
 	}
@@ -758,7 +797,7 @@ func TestUpdateRule(t *testing.T) {
 			auth:        token,
 			id:          ruleID,
 			contentType: contentType,
-			body:        rule{Name: "updated-rule", Actions: []rules.Action{{Type: rules.ActionTypeAlarm}}},
+			body:        rule{Name: "updated-rule", Input: rules.Input{Type: rules.InputTypeMessage, ThingIDs: []string{thingID}}, Actions: []rules.Action{{Type: rules.ActionTypeAlarm}}},
 			status:      http.StatusBadRequest,
 		},
 	}
@@ -853,169 +892,3 @@ func TestRemoveRules(t *testing.T) {
 	}
 }
 
-func TestAssignRules(t *testing.T) {
-	svc := newService()
-	ts := newHTTPServer(svc)
-	defer ts.Close()
-
-	saved := saveRules(t, svc, 2)
-	ruleID1 := saved[0].ID
-	ruleID2 := saved[1].ID
-
-	cases := []struct {
-		desc        string
-		auth        string
-		thingID     string
-		contentType string
-		ids         []string
-		status      int
-	}{
-		{
-			desc:        "assign rules to thing",
-			auth:        token,
-			thingID:     thingID,
-			contentType: contentType,
-			ids:         []string{ruleID1, ruleID2},
-			status:      http.StatusOK,
-		},
-		{
-			desc:        "assign rules with empty token",
-			auth:        emptyValue,
-			thingID:     thingID,
-			contentType: contentType,
-			ids:         []string{ruleID1},
-			status:      http.StatusUnauthorized,
-		},
-		{
-			desc:        "assign rules with wrong token",
-			auth:        wrongValue,
-			thingID:     thingID,
-			contentType: contentType,
-			ids:         []string{ruleID1},
-			status:      http.StatusUnauthorized,
-		},
-		{
-			desc:        "assign rules to wrong thing ID",
-			auth:        token,
-			thingID:     wrongValue,
-			contentType: contentType,
-			ids:         []string{ruleID1},
-			status:      http.StatusForbidden,
-		},
-		{
-			desc:        "assign rules without content type",
-			auth:        token,
-			thingID:     thingID,
-			contentType: emptyValue,
-			ids:         []string{ruleID1},
-			status:      http.StatusUnsupportedMediaType,
-		},
-		{
-			desc:        "assign rules with empty list",
-			auth:        token,
-			thingID:     thingID,
-			contentType: contentType,
-			ids:         []string{},
-			status:      http.StatusBadRequest,
-		},
-	}
-
-	for _, tc := range cases {
-		body := toJSON(struct {
-			RuleIDs []string `json:"rule_ids"`
-		}{tc.ids})
-
-		req := testRequest{
-			client:      ts.Client(),
-			method:      http.MethodPost,
-			url:         fmt.Sprintf("%s/things/%s/rules", ts.URL, tc.thingID),
-			token:       tc.auth,
-			contentType: tc.contentType,
-			body:        strings.NewReader(body),
-		}
-		res, err := req.make()
-		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s\n", tc.desc, err))
-		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected status %d got %d\n", tc.desc, tc.status, res.StatusCode))
-	}
-}
-
-func TestUnassignRules(t *testing.T) {
-	svc := newService()
-	ts := newHTTPServer(svc)
-	defer ts.Close()
-
-	saved := saveRules(t, svc, 2)
-	ruleID1 := saved[0].ID
-	ruleID2 := saved[1].ID
-
-	err := svc.AssignRules(context.Background(), token, thingID, ruleID1, ruleID2)
-	require.Nil(t, err, fmt.Sprintf("unexpected error assigning rules: %s", err))
-
-	cases := []struct {
-		desc        string
-		auth        string
-		thingID     string
-		contentType string
-		ids         []string
-		status      int
-	}{
-		{
-			desc:        "unassign rules from thing",
-			auth:        token,
-			thingID:     thingID,
-			contentType: contentType,
-			ids:         []string{ruleID1, ruleID2},
-			status:      http.StatusOK,
-		},
-		{
-			desc:        "unassign rules with empty token",
-			auth:        emptyValue,
-			thingID:     thingID,
-			contentType: contentType,
-			ids:         []string{ruleID1},
-			status:      http.StatusUnauthorized,
-		},
-		{
-			desc:        "unassign rules from wrong thing ID",
-			auth:        token,
-			thingID:     wrongValue,
-			contentType: contentType,
-			ids:         []string{ruleID1},
-			status:      http.StatusForbidden,
-		},
-		{
-			desc:        "unassign rules without content type",
-			auth:        token,
-			thingID:     thingID,
-			contentType: emptyValue,
-			ids:         []string{ruleID1},
-			status:      http.StatusUnsupportedMediaType,
-		},
-		{
-			desc:        "unassign rules with empty list",
-			auth:        token,
-			thingID:     thingID,
-			contentType: contentType,
-			ids:         []string{},
-			status:      http.StatusBadRequest,
-		},
-	}
-
-	for _, tc := range cases {
-		body := toJSON(struct {
-			RuleIDs []string `json:"rule_ids"`
-		}{tc.ids})
-
-		req := testRequest{
-			client:      ts.Client(),
-			method:      http.MethodPatch,
-			url:         fmt.Sprintf("%s/things/%s/rules", ts.URL, tc.thingID),
-			token:       tc.auth,
-			contentType: tc.contentType,
-			body:        strings.NewReader(body),
-		}
-		res, err := req.make()
-		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s\n", tc.desc, err))
-		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected status %d got %d\n", tc.desc, tc.status, res.StatusCode))
-	}
-}

--- a/rules/api/http/rules/endpoint_test.go
+++ b/rules/api/http/rules/endpoint_test.go
@@ -32,6 +32,7 @@ const (
 	emptyValue  = ""
 	contentType = "application/json"
 	thingID     = "5384fb1c-d0ae-4cbe-be52-c54223150fe0"
+	thingID2    = "7a9b3c1d-e2f4-5678-90ab-cdef01234567"
 	groupID     = "574106f7-030e-4881-8ab0-151195c29f94"
 	ruleName    = "test-rule"
 	prefixID    = "fe6b4e92-cc98-425e-b0aa-"
@@ -75,8 +76,9 @@ func newService() rules.Service {
 	ths := pkgmocks.NewThingsServiceClient(
 		nil,
 		map[string]things.Thing{
-			token:   {ID: thingID, GroupID: groupID},
-			thingID: {ID: thingID, GroupID: groupID},
+			token:    {ID: thingID, GroupID: groupID},
+			thingID:  {ID: thingID, GroupID: groupID},
+			thingID2: {ID: thingID2, GroupID: groupID},
 		},
 		map[string]things.Group{
 			token: {ID: groupID},
@@ -731,7 +733,7 @@ func TestUpdateRule(t *testing.T) {
 	updThreshold := 35.0
 	updatedRule := rule{
 		Name:       "updated-rule",
-		Input:      rules.Input{Type: rules.InputTypeMessage, ThingIDs: []string{thingID}},
+		Input:      rules.Input{Type: rules.InputTypeMessage},
 		Conditions: []rules.Condition{{Field: "temperature", Comparator: ">", Threshold: &updThreshold}},
 		Actions:    []rules.Action{action},
 	}
@@ -797,7 +799,23 @@ func TestUpdateRule(t *testing.T) {
 			auth:        token,
 			id:          ruleID,
 			contentType: contentType,
-			body:        rule{Name: "updated-rule", Input: rules.Input{Type: rules.InputTypeMessage, ThingIDs: []string{thingID}}, Actions: []rules.Action{{Type: rules.ActionTypeAlarm}}},
+			body:        rule{Name: "updated-rule", Input: rules.Input{Type: rules.InputTypeMessage}, Actions: []rules.Action{{Type: rules.ActionTypeAlarm}}},
+			status:      http.StatusBadRequest,
+		},
+		{
+			desc:        "update rule with missing input type",
+			auth:        token,
+			id:          ruleID,
+			contentType: contentType,
+			body:        rule{Name: "updated-rule", Input: rules.Input{}, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{action}},
+			status:      http.StatusBadRequest,
+		},
+		{
+			desc:        "update rule with invalid input type",
+			auth:        token,
+			id:          ruleID,
+			contentType: contentType,
+			body:        rule{Name: "updated-rule", Input: rules.Input{Type: "invalid"}, Conditions: []rules.Condition{condTemp}, Actions: []rules.Action{action}},
 			status:      http.StatusBadRequest,
 		},
 	}
@@ -892,3 +910,188 @@ func TestRemoveRules(t *testing.T) {
 	}
 }
 
+func TestAssignThings(t *testing.T) {
+	svc := newService()
+	ts := newHTTPServer(svc)
+	defer ts.Close()
+
+	saved := saveRules(t, svc, 1)
+	ruleID := saved[0].ID
+
+	cases := []struct {
+		desc        string
+		auth        string
+		ruleID      string
+		contentType string
+		thingIDs    []string
+		status      int
+	}{
+		{
+			desc:        "assign things to existing rule",
+			auth:        token,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{thingID2},
+			status:      http.StatusOK,
+		},
+		{
+			desc:        "assign already assigned thing",
+			auth:        token,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{thingID},
+			status:      http.StatusConflict,
+		},
+		{
+			desc:        "assign things to non-existing rule",
+			auth:        token,
+			ruleID:      wrongValue,
+			contentType: contentType,
+			thingIDs:    []string{thingID},
+			status:      http.StatusNotFound,
+		},
+		{
+			desc:        "assign with invalid thing ID format",
+			auth:        token,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{"not-a-uuid"},
+			status:      http.StatusBadRequest,
+		},
+		{
+			desc:        "assign with empty thing IDs",
+			auth:        token,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{},
+			status:      http.StatusBadRequest,
+		},
+		{
+			desc:        "assign with empty token",
+			auth:        emptyValue,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{thingID},
+			status:      http.StatusUnauthorized,
+		},
+		{
+			desc:        "assign with wrong token",
+			auth:        wrongValue,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{thingID},
+			status:      http.StatusUnauthorized,
+		},
+		{
+			desc:        "assign without content type",
+			auth:        token,
+			ruleID:      ruleID,
+			contentType: emptyValue,
+			thingIDs:    []string{thingID},
+			status:      http.StatusUnsupportedMediaType,
+		},
+	}
+
+	for _, tc := range cases {
+		body := toJSON(struct {
+			ThingIDs []string `json:"thing_ids"`
+		}{tc.thingIDs})
+
+		req := testRequest{
+			client:      ts.Client(),
+			method:      http.MethodPost,
+			url:         fmt.Sprintf("%s/rules/%s/things", ts.URL, tc.ruleID),
+			token:       tc.auth,
+			contentType: tc.contentType,
+			body:        strings.NewReader(body),
+		}
+		res, err := req.make()
+		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s\n", tc.desc, err))
+		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected status %d got %d\n", tc.desc, tc.status, res.StatusCode))
+	}
+}
+
+func TestUnassignThings(t *testing.T) {
+	svc := newService()
+	ts := newHTTPServer(svc)
+	defer ts.Close()
+
+	saved := saveRules(t, svc, 1)
+	ruleID := saved[0].ID
+
+	cases := []struct {
+		desc        string
+		auth        string
+		ruleID      string
+		contentType string
+		thingIDs    []string
+		status      int
+	}{
+		{
+			desc:        "unassign things from rule",
+			auth:        token,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{thingID},
+			status:      http.StatusNoContent,
+		},
+		{
+			desc:        "unassign with invalid thing ID format",
+			auth:        token,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{"not-a-uuid"},
+			status:      http.StatusBadRequest,
+		},
+		{
+			desc:        "unassign with empty thing IDs",
+			auth:        token,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{},
+			status:      http.StatusBadRequest,
+		},
+		{
+			desc:        "unassign with empty token",
+			auth:        emptyValue,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{thingID},
+			status:      http.StatusUnauthorized,
+		},
+		{
+			desc:        "unassign with wrong token",
+			auth:        wrongValue,
+			ruleID:      ruleID,
+			contentType: contentType,
+			thingIDs:    []string{thingID},
+			status:      http.StatusUnauthorized,
+		},
+		{
+			desc:        "unassign without content type",
+			auth:        token,
+			ruleID:      ruleID,
+			contentType: emptyValue,
+			thingIDs:    []string{thingID},
+			status:      http.StatusUnsupportedMediaType,
+		},
+	}
+
+	for _, tc := range cases {
+		body := toJSON(struct {
+			ThingIDs []string `json:"thing_ids"`
+		}{tc.thingIDs})
+
+		req := testRequest{
+			client:      ts.Client(),
+			method:      http.MethodPatch,
+			url:         fmt.Sprintf("%s/rules/%s/things", ts.URL, tc.ruleID),
+			token:       tc.auth,
+			contentType: tc.contentType,
+			body:        strings.NewReader(body),
+		}
+		res, err := req.make()
+		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s\n", tc.desc, err))
+		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected status %d got %d\n", tc.desc, tc.status, res.StatusCode))
+	}
+}

--- a/rules/api/http/rules/requests.go
+++ b/rules/api/http/rules/requests.go
@@ -6,6 +6,7 @@ package rules
 import (
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/rules"
+	"github.com/gofrs/uuid"
 )
 
 const (
@@ -19,6 +20,7 @@ const (
 type rule struct {
 	Name        string            `json:"name"`
 	Description string            `json:"description,omitempty"`
+	Input       rules.Input       `json:"input"`
 	Conditions  []rules.Condition `json:"conditions"`
 	Operator    string            `json:"operator,omitempty"`
 	Actions     []rules.Action    `json:"actions"`
@@ -55,6 +57,21 @@ func (req createRulesReq) validate() error {
 func (req rule) validate() error {
 	if req.Name == "" || len(req.Name) > maxNameSize {
 		return apiutil.ErrNameSize
+	}
+
+	switch req.Input.Type {
+	case rules.InputTypeMessage, rules.InputTypeAlarm, rules.InputTypeSchedule, rules.InputTypeCommand:
+	default:
+		return apiutil.ErrInvalidInputType
+	}
+
+	if len(req.Input.ThingIDs) < minLen {
+		return apiutil.ErrEmptyList
+	}
+	for _, id := range req.Input.ThingIDs {
+		if _, err := uuid.FromString(id); err != nil {
+			return apiutil.ErrInvalidIDFormat
+		}
 	}
 
 	if len(req.Conditions) < minLen {
@@ -193,30 +210,3 @@ func (req removeRulesReq) validate() error {
 	return nil
 }
 
-type thingRulesReq struct {
-	token   string
-	thingID string
-	RuleIDs []string `json:"rule_ids"`
-}
-
-func (req thingRulesReq) validate() error {
-	if req.token == "" {
-		return apiutil.ErrBearerToken
-	}
-
-	if req.thingID == "" {
-		return apiutil.ErrMissingThingID
-	}
-
-	if len(req.RuleIDs) < minLen {
-		return apiutil.ErrEmptyList
-	}
-
-	for _, ruleID := range req.RuleIDs {
-		if ruleID == "" {
-			return apiutil.ErrMissingRuleID
-		}
-	}
-
-	return nil
-}

--- a/rules/api/http/rules/requests.go
+++ b/rules/api/http/rules/requests.go
@@ -20,7 +20,7 @@ const (
 	maxAlarmLevel = 5
 )
 
-type rule struct {
+type createRule struct {
 	Name        string            `json:"name"`
 	Description string            `json:"description,omitempty"`
 	Input       rules.Input       `json:"input"`
@@ -32,7 +32,7 @@ type rule struct {
 type createRulesReq struct {
 	token   string
 	groupID string
-	Rules   []rule `json:"rules"`
+	Rules   []createRule `json:"rules"`
 }
 
 func (req createRulesReq) validate() error {
@@ -48,16 +48,8 @@ func (req createRulesReq) validate() error {
 		return apiutil.ErrEmptyList
 	}
 
-	for _, rule := range req.Rules {
-		if len(rule.Input.ThingIDs) < minLen || len(rule.Input.ThingIDs) > maxThingIDs {
-			return apiutil.ErrThingIDsSize
-		}
-		for _, id := range rule.Input.ThingIDs {
-			if _, err := uuid.FromString(id); err != nil {
-				return apiutil.ErrInvalidIDFormat
-			}
-		}
-		if err := rule.validate(); err != nil {
+	for _, r := range req.Rules {
+		if err := r.validate(); err != nil {
 			return err
 		}
 	}
@@ -65,57 +57,24 @@ func (req createRulesReq) validate() error {
 	return nil
 }
 
-func (req rule) validate() error {
+func (req createRule) validate() error {
 	if req.Name == "" || len(req.Name) > maxNameSize {
 		return apiutil.ErrNameSize
 	}
 
-	switch req.Input.Type {
-	case rules.InputTypeMessage, rules.InputTypeAlarm, rules.InputTypeSchedule, rules.InputTypeCommand:
-	default:
-		return apiutil.ErrInvalidInputType
+	if err := validateInputType(req.Input.Type); err != nil {
+		return err
 	}
 
-	if len(req.Conditions) < minLen {
-		return apiutil.ErrEmptyList
-	}
-	for _, condition := range req.Conditions {
-		if condition.Field == "" {
-			return apiutil.ErrMissingConditionField
-		}
-		if condition.Comparator == "" {
-			return apiutil.ErrMissingConditionComparator
-		}
-		if condition.Threshold == nil {
-			return apiutil.ErrMissingConditionThreshold
-		}
+	if err := validateThingIDs(req.Input.ThingIDs); err != nil {
+		return err
 	}
 
-	if len(req.Conditions) > minLen {
-		if req.Operator != rules.OperatorAND && req.Operator != rules.OperatorOR {
-			return apiutil.ErrInvalidOperator
-		}
+	if err := validateConditions(req.Conditions, req.Operator); err != nil {
+		return err
 	}
 
-	if len(req.Actions) < minLen {
-		return apiutil.ErrEmptyList
-	}
-	for _, action := range req.Actions {
-		switch action.Type {
-		case rules.ActionTypeSMTP, rules.ActionTypeSMPP:
-			if action.ID == "" {
-				return apiutil.ErrMissingActionID
-			}
-		case rules.ActionTypeAlarm:
-			if action.Level < minAlarmLevel || action.Level > maxAlarmLevel {
-				return apiutil.ErrInvalidAlarmLevel
-			}
-		default:
-			return apiutil.ErrInvalidActionType
-		}
-	}
-
-	return nil
+	return validateActions(req.Actions)
 }
 
 type ruleReq struct {
@@ -171,10 +130,19 @@ func (req listRulesByGroupReq) validate() error {
 	return req.pageMetadata.Validate(maxLimitSize, maxNameSize)
 }
 
+type updateRuleInput struct {
+	Type string `json:"type"`
+}
+
 type updateRuleReq struct {
-	token string
-	id    string
-	rule
+	token       string
+	id          string
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Input       updateRuleInput   `json:"input"`
+	Conditions  []rules.Condition `json:"conditions"`
+	Operator    string            `json:"operator,omitempty"`
+	Actions     []rules.Action    `json:"actions"`
 }
 
 func (req updateRuleReq) validate() error {
@@ -186,7 +154,19 @@ func (req updateRuleReq) validate() error {
 		return apiutil.ErrMissingRuleID
 	}
 
-	return req.rule.validate()
+	if req.Name == "" || len(req.Name) > maxNameSize {
+		return apiutil.ErrNameSize
+	}
+
+	if err := validateInputType(req.Input.Type); err != nil {
+		return err
+	}
+
+	if err := validateConditions(req.Conditions, req.Operator); err != nil {
+		return err
+	}
+
+	return validateActions(req.Actions)
 }
 
 type ruleThingsReq struct {
@@ -204,17 +184,7 @@ func (req ruleThingsReq) validate() error {
 		return apiutil.ErrMissingRuleID
 	}
 
-	if len(req.ThingIDs) < minLen || len(req.ThingIDs) > maxThingIDs {
-		return apiutil.ErrThingIDsSize
-	}
-
-	for _, id := range req.ThingIDs {
-		if _, err := uuid.FromString(id); err != nil {
-			return apiutil.ErrInvalidIDFormat
-		}
-	}
-
-	return nil
+	return validateThingIDs(req.ThingIDs)
 }
 
 type removeRulesReq struct {
@@ -235,5 +205,70 @@ func (req removeRulesReq) validate() error {
 		return apiutil.ErrMissingRuleID
 	}
 
+	return nil
+}
+
+func validateThingIDs(ids []string) error {
+	if len(ids) < minLen || len(ids) > maxThingIDs {
+		return apiutil.ErrThingIDsSize
+	}
+	for _, id := range ids {
+		if _, err := uuid.FromString(id); err != nil {
+			return apiutil.ErrInvalidIDFormat
+		}
+	}
+	return nil
+}
+
+func validateInputType(inputType string) error {
+	switch inputType {
+	case rules.InputTypeMessage, rules.InputTypeAlarm, rules.InputTypeSchedule, rules.InputTypeCommand:
+		return nil
+	default:
+		return apiutil.ErrInvalidInputType
+	}
+}
+
+func validateConditions(conditions []rules.Condition, operator string) error {
+	if len(conditions) < minLen {
+		return apiutil.ErrEmptyList
+	}
+	for _, condition := range conditions {
+		if condition.Field == "" {
+			return apiutil.ErrMissingConditionField
+		}
+		if condition.Comparator == "" {
+			return apiutil.ErrMissingConditionComparator
+		}
+		if condition.Threshold == nil {
+			return apiutil.ErrMissingConditionThreshold
+		}
+	}
+	if len(conditions) > minLen {
+		if operator != rules.OperatorAND && operator != rules.OperatorOR {
+			return apiutil.ErrInvalidOperator
+		}
+	}
+	return nil
+}
+
+func validateActions(actions []rules.Action) error {
+	if len(actions) < minLen {
+		return apiutil.ErrEmptyList
+	}
+	for _, action := range actions {
+		switch action.Type {
+		case rules.ActionTypeSMTP, rules.ActionTypeSMPP:
+			if action.ID == "" {
+				return apiutil.ErrMissingActionID
+			}
+		case rules.ActionTypeAlarm:
+			if action.Level < minAlarmLevel || action.Level > maxAlarmLevel {
+				return apiutil.ErrInvalidAlarmLevel
+			}
+		default:
+			return apiutil.ErrInvalidActionType
+		}
+	}
 	return nil
 }

--- a/rules/api/http/rules/requests.go
+++ b/rules/api/http/rules/requests.go
@@ -13,6 +13,7 @@ const (
 	minLen        = 1
 	maxLimitSize  = 200
 	maxNameSize   = 254
+	maxThingIDs   = 100
 	minAlarmLevel = 1
 	maxAlarmLevel = 5
 )
@@ -65,8 +66,8 @@ func (req rule) validate() error {
 		return apiutil.ErrInvalidInputType
 	}
 
-	if len(req.Input.ThingIDs) < minLen {
-		return apiutil.ErrEmptyList
+	if len(req.Input.ThingIDs) < minLen || len(req.Input.ThingIDs) > maxThingIDs {
+		return apiutil.ErrThingIDsSize
 	}
 	for _, id := range req.Input.ThingIDs {
 		if _, err := uuid.FromString(id); err != nil {
@@ -209,4 +210,3 @@ func (req removeRulesReq) validate() error {
 
 	return nil
 }
-

--- a/rules/api/http/rules/requests.go
+++ b/rules/api/http/rules/requests.go
@@ -4,6 +4,8 @@
 package rules
 
 import (
+	"slices"
+
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/rules"
 	"github.com/gofrs/uuid"
@@ -47,6 +49,14 @@ func (req createRulesReq) validate() error {
 	}
 
 	for _, rule := range req.Rules {
+		if len(rule.Input.ThingIDs) < minLen || len(rule.Input.ThingIDs) > maxThingIDs {
+			return apiutil.ErrThingIDsSize
+		}
+		for _, id := range rule.Input.ThingIDs {
+			if _, err := uuid.FromString(id); err != nil {
+				return apiutil.ErrInvalidIDFormat
+			}
+		}
 		if err := rule.validate(); err != nil {
 			return err
 		}
@@ -64,15 +74,6 @@ func (req rule) validate() error {
 	case rules.InputTypeMessage, rules.InputTypeAlarm, rules.InputTypeSchedule, rules.InputTypeCommand:
 	default:
 		return apiutil.ErrInvalidInputType
-	}
-
-	if len(req.Input.ThingIDs) < minLen || len(req.Input.ThingIDs) > maxThingIDs {
-		return apiutil.ErrThingIDsSize
-	}
-	for _, id := range req.Input.ThingIDs {
-		if _, err := uuid.FromString(id); err != nil {
-			return apiutil.ErrInvalidIDFormat
-		}
 	}
 
 	if len(req.Conditions) < minLen {
@@ -188,6 +189,34 @@ func (req updateRuleReq) validate() error {
 	return req.rule.validate()
 }
 
+type ruleThingsReq struct {
+	token    string
+	ruleID   string
+	ThingIDs []string `json:"thing_ids"`
+}
+
+func (req ruleThingsReq) validate() error {
+	if req.token == "" {
+		return apiutil.ErrBearerToken
+	}
+
+	if req.ruleID == "" {
+		return apiutil.ErrMissingRuleID
+	}
+
+	if len(req.ThingIDs) < minLen || len(req.ThingIDs) > maxThingIDs {
+		return apiutil.ErrThingIDsSize
+	}
+
+	for _, id := range req.ThingIDs {
+		if _, err := uuid.FromString(id); err != nil {
+			return apiutil.ErrInvalidIDFormat
+		}
+	}
+
+	return nil
+}
+
 type removeRulesReq struct {
 	token   string
 	RuleIDs []string `json:"rule_ids"`
@@ -202,10 +231,8 @@ func (req removeRulesReq) validate() error {
 		return apiutil.ErrEmptyList
 	}
 
-	for _, ruleID := range req.RuleIDs {
-		if ruleID == "" {
-			return apiutil.ErrMissingRuleID
-		}
+	if slices.Contains(req.RuleIDs, "") {
+		return apiutil.ErrMissingRuleID
 	}
 
 	return nil

--- a/rules/api/http/rules/requests.go
+++ b/rules/api/http/rules/requests.go
@@ -222,7 +222,7 @@ func validateThingIDs(ids []string) error {
 
 func validateInputType(inputType string) error {
 	switch inputType {
-	case rules.InputTypeMessage, rules.InputTypeAlarm, rules.InputTypeSchedule, rules.InputTypeCommand:
+	case rules.InputTypeMessage, rules.InputTypeAlarm, rules.InputTypeCommand:
 		return nil
 	default:
 		return apiutil.ErrInvalidInputType

--- a/rules/api/http/rules/responses.go
+++ b/rules/api/http/rules/responses.go
@@ -88,6 +88,21 @@ func (res RulesPageRes) Empty() bool {
 	return false
 }
 
+// TODO: Consider introducing apiutil.EmptyRes with a configurable status code.
+type assignRes struct{}
+
+func (res assignRes) Code() int {
+	return http.StatusOK
+}
+
+func (res assignRes) Headers() map[string]string {
+	return map[string]string{}
+}
+
+func (res assignRes) Empty() bool {
+	return true
+}
+
 type removeRes struct{}
 
 func (res removeRes) Code() int {

--- a/rules/api/http/rules/responses.go
+++ b/rules/api/http/rules/responses.go
@@ -15,7 +15,6 @@ var (
 	_ apiutil.Response = (*ruleResponse)(nil)
 	_ apiutil.Response = (*rulesRes)(nil)
 	_ apiutil.Response = (*thingIDsRes)(nil)
-	_ apiutil.Response = (*thingRulesRes)(nil)
 )
 
 type pageRes struct {
@@ -32,6 +31,7 @@ type ruleResponse struct {
 	GroupID     string            `json:"group_id"`
 	Name        string            `json:"name"`
 	Description string            `json:"description,omitempty"`
+	Input       rules.Input       `json:"input"`
 	Conditions  []rules.Condition `json:"conditions"`
 	Operator    string            `json:"operator"`
 	Actions     []rules.Action    `json:"actions"`
@@ -118,16 +118,3 @@ func (res thingIDsRes) Empty() bool {
 	return false
 }
 
-type thingRulesRes struct{}
-
-func (res thingRulesRes) Code() int {
-	return http.StatusOK
-}
-
-func (res thingRulesRes) Headers() map[string]string {
-	return map[string]string{}
-}
-
-func (res thingRulesRes) Empty() bool {
-	return true
-}

--- a/rules/api/http/rules/responses.go
+++ b/rules/api/http/rules/responses.go
@@ -26,12 +26,17 @@ type pageRes struct {
 	Name   string `json:"name,omitempty"`
 }
 
+type input struct {
+	Type     string   `json:"type"`
+	ThingIDs []string `json:"thing_ids,omitempty"`
+}
+
 type ruleResponse struct {
 	ID          string            `json:"id"`
 	GroupID     string            `json:"group_id"`
 	Name        string            `json:"name"`
 	Description string            `json:"description,omitempty"`
-	Input       rules.Input       `json:"input"`
+	Input       input             `json:"input"`
 	Conditions  []rules.Condition `json:"conditions"`
 	Operator    string            `json:"operator"`
 	Actions     []rules.Action    `json:"actions"`
@@ -117,4 +122,3 @@ func (res thingIDsRes) Headers() map[string]string {
 func (res thingIDsRes) Empty() bool {
 	return false
 }
-

--- a/rules/api/http/rules/responses.go
+++ b/rules/api/http/rules/responses.go
@@ -26,17 +26,12 @@ type pageRes struct {
 	Name   string `json:"name,omitempty"`
 }
 
-type input struct {
-	Type     string   `json:"type"`
-	ThingIDs []string `json:"thing_ids,omitempty"`
-}
-
 type ruleResponse struct {
 	ID          string            `json:"id"`
 	GroupID     string            `json:"group_id"`
 	Name        string            `json:"name"`
 	Description string            `json:"description,omitempty"`
-	Input       input             `json:"input"`
+	Input       rules.Input       `json:"input"`
 	Conditions  []rules.Condition `json:"conditions"`
 	Operator    string            `json:"operator"`
 	Actions     []rules.Action    `json:"actions"`

--- a/rules/api/http/rules/responses.go
+++ b/rules/api/http/rules/responses.go
@@ -88,7 +88,6 @@ func (res RulesPageRes) Empty() bool {
 	return false
 }
 
-// TODO: Consider introducing apiutil.EmptyRes with a configurable status code.
 type assignRes struct{}
 
 func (res assignRes) Code() int {

--- a/rules/api/http/rules/transport.go
+++ b/rules/api/http/rules/transport.go
@@ -62,6 +62,18 @@ func MakeHandler(svc rules.Service, mux *bone.Mux, tracer opentracing.Tracer, lo
 		encodeResponse,
 		opts...,
 	))
+	mux.Post("/rules/:id/things", kithttp.NewServer(
+		kitot.TraceServer(tracer, "assign_things")(assignThingsEndpoint(svc)),
+		decodeRuleThings,
+		encodeResponse,
+		opts...,
+	))
+	mux.Delete("/rules/:id/things", kithttp.NewServer(
+		kitot.TraceServer(tracer, "unassign_things")(unassignThingsEndpoint(svc)),
+		decodeRuleThings,
+		encodeResponse,
+		opts...,
+	))
 	mux.Patch("/rules", kithttp.NewServer(
 		kitot.TraceServer(tracer, "remove_rules")(removeRulesEndpoint(svc)),
 		decodeRemoveRules,
@@ -153,6 +165,22 @@ func decodeUpdateRule(_ context.Context, r *http.Request) (any, error) {
 	req := updateRuleReq{
 		token: apiutil.ExtractBearerToken(r),
 		id:    bone.GetValue(r, apiutil.IDKey),
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+	}
+
+	return req, nil
+}
+
+func decodeRuleThings(_ context.Context, r *http.Request) (any, error) {
+	if !strings.Contains(r.Header.Get("Content-Type"), apiutil.ContentTypeJSON) {
+		return nil, apiutil.ErrUnsupportedContentType
+	}
+
+	req := ruleThingsReq{
+		token:  apiutil.ExtractBearerToken(r),
+		ruleID: bone.GetValue(r, apiutil.IDKey),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, errors.Wrap(errors.ErrMalformedEntity, err)

--- a/rules/api/http/rules/transport.go
+++ b/rules/api/http/rules/transport.go
@@ -68,7 +68,7 @@ func MakeHandler(svc rules.Service, mux *bone.Mux, tracer opentracing.Tracer, lo
 		encodeResponse,
 		opts...,
 	))
-	mux.Delete("/rules/:id/things", kithttp.NewServer(
+	mux.Patch("/rules/:id/things", kithttp.NewServer(
 		kitot.TraceServer(tracer, "unassign_things")(unassignThingsEndpoint(svc)),
 		decodeRuleThings,
 		encodeResponse,

--- a/rules/api/http/rules/transport.go
+++ b/rules/api/http/rules/transport.go
@@ -68,19 +68,6 @@ func MakeHandler(svc rules.Service, mux *bone.Mux, tracer opentracing.Tracer, lo
 		encodeResponse,
 		opts...,
 	))
-	mux.Post("/things/:id/rules", kithttp.NewServer(
-		kitot.TraceServer(tracer, "assign_rules")(assignRulesEndpoint(svc)),
-		decodeThingRules,
-		encodeResponse,
-		opts...,
-	))
-	mux.Patch("/things/:id/rules", kithttp.NewServer(
-		kitot.TraceServer(tracer, "unassign_rules")(unassignRulesEndpoint(svc)),
-		decodeThingRules,
-		encodeResponse,
-		opts...,
-	))
-
 	return mux
 }
 
@@ -176,23 +163,6 @@ func decodeRemoveRules(_ context.Context, r *http.Request) (any, error) {
 	}
 
 	req := removeRulesReq{token: apiutil.ExtractBearerToken(r)}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
-	}
-
-	return req, nil
-}
-
-func decodeThingRules(_ context.Context, r *http.Request) (any, error) {
-	if !strings.Contains(r.Header.Get("Content-Type"), apiutil.ContentTypeJSON) {
-		return nil, apiutil.ErrUnsupportedContentType
-	}
-
-	req := thingRulesReq{
-		token:   apiutil.ExtractBearerToken(r),
-		thingID: bone.GetValue(r, apiutil.IDKey),
-	}
-
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
 	}

--- a/rules/api/http/rules/transport.go
+++ b/rules/api/http/rules/transport.go
@@ -94,16 +94,18 @@ func decodeListRulesByThing(_ context.Context, r *http.Request) (any, error) {
 	}
 
 	name, _ := apiutil.ReadStringQuery(r, apiutil.NameKey, "")
+	inputType, _ := apiutil.ReadStringQuery(r, apiutil.InputTypeKey, "")
 
 	req := listRulesByThingReq{
 		token:   apiutil.ExtractBearerToken(r),
 		thingID: bone.GetValue(r, apiutil.IDKey),
 		pageMetadata: rules.PageMetadata{
-			Offset: base.Offset,
-			Limit:  base.Limit,
-			Order:  base.Order,
-			Dir:    base.Dir,
-			Name:   name,
+			Offset:    base.Offset,
+			Limit:     base.Limit,
+			Order:     base.Order,
+			Dir:       base.Dir,
+			Name:      name,
+			InputType: inputType,
 		},
 	}
 
@@ -116,16 +118,18 @@ func decodeListRulesByGroup(_ context.Context, r *http.Request) (any, error) {
 		return nil, err
 	}
 	name, _ := apiutil.ReadStringQuery(r, apiutil.NameKey, "")
+	inputType, _ := apiutil.ReadStringQuery(r, apiutil.InputTypeKey, "")
 
 	req := listRulesByGroupReq{
 		token:   apiutil.ExtractBearerToken(r),
 		groupID: bone.GetValue(r, apiutil.IDKey),
 		pageMetadata: rules.PageMetadata{
-			Offset: base.Offset,
-			Limit:  base.Limit,
-			Order:  base.Order,
-			Dir:    base.Dir,
-			Name:   name,
+			Offset:    base.Offset,
+			Limit:     base.Limit,
+			Order:     base.Order,
+			Dir:       base.Dir,
+			Name:      name,
+			InputType: inputType,
 		},
 	}
 

--- a/rules/api/logging.go
+++ b/rules/api/logging.go
@@ -108,6 +108,34 @@ func (lm loggingMiddleware) UpdateRule(ctx context.Context, token string, rule r
 	return lm.svc.UpdateRule(ctx, token, rule)
 }
 
+func (lm loggingMiddleware) AssignThings(ctx context.Context, token, ruleID string, thingIDs ...string) (err error) {
+	defer func(begin time.Time) {
+		email := pkgauth.EmailFromToken(token)
+		message := fmt.Sprintf("Method assign_things for rule id %s by user %s took %s to complete", ruleID, email, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.AssignThings(ctx, token, ruleID, thingIDs...)
+}
+
+func (lm loggingMiddleware) UnassignThings(ctx context.Context, token, ruleID string, thingIDs ...string) (err error) {
+	defer func(begin time.Time) {
+		email := pkgauth.EmailFromToken(token)
+		message := fmt.Sprintf("Method unassign_things for rule id %s by user %s took %s to complete", ruleID, email, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.UnassignThings(ctx, token, ruleID, thingIDs...)
+}
+
 func (lm loggingMiddleware) RemoveRules(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
 		email := pkgauth.EmailFromToken(token)

--- a/rules/api/logging.go
+++ b/rules/api/logging.go
@@ -135,6 +135,19 @@ func (lm loggingMiddleware) RemoveRulesByGroup(ctx context.Context, groupID stri
 	return lm.svc.RemoveRulesByGroup(ctx, groupID)
 }
 
+func (lm loggingMiddleware) UnassignRulesFromThing(ctx context.Context, thingID string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method unassign_rules_from_thing for thing id %s took %s to complete", thingID, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.UnassignRulesFromThing(ctx, thingID)
+}
+
 func (lm loggingMiddleware) ConsumeMessage(subject string, msg protomfx.Message) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method consume_message took %s to complete", time.Since(begin))

--- a/rules/api/logging.go
+++ b/rules/api/logging.go
@@ -135,47 +135,6 @@ func (lm loggingMiddleware) RemoveRulesByGroup(ctx context.Context, groupID stri
 	return lm.svc.RemoveRulesByGroup(ctx, groupID)
 }
 
-func (lm loggingMiddleware) AssignRules(ctx context.Context, token, thingID string, ruleIDs ...string) (err error) {
-	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
-		message := fmt.Sprintf("Method assign_rules by user %s took %s to complete", email, time.Since(begin))
-		if err != nil {
-			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
-			return
-		}
-		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
-	}(time.Now())
-
-	return lm.svc.AssignRules(ctx, token, thingID, ruleIDs...)
-}
-
-func (lm loggingMiddleware) UnassignRules(ctx context.Context, token, thingID string, ruleIDs ...string) (err error) {
-	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
-		message := fmt.Sprintf("Method unassign_rules by user %s, thing id %s and rule ids %v took %s to complete", email, thingID, ruleIDs, time.Since(begin))
-		if err != nil {
-			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
-			return
-		}
-		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
-	}(time.Now())
-
-	return lm.svc.UnassignRules(ctx, token, thingID, ruleIDs...)
-}
-
-func (lm loggingMiddleware) UnassignRulesByThing(ctx context.Context, thingID string) (err error) {
-	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method unassign_rules_by_thing for thing id %s took %s to complete", thingID, time.Since(begin))
-		if err != nil {
-			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
-			return
-		}
-		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
-	}(time.Now())
-
-	return lm.svc.UnassignRulesByThing(ctx, thingID)
-}
-
 func (lm loggingMiddleware) ConsumeMessage(subject string, msg protomfx.Message) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method consume_message took %s to complete", time.Since(begin))

--- a/rules/api/metrics.go
+++ b/rules/api/metrics.go
@@ -99,6 +99,15 @@ func (ms metricsMiddleware) RemoveRulesByGroup(ctx context.Context, groupID stri
 	return ms.svc.RemoveRulesByGroup(ctx, groupID)
 }
 
+func (ms metricsMiddleware) UnassignRulesFromThing(ctx context.Context, thingID string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "unassign_rules_from_thing").Add(1)
+		ms.latency.With("method", "unassign_rules_from_thing").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.UnassignRulesFromThing(ctx, thingID)
+}
+
 func (ms metricsMiddleware) ConsumeMessage(subject string, msg protomfx.Message) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "consume_message").Add(1)

--- a/rules/api/metrics.go
+++ b/rules/api/metrics.go
@@ -99,33 +99,6 @@ func (ms metricsMiddleware) RemoveRulesByGroup(ctx context.Context, groupID stri
 	return ms.svc.RemoveRulesByGroup(ctx, groupID)
 }
 
-func (ms metricsMiddleware) AssignRules(ctx context.Context, token, thingID string, ruleIDs ...string) error {
-	defer func(begin time.Time) {
-		ms.counter.With("method", "assign_rules").Add(1)
-		ms.latency.With("method", "assign_rules").Observe(time.Since(begin).Seconds())
-	}(time.Now())
-
-	return ms.svc.AssignRules(ctx, token, thingID, ruleIDs...)
-}
-
-func (ms metricsMiddleware) UnassignRules(ctx context.Context, token, thingID string, ruleIDs ...string) error {
-	defer func(begin time.Time) {
-		ms.counter.With("method", "unassign_rules").Add(1)
-		ms.latency.With("method", "unassign_rules").Observe(time.Since(begin).Seconds())
-	}(time.Now())
-
-	return ms.svc.UnassignRules(ctx, token, thingID, ruleIDs...)
-}
-
-func (ms metricsMiddleware) UnassignRulesByThing(ctx context.Context, thingID string) error {
-	defer func(begin time.Time) {
-		ms.counter.With("method", "unassign_rules_by_thing").Add(1)
-		ms.latency.With("method", "unassign_rules_by_thing").Observe(time.Since(begin).Seconds())
-	}(time.Now())
-
-	return ms.svc.UnassignRulesByThing(ctx, thingID)
-}
-
 func (ms metricsMiddleware) ConsumeMessage(subject string, msg protomfx.Message) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "consume_message").Add(1)

--- a/rules/api/metrics.go
+++ b/rules/api/metrics.go
@@ -81,6 +81,24 @@ func (ms metricsMiddleware) UpdateRule(ctx context.Context, token string, rule r
 	return ms.svc.UpdateRule(ctx, token, rule)
 }
 
+func (ms metricsMiddleware) AssignThings(ctx context.Context, token, ruleID string, thingIDs ...string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "assign_things").Add(1)
+		ms.latency.With("method", "assign_things").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.AssignThings(ctx, token, ruleID, thingIDs...)
+}
+
+func (ms metricsMiddleware) UnassignThings(ctx context.Context, token, ruleID string, thingIDs ...string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "unassign_things").Add(1)
+		ms.latency.With("method", "unassign_things").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.UnassignThings(ctx, token, ruleID, thingIDs...)
+}
+
 func (ms metricsMiddleware) RemoveRules(ctx context.Context, token string, ids ...string) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "remove_rules").Add(1)

--- a/rules/events/handler.go
+++ b/rules/events/handler.go
@@ -22,7 +22,7 @@ func NewEventHandler(svc rules.Service) events.EventHandler {
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
 	switch e := event.(type) {
 	case events.ThingRemoved:
-		if err := h.svc.UnassignRulesByThing(ctx, e.ID); err != nil {
+		if err := h.svc.UnassignRulesFromThing(ctx, e.ID); err != nil {
 			return err
 		}
 		if err := h.svc.UnassignScriptsFromThing(ctx, e.ID); err != nil {

--- a/rules/events/streams.go
+++ b/rules/events/streams.go
@@ -28,6 +28,10 @@ func (es eventHandler) Handle(ctx context.Context, event events.Event) error {
 	case events.ThingRemove:
 		re := decodeRemoveEvent(msg)
 
+		if err := es.svc.UnassignRulesFromThing(ctx, re.id); err != nil {
+			return err
+		}
+
 		if err := es.svc.UnassignScriptsFromThing(ctx, re.id); err != nil {
 			return err
 		}

--- a/rules/events/streams.go
+++ b/rules/events/streams.go
@@ -28,10 +28,6 @@ func (es eventHandler) Handle(ctx context.Context, event events.Event) error {
 	case events.ThingRemove:
 		re := decodeRemoveEvent(msg)
 
-		if err := es.svc.UnassignRulesByThing(ctx, re.id); err != nil {
-			return err
-		}
-
 		if err := es.svc.UnassignScriptsFromThing(ctx, re.id); err != nil {
 			return err
 		}

--- a/rules/mocks/rules.go
+++ b/rules/mocks/rules.go
@@ -133,13 +133,42 @@ func (rrm *ruleRepositoryMock) Update(_ context.Context, r rules.Rule) error {
 		return dbutil.ErrNotFound
 	}
 
-	rrm.unassignThingsFromRule(r.ID)
+	rrm.rules[r.ID] = r
 
-	for _, thingID := range r.Input.ThingIDs {
-		rrm.ruleAssignments[thingID] = append(rrm.ruleAssignments[thingID], r.ID)
+	return nil
+}
+
+func (rrm *ruleRepositoryMock) AssignThings(_ context.Context, ruleID string, thingIDs ...string) error {
+	rrm.mu.Lock()
+	defer rrm.mu.Unlock()
+
+	if _, ok := rrm.rules[ruleID]; !ok {
+		return dbutil.ErrNotFound
 	}
 
-	rrm.rules[r.ID] = r
+	for _, thingID := range thingIDs {
+		if slices.Contains(rrm.ruleAssignments[thingID], ruleID) {
+			return dbutil.ErrConflict
+		}
+		rrm.ruleAssignments[thingID] = append(rrm.ruleAssignments[thingID], ruleID)
+	}
+
+	return nil
+}
+
+func (rrm *ruleRepositoryMock) UnassignThings(_ context.Context, ruleID string, thingIDs ...string) error {
+	rrm.mu.Lock()
+	defer rrm.mu.Unlock()
+
+	for _, thingID := range thingIDs {
+		var filtered []string
+		for _, id := range rrm.ruleAssignments[thingID] {
+			if id != ruleID {
+				filtered = append(filtered, id)
+			}
+		}
+		rrm.ruleAssignments[thingID] = filtered
+	}
 
 	return nil
 }

--- a/rules/mocks/rules.go
+++ b/rules/mocks/rules.go
@@ -4,8 +4,8 @@
 package mocks
 
 import (
-	"slices"
 	"context"
+	"slices"
 	"sync"
 
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
@@ -65,13 +65,13 @@ func (rrm *ruleRepositoryMock) RetrieveByThing(_ context.Context, thingID string
 	last := first + pm.Limit
 
 	for _, r := range rrm.rules {
-		if slices.Contains(r.Input.ThingIDs, thingID) {
-				all = append(all, r)
-				id := uuid.ParseID(r.ID)
-				if pm.Limit == 0 || (id >= first && id < last) {
-					items = append(items, r)
-				}
+		if slices.Contains(r.Input.ThingIDs, thingID) && (pm.InputType == "" || r.Input.Type == pm.InputType) {
+			all = append(all, r)
+			id := uuid.ParseID(r.ID)
+			if pm.Limit == 0 || (id >= first && id < last) {
+				items = append(items, r)
 			}
+		}
 	}
 
 	return rules.RulesPage{
@@ -89,7 +89,7 @@ func (rrm *ruleRepositoryMock) RetrieveByGroup(_ context.Context, groupID string
 	last := first + pm.Limit
 
 	for _, r := range rrm.rules {
-		if r.GroupID == groupID {
+		if r.GroupID == groupID && (pm.InputType == "" || r.Input.Type == pm.InputType) {
 			all = append(all, r)
 			id := uuid.ParseID(r.ID)
 			if pm.Limit == 0 || (id >= first && id < last) {
@@ -143,4 +143,3 @@ func (rrm *ruleRepositoryMock) RemoveByGroup(_ context.Context, groupID string) 
 
 	return nil
 }
-

--- a/rules/mocks/rules.go
+++ b/rules/mocks/rules.go
@@ -4,6 +4,7 @@
 package mocks
 
 import (
+	"slices"
 	"context"
 	"sync"
 
@@ -17,7 +18,6 @@ var _ rules.Repository = (*ruleRepositoryMock)(nil)
 type ruleRepositoryMock struct {
 	mu                sync.Mutex
 	rules             map[string]rules.Rule
-	assignments       map[string][]string // thingID -> []ruleID
 	scripts           map[string]rules.LuaScript
 	scriptAssignments map[string][]string // thingID -> []scriptID
 	scriptRuns        map[string]rules.ScriptRun
@@ -27,7 +27,6 @@ type ruleRepositoryMock struct {
 func NewRuleRepository() rules.Repository {
 	return &ruleRepositoryMock{
 		rules:             make(map[string]rules.Rule),
-		assignments:       make(map[string][]string),
 		scripts:           make(map[string]rules.LuaScript),
 		scriptAssignments: make(map[string][]string),
 		scriptRuns:        make(map[string]rules.ScriptRun),
@@ -61,22 +60,18 @@ func (rrm *ruleRepositoryMock) RetrieveByThing(_ context.Context, thingID string
 	rrm.mu.Lock()
 	defer rrm.mu.Unlock()
 
-	ruleIDs := rrm.assignments[thingID]
 	var all, items []rules.Rule
-
 	first := uint64(pm.Offset) + 1
 	last := first + pm.Limit
 
-	for _, rID := range ruleIDs {
-		r, ok := rrm.rules[rID]
-		if !ok {
-			continue
-		}
-		all = append(all, r)
-		id := uuid.ParseID(r.ID)
-		if pm.Limit == 0 || (id >= first && id < last) {
-			items = append(items, r)
-		}
+	for _, r := range rrm.rules {
+		if slices.Contains(r.Input.ThingIDs, thingID) {
+				all = append(all, r)
+				id := uuid.ParseID(r.ID)
+				if pm.Limit == 0 || (id >= first && id < last) {
+					items = append(items, r)
+				}
+			}
 	}
 
 	return rules.RulesPage{
@@ -107,23 +102,6 @@ func (rrm *ruleRepositoryMock) RetrieveByGroup(_ context.Context, groupID string
 		Total: uint64(len(all)),
 		Rules: items,
 	}, nil
-}
-
-func (rrm *ruleRepositoryMock) RetrieveThingIDsByRule(_ context.Context, ruleID string) ([]string, error) {
-	rrm.mu.Lock()
-	defer rrm.mu.Unlock()
-
-	var thingIDs []string
-	for thingID, rIDs := range rrm.assignments {
-		for _, rID := range rIDs {
-			if rID == ruleID {
-				thingIDs = append(thingIDs, thingID)
-				break
-			}
-		}
-	}
-
-	return thingIDs, nil
 }
 
 func (rrm *ruleRepositoryMock) Update(_ context.Context, r rules.Rule) error {
@@ -166,49 +144,3 @@ func (rrm *ruleRepositoryMock) RemoveByGroup(_ context.Context, groupID string) 
 	return nil
 }
 
-func (rrm *ruleRepositoryMock) Assign(_ context.Context, thingID string, ruleIDs ...string) error {
-	rrm.mu.Lock()
-	defer rrm.mu.Unlock()
-
-	existing := make(map[string]struct{})
-	for _, id := range rrm.assignments[thingID] {
-		existing[id] = struct{}{}
-	}
-
-	for _, id := range ruleIDs {
-		if _, ok := existing[id]; !ok {
-			rrm.assignments[thingID] = append(rrm.assignments[thingID], id)
-		}
-	}
-
-	return nil
-}
-
-func (rrm *ruleRepositoryMock) Unassign(_ context.Context, thingID string, ruleIDs ...string) error {
-	rrm.mu.Lock()
-	defer rrm.mu.Unlock()
-
-	remove := make(map[string]struct{})
-	for _, id := range ruleIDs {
-		remove[id] = struct{}{}
-	}
-
-	var remaining []string
-	for _, id := range rrm.assignments[thingID] {
-		if _, ok := remove[id]; !ok {
-			remaining = append(remaining, id)
-		}
-	}
-	rrm.assignments[thingID] = remaining
-
-	return nil
-}
-
-func (rrm *ruleRepositoryMock) UnassignByThing(_ context.Context, thingID string) error {
-	rrm.mu.Lock()
-	defer rrm.mu.Unlock()
-
-	delete(rrm.assignments, thingID)
-
-	return nil
-}

--- a/rules/mocks/rules.go
+++ b/rules/mocks/rules.go
@@ -18,6 +18,7 @@ var _ rules.Repository = (*ruleRepositoryMock)(nil)
 type ruleRepositoryMock struct {
 	mu                sync.Mutex
 	rules             map[string]rules.Rule
+	ruleAssignments   map[string][]string // thingID -> []ruleID
 	scripts           map[string]rules.LuaScript
 	scriptAssignments map[string][]string // thingID -> []scriptID
 	scriptRuns        map[string]rules.ScriptRun
@@ -27,6 +28,7 @@ type ruleRepositoryMock struct {
 func NewRuleRepository() rules.Repository {
 	return &ruleRepositoryMock{
 		rules:             make(map[string]rules.Rule),
+		ruleAssignments:   make(map[string][]string),
 		scripts:           make(map[string]rules.LuaScript),
 		scriptAssignments: make(map[string][]string),
 		scriptRuns:        make(map[string]rules.ScriptRun),
@@ -39,6 +41,10 @@ func (rrm *ruleRepositoryMock) Save(_ context.Context, rs ...rules.Rule) ([]rule
 
 	for _, r := range rs {
 		rrm.rules[r.ID] = r
+
+		for _, thingID := range r.Input.ThingIDs {
+			rrm.ruleAssignments[thingID] = append(rrm.ruleAssignments[thingID], r.ID)
+		}
 	}
 
 	return rs, nil
@@ -53,6 +59,14 @@ func (rrm *ruleRepositoryMock) RetrieveByID(_ context.Context, id string) (rules
 		return rules.Rule{}, dbutil.ErrNotFound
 	}
 
+	var thingIDs []string
+	for thingID, ruleIDs := range rrm.ruleAssignments {
+		if slices.Contains(ruleIDs, id) {
+			thingIDs = append(thingIDs, thingID)
+		}
+	}
+	r.Input.ThingIDs = thingIDs
+
 	return r, nil
 }
 
@@ -60,17 +74,24 @@ func (rrm *ruleRepositoryMock) RetrieveByThing(_ context.Context, thingID string
 	rrm.mu.Lock()
 	defer rrm.mu.Unlock()
 
+	ruleIDs := rrm.ruleAssignments[thingID]
+
 	var all, items []rules.Rule
 	first := uint64(pm.Offset) + 1
 	last := first + pm.Limit
 
-	for _, r := range rrm.rules {
-		if slices.Contains(r.Input.ThingIDs, thingID) && (pm.InputType == "" || r.Input.Type == pm.InputType) {
-			all = append(all, r)
-			id := uuid.ParseID(r.ID)
-			if pm.Limit == 0 || (id >= first && id < last) {
-				items = append(items, r)
-			}
+	for _, ruleID := range ruleIDs {
+		r, ok := rrm.rules[ruleID]
+		if !ok {
+			continue
+		}
+		if pm.InputType != "" && r.Input.Type != pm.InputType {
+			continue
+		}
+		all = append(all, r)
+		id := uuid.ParseID(r.ID)
+		if pm.Limit == 0 || (id >= first && id < last) {
+			items = append(items, r)
 		}
 	}
 
@@ -112,6 +133,12 @@ func (rrm *ruleRepositoryMock) Update(_ context.Context, r rules.Rule) error {
 		return dbutil.ErrNotFound
 	}
 
+	rrm.unassignThingsFromRule(r.ID)
+
+	for _, thingID := range r.Input.ThingIDs {
+		rrm.ruleAssignments[thingID] = append(rrm.ruleAssignments[thingID], r.ID)
+	}
+
 	rrm.rules[r.ID] = r
 
 	return nil
@@ -126,6 +153,7 @@ func (rrm *ruleRepositoryMock) Remove(_ context.Context, ids ...string) error {
 			return dbutil.ErrNotFound
 		}
 		delete(rrm.rules, id)
+		rrm.unassignThingsFromRule(id)
 	}
 
 	return nil
@@ -138,8 +166,30 @@ func (rrm *ruleRepositoryMock) RemoveByGroup(_ context.Context, groupID string) 
 	for id, r := range rrm.rules {
 		if r.GroupID == groupID {
 			delete(rrm.rules, id)
+			rrm.unassignThingsFromRule(id)
 		}
 	}
 
 	return nil
+}
+
+func (rrm *ruleRepositoryMock) UnassignRulesFromThing(_ context.Context, thingID string) error {
+	rrm.mu.Lock()
+	defer rrm.mu.Unlock()
+
+	delete(rrm.ruleAssignments, thingID)
+
+	return nil
+}
+
+func (rrm *ruleRepositoryMock) unassignThingsFromRule(ruleID string) {
+	for thingID, ruleIDs := range rrm.ruleAssignments {
+		var filtered []string
+		for _, id := range ruleIDs {
+			if id != ruleID {
+				filtered = append(filtered, id)
+			}
+		}
+		rrm.ruleAssignments[thingID] = filtered
+	}
 }

--- a/rules/mocks/rules.go
+++ b/rules/mocks/rules.go
@@ -59,15 +59,19 @@ func (rrm *ruleRepositoryMock) RetrieveByID(_ context.Context, id string) (rules
 		return rules.Rule{}, dbutil.ErrNotFound
 	}
 
+	r.Input.ThingIDs = rrm.thingIDsByRule(id)
+
+	return r, nil
+}
+
+func (rrm *ruleRepositoryMock) thingIDsByRule(ruleID string) []string {
 	var thingIDs []string
 	for thingID, ruleIDs := range rrm.ruleAssignments {
-		if slices.Contains(ruleIDs, id) {
+		if slices.Contains(ruleIDs, ruleID) {
 			thingIDs = append(thingIDs, thingID)
 		}
 	}
-	r.Input.ThingIDs = thingIDs
-
-	return r, nil
+	return thingIDs
 }
 
 func (rrm *ruleRepositoryMock) RetrieveByThing(_ context.Context, thingID string, pm rules.PageMetadata) (rules.RulesPage, error) {
@@ -88,6 +92,7 @@ func (rrm *ruleRepositoryMock) RetrieveByThing(_ context.Context, thingID string
 		if pm.InputType != "" && r.Input.Type != pm.InputType {
 			continue
 		}
+		r.Input.ThingIDs = rrm.thingIDsByRule(ruleID)
 		all = append(all, r)
 		id := uuid.ParseID(r.ID)
 		if pm.Limit == 0 || (id >= first && id < last) {
@@ -111,6 +116,7 @@ func (rrm *ruleRepositoryMock) RetrieveByGroup(_ context.Context, groupID string
 
 	for _, r := range rrm.rules {
 		if r.GroupID == groupID && (pm.InputType == "" || r.Input.Type == pm.InputType) {
+			r.Input.ThingIDs = rrm.thingIDsByRule(r.ID)
 			all = append(all, r)
 			id := uuid.ParseID(r.ID)
 			if pm.Limit == 0 || (id >= first && id < last) {

--- a/rules/postgres/init.go
+++ b/rules/postgres/init.go
@@ -125,6 +125,21 @@ func migrateDB(db *sqlx.DB) error {
 					`DROP INDEX IF EXISTS idx_lua_script_runs_script_id;`,
 				},
 			},
+			{
+				Id: "rules_6",
+				Up: []string{
+					`ALTER TABLE rules ADD COLUMN IF NOT EXISTS input JSONB NOT NULL DEFAULT '{}'::jsonb`,
+					`DROP TABLE IF EXISTS rules_things`,
+				},
+				Down: []string{
+					`ALTER TABLE rules DROP COLUMN IF EXISTS input`,
+					`CREATE TABLE IF NOT EXISTS rules_things (
+						rule_id   UUID NOT NULL REFERENCES rules(id) ON DELETE CASCADE,
+						thing_id  UUID NOT NULL,
+						PRIMARY KEY (rule_id, thing_id)
+					)`,
+				},
+			},
 		},
 	}
 	_, err := migrate.Exec(db.DB, "postgres", migrations, migrate.Up)

--- a/rules/postgres/init.go
+++ b/rules/postgres/init.go
@@ -128,16 +128,14 @@ func migrateDB(db *sqlx.DB) error {
 			{
 				Id: "rules_6",
 				Up: []string{
-					`ALTER TABLE rules ADD COLUMN IF NOT EXISTS input JSONB NOT NULL DEFAULT '{}'::jsonb`,
-					`DROP TABLE IF EXISTS rules_things`,
+					`ALTER TABLE rules ADD COLUMN IF NOT EXISTS input_type TEXT NOT NULL DEFAULT 'message'`,
+					`CREATE INDEX IF NOT EXISTS idx_rules_group_input_type ON rules (group_id, input_type)`,
+					`CREATE INDEX IF NOT EXISTS idx_rules_things_thing_id ON rules_things (thing_id)`,
 				},
 				Down: []string{
-					`ALTER TABLE rules DROP COLUMN IF EXISTS input`,
-					`CREATE TABLE IF NOT EXISTS rules_things (
-						rule_id   UUID NOT NULL REFERENCES rules(id) ON DELETE CASCADE,
-						thing_id  UUID NOT NULL,
-						PRIMARY KEY (rule_id, thing_id)
-					)`,
+					`DROP INDEX IF EXISTS idx_rules_things_thing_id`,
+					`DROP INDEX IF EXISTS idx_rules_group_input_type`,
+					`ALTER TABLE rules DROP COLUMN IF EXISTS input_type`,
 				},
 			},
 		},

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -92,7 +92,7 @@ func (rr ruleRepository) RetrieveByGroup(ctx context.Context, groupID string, pm
 		FROM rules %s
 		ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
 
-	qc := fmt.Sprintf(`SELECT COUNT(*) FROM rules WHERE %s;`, dbutil.BuildWhereClause(gq, itq))
+	qc := fmt.Sprintf(`SELECT COUNT(*) FROM rules %s;`, dbutil.BuildWhereClause(gq, itq))
 
 	params := map[string]any{
 		"group_id":   groupID,

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -237,6 +237,16 @@ func (rr ruleRepository) RemoveByGroup(ctx context.Context, groupID string) erro
 	return nil
 }
 
+func (rr ruleRepository) UnassignRulesFromThing(ctx context.Context, thingID string) error {
+	q := `DELETE FROM rules_things WHERE thing_id = :thing_id;`
+	
+	if _, err := rr.db.NamedExecContext(ctx, q, map[string]any{"thing_id": thingID}); err != nil {
+		return errors.Wrap(dbutil.ErrRemoveEntity, err)
+	}
+
+	return nil
+}
+
 func (rr ruleRepository) retrieveRules(ctx context.Context, query, cquery string, params map[string]any) (rules.RulesPage, error) {
 	rows, err := rr.db.NamedQueryContext(ctx, query, params)
 	if err != nil {

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -138,17 +138,6 @@ func (rr ruleRepository) RetrieveByID(ctx context.Context, id string) (rules.Rul
 	return toRule(dbr)
 }
 
-func (rr ruleRepository) RetrieveThingIDsByRule(ctx context.Context, ruleID string) ([]string, error) {
-	q := `SELECT thing_id FROM rules_things WHERE rule_id = $1;`
-
-	thingIDs := []string{}
-	if err := rr.db.SelectContext(ctx, &thingIDs, q, ruleID); err != nil {
-		return nil, err
-	}
-
-	return thingIDs, nil
-}
-
 func (rr ruleRepository) Update(ctx context.Context, r rules.Rule) error {
 	q := `UPDATE rules
 		SET name = :name, description = :description, input = :input, conditions = :conditions, operator = :operator, actions = :actions
@@ -204,72 +193,6 @@ func (rr ruleRepository) RemoveByGroup(ctx context.Context, groupID string) erro
 
 	dbr := dbRule{GroupID: groupID}
 	if _, err := rr.db.NamedExecContext(ctx, q, dbr); err != nil {
-		return errors.Wrap(dbutil.ErrRemoveEntity, err)
-	}
-
-	return nil
-}
-
-func (rr ruleRepository) Assign(ctx context.Context, thingID string, ruleIDs ...string) error {
-	tx, err := rr.db.BeginTxx(ctx, nil)
-	if err != nil {
-		return errors.Wrap(dbutil.ErrCreateEntity, err)
-	}
-	defer tx.Rollback()
-
-	q := `INSERT INTO rules_things (rule_id, thing_id) VALUES (:rule_id, :thing_id);`
-
-	for _, ruleID := range ruleIDs {
-		params := map[string]any{
-			"rule_id":  ruleID,
-			"thing_id": thingID,
-		}
-
-		if _, err := tx.NamedExecContext(ctx, q, params); err != nil {
-			pgErr, ok := err.(*pgconn.PgError)
-			if ok {
-				switch pgErr.Code {
-				case pgerrcode.InvalidTextRepresentation:
-					return errors.Wrap(dbutil.ErrMalformedEntity, err)
-				case pgerrcode.UniqueViolation:
-					continue
-				}
-			}
-			return errors.Wrap(dbutil.ErrCreateEntity, err)
-		}
-
-	}
-
-	if err := tx.Commit(); err != nil {
-		return errors.Wrap(dbutil.ErrCreateEntity, err)
-	}
-
-	return nil
-}
-
-func (rr ruleRepository) Unassign(ctx context.Context, thingID string, ruleIDs ...string) error {
-	q := `DELETE FROM rules_things WHERE rule_id = :rule_id AND thing_id = :thing_id;`
-
-	for _, ruleID := range ruleIDs {
-		params := map[string]any{
-			"rule_id":  ruleID,
-			"thing_id": thingID,
-		}
-		if _, err := rr.db.NamedExecContext(ctx, q, params); err != nil {
-			return errors.Wrap(dbutil.ErrRemoveEntity, err)
-		}
-	}
-
-	return nil
-}
-
-func (rr ruleRepository) UnassignByThing(ctx context.Context, thingID string) error {
-	q := `DELETE FROM rules_things WHERE thing_id = :thing_id;`
-
-	params := map[string]any{
-		"thing_id": thingID,
-	}
-	if _, err := rr.db.NamedExecContext(ctx, q, params); err != nil {
 		return errors.Wrap(dbutil.ErrRemoveEntity, err)
 	}
 

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MainfluxLabs/mainflux/rules"
 	"github.com/gofrs/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jmoiron/sqlx"
 
 	"github.com/jackc/pgerrcode"
 )
@@ -35,8 +36,8 @@ func (rr ruleRepository) Save(ctx context.Context, rls ...rules.Rule) ([]rules.R
 	}
 	defer tx.Rollback()
 
-	q := `INSERT INTO rules (id, group_id, name, description, input, conditions, operator, actions)
-		VALUES (:id, :group_id, :name, :description, :input, :conditions, :operator, :actions);`
+	rq := `INSERT INTO rules (id, group_id, name, description, input_type, conditions, operator, actions)
+		VALUES (:id, :group_id, :name, :description, :input_type, :conditions, :operator, :actions);`
 
 	for _, rule := range rls {
 		dbr, err := toDBRule(rule)
@@ -44,7 +45,7 @@ func (rr ruleRepository) Save(ctx context.Context, rls ...rules.Rule) ([]rules.R
 			return []rules.Rule{}, errors.Wrap(dbutil.ErrCreateEntity, err)
 		}
 
-		if _, err := tx.NamedExecContext(ctx, q, dbr); err != nil {
+		if _, err := tx.NamedExecContext(ctx, rq, dbr); err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {
 				switch pgErr.Code {
@@ -56,7 +57,10 @@ func (rr ruleRepository) Save(ctx context.Context, rls ...rules.Rule) ([]rules.R
 					return []rules.Rule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
 				}
 			}
+			return []rules.Rule{}, errors.Wrap(dbutil.ErrCreateEntity, err)
+		}
 
+		if err := insertRulesThings(ctx, tx, rule.ID, rule.Input.ThingIDs); err != nil {
 			return []rules.Rule{}, errors.Wrap(dbutil.ErrCreateEntity, err)
 		}
 	}
@@ -64,6 +68,7 @@ func (rr ruleRepository) Save(ctx context.Context, rls ...rules.Rule) ([]rules.R
 	if err = tx.Commit(); err != nil {
 		return []rules.Rule{}, errors.Wrap(dbutil.ErrCreateEntity, err)
 	}
+
 	return rls, nil
 }
 
@@ -77,18 +82,23 @@ func (rr ruleRepository) RetrieveByGroup(ctx context.Context, groupID string, pm
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)
-	whereClause := dbutil.BuildWhereClause(gq, nq)
+	itq := ""
+	if pm.InputType != "" {
+		itq = "input_type = :input_type"
+	}
+	whereClause := dbutil.BuildWhereClause(gq, nq, itq)
 
-	q := fmt.Sprintf(`SELECT id, group_id, name, description, input, conditions, operator, actions
+	q := fmt.Sprintf(`SELECT id, group_id, name, description, input_type, conditions, operator, actions
 		FROM rules %s
 		ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
-	qc := fmt.Sprintf(`SELECT COUNT(*) FROM rules WHERE %s;`, gq)
+	qc := fmt.Sprintf(`SELECT COUNT(*) FROM rules WHERE %s;`, dbutil.BuildWhereClause(gq, itq))
 
 	params := map[string]any{
-		"group_id": groupID,
-		"name":     name,
-		"limit":    pm.Limit,
-		"offset":   pm.Offset,
+		"group_id":   groupID,
+		"name":       name,
+		"input_type": pm.InputType,
+		"limit":      pm.Limit,
+		"offset":     pm.Offset,
 	}
 
 	return rr.retrieveRules(ctx, q, qc, params)
@@ -102,45 +112,64 @@ func (rr ruleRepository) RetrieveByThing(ctx context.Context, thingID string, pm
 	oq := dbutil.GetOrderQuery(pm.Order)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
-	tq := "input->'thing_ids' @> jsonb_build_array(:thing_id::text)"
 	nq, name := dbutil.GetNameQuery(pm.Name)
-	whereClause := dbutil.BuildWhereClause(tq, nq)
 
-	q := fmt.Sprintf(`SELECT id, group_id, name, description, input, conditions, operator, actions
-		FROM rules %s
-		ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
-	qc := fmt.Sprintf(`SELECT COUNT(*) FROM rules WHERE %s;`, tq)
+	tq := "rt.thing_id = :thing_id"
+	itq := ""
+	if pm.InputType != "" {
+		itq = "r.input_type = :input_type"
+	}
+	joinClause := "JOIN rules_things rt ON rt.rule_id = r.id"
+	whereClause := dbutil.BuildWhereClause(tq, nq, itq)
+	countClause := dbutil.BuildWhereClause(tq, itq)
+
+	q := fmt.Sprintf(`SELECT r.id, r.group_id, r.name, r.description, r.input_type, r.conditions, r.operator, r.actions
+		FROM rules r %s %s
+		ORDER BY r.%s %s %s;`, joinClause, whereClause, oq, dq, olq)
+	qc := fmt.Sprintf(`SELECT COUNT(*) FROM rules r %s %s;`, joinClause, countClause)
 
 	params := map[string]any{
-		"thing_id": thingID,
-		"name":     name,
-		"limit":    pm.Limit,
-		"offset":   pm.Offset,
+		"thing_id":   thingID,
+		"name":       name,
+		"input_type": pm.InputType,
+		"limit":      pm.Limit,
+		"offset":     pm.Offset,
 	}
 
 	return rr.retrieveRules(ctx, q, qc, params)
 }
 
 func (rr ruleRepository) RetrieveByID(ctx context.Context, id string) (rules.Rule, error) {
-	q := `SELECT id, group_id, name, description, input, conditions, operator, actions
+	q := `SELECT id, group_id, name, description, input_type, conditions, operator, actions
 		FROM rules WHERE id = $1;`
 
 	var dbr dbRule
 	if err := rr.db.QueryRowxContext(ctx, q, id).StructScan(&dbr); err != nil {
 		pgErr, ok := err.(*pgconn.PgError)
-		//  If there is no result or ID is in an invalid format, return ErrNotFound.
 		if err == sql.ErrNoRows || ok && pgerrcode.InvalidTextRepresentation == pgErr.Code {
 			return rules.Rule{}, errors.Wrap(dbutil.ErrNotFound, err)
 		}
 		return rules.Rule{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
-	return toRule(dbr)
+	thingIDs, err := rr.fetchThingIDs(ctx, dbr.ID)
+	if err != nil {
+		return rules.Rule{}, err
+	}
+
+	return toRuleThings(dbr, thingIDs)
 }
 
 func (rr ruleRepository) Update(ctx context.Context, r rules.Rule) error {
-	q := `UPDATE rules
-		SET name = :name, description = :description, input = :input, conditions = :conditions, operator = :operator, actions = :actions
+	tx, err := rr.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(dbutil.ErrUpdateEntity, err)
+	}
+	defer tx.Rollback()
+
+	uq := `UPDATE rules
+		SET name = :name, description = :description, input_type = :input_type,
+		    conditions = :conditions, operator = :operator, actions = :actions
 		WHERE id = :id;`
 
 	dbr, err := toDBRule(r)
@@ -148,28 +177,37 @@ func (rr ruleRepository) Update(ctx context.Context, r rules.Rule) error {
 		return errors.Wrap(dbutil.ErrUpdateEntity, err)
 	}
 
-	res, errdb := rr.db.NamedExecContext(ctx, q, dbr)
-	if errdb != nil {
-		pgErr, ok := errdb.(*pgconn.PgError)
+	res, err := tx.NamedExecContext(ctx, uq, dbr)
+	if err != nil {
+		pgErr, ok := err.(*pgconn.PgError)
 		if ok {
 			switch pgErr.Code {
-			case pgerrcode.InvalidTextRepresentation:
-				return errors.Wrap(dbutil.ErrMalformedEntity, errdb)
-			case pgerrcode.StringDataRightTruncationDataException:
+			case pgerrcode.InvalidTextRepresentation, pgerrcode.StringDataRightTruncationDataException:
 				return errors.Wrap(dbutil.ErrMalformedEntity, err)
 			}
 		}
-
-		return errors.Wrap(dbutil.ErrUpdateEntity, errdb)
+		return errors.Wrap(dbutil.ErrUpdateEntity, err)
 	}
 
-	cnt, errdb := res.RowsAffected()
-	if errdb != nil {
-		return errors.Wrap(dbutil.ErrUpdateEntity, errdb)
+	cnt, err := res.RowsAffected()
+	if err != nil {
+		return errors.Wrap(dbutil.ErrUpdateEntity, err)
 	}
-
 	if cnt == 0 {
 		return dbutil.ErrNotFound
+	}
+
+	if _, err := tx.NamedExecContext(ctx, `DELETE FROM rules_things WHERE rule_id = :rule_id;`,
+		map[string]any{"rule_id": r.ID}); err != nil {
+		return errors.Wrap(dbutil.ErrUpdateEntity, err)
+	}
+
+	if err := insertRulesThings(ctx, tx, r.ID, r.Input.ThingIDs); err != nil {
+		return errors.Wrap(dbutil.ErrUpdateEntity, err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return errors.Wrap(dbutil.ErrUpdateEntity, err)
 	}
 
 	return nil
@@ -212,12 +250,10 @@ func (rr ruleRepository) retrieveRules(ctx context.Context, query, cquery string
 		if err = rows.StructScan(&dbr); err != nil {
 			return rules.RulesPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
-
 		rule, err := toRule(dbr)
 		if err != nil {
 			return rules.RulesPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
-
 		items = append(items, rule)
 	}
 
@@ -226,12 +262,32 @@ func (rr ruleRepository) retrieveRules(ctx context.Context, query, cquery string
 		return rules.RulesPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
-	page := rules.RulesPage{
+	return rules.RulesPage{
 		Rules: items,
 		Total: total,
-	}
+	}, nil
+}
 
-	return page, nil
+func (rr ruleRepository) fetchThingIDs(ctx context.Context, ruleID string) ([]string, error) {
+	q := `SELECT thing_id FROM rules_things WHERE rule_id = $1;`
+	var ids []string
+	if err := rr.db.SelectContext(ctx, &ids, q, ruleID); err != nil {
+		return nil, errors.Wrap(dbutil.ErrRetrieveEntity, err)
+	}
+	return ids, nil
+}
+
+func insertRulesThings(ctx context.Context, tx *sqlx.Tx, ruleID string, thingIDs []string) error {
+	q := `INSERT INTO rules_things (rule_id, thing_id) VALUES (:rule_id, :thing_id);`
+	for _, thingID := range thingIDs {
+		if _, err := tx.NamedExecContext(ctx, q, map[string]any{
+			"rule_id":  ruleID,
+			"thing_id": thingID,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type dbRule struct {
@@ -239,18 +295,13 @@ type dbRule struct {
 	GroupID     string `db:"group_id"`
 	Name        string `db:"name"`
 	Description string `db:"description"`
-	Input       []byte `db:"input"`
+	InputType   string `db:"input_type"`
 	Conditions  []byte `db:"conditions"`
 	Operator    string `db:"operator"`
 	Actions     []byte `db:"actions"`
 }
 
 func toDBRule(r rules.Rule) (dbRule, error) {
-	input, err := json.Marshal(r.Input)
-	if err != nil {
-		return dbRule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
-	}
-
 	conditions, err := json.Marshal(r.Conditions)
 	if err != nil {
 		return dbRule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
@@ -266,19 +317,23 @@ func toDBRule(r rules.Rule) (dbRule, error) {
 		GroupID:     r.GroupID,
 		Name:        r.Name,
 		Description: r.Description,
-		Input:       input,
+		InputType:   r.Input.Type,
 		Conditions:  conditions,
 		Operator:    r.Operator,
 		Actions:     actions,
 	}, nil
 }
 
-func toRule(dbr dbRule) (rules.Rule, error) {
-	var input rules.Input
-	if err := json.Unmarshal(dbr.Input, &input); err != nil {
-		return rules.Rule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
+func toRuleThings(dbr dbRule, thingIDs []string) (rules.Rule, error) {
+	r, err := toRule(dbr)
+	if err != nil {
+		return rules.Rule{}, err
 	}
+	r.Input.ThingIDs = thingIDs
+	return r, nil
+}
 
+func toRule(dbr dbRule) (rules.Rule, error) {
 	var conditions []rules.Condition
 	if err := json.Unmarshal(dbr.Conditions, &conditions); err != nil {
 		return rules.Rule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
@@ -294,7 +349,7 @@ func toRule(dbr dbRule) (rules.Rule, error) {
 		GroupID:     dbr.GroupID,
 		Name:        dbr.Name,
 		Description: dbr.Description,
-		Input:       input,
+		Input:       rules.Input{Type: dbr.InputType},
 		Conditions:  conditions,
 		Operator:    dbr.Operator,
 		Actions:     actions,

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -91,6 +91,7 @@ func (rr ruleRepository) RetrieveByGroup(ctx context.Context, groupID string, pm
 	q := fmt.Sprintf(`SELECT id, group_id, name, description, input_type, conditions, operator, actions
 		FROM rules %s
 		ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
+
 	qc := fmt.Sprintf(`SELECT COUNT(*) FROM rules WHERE %s;`, dbutil.BuildWhereClause(gq, itq))
 
 	params := map[string]any{
@@ -119,13 +120,16 @@ func (rr ruleRepository) RetrieveByThing(ctx context.Context, thingID string, pm
 	if pm.InputType != "" {
 		itq = "r.input_type = :input_type"
 	}
+
 	joinClause := "JOIN rules_things rt ON rt.rule_id = r.id"
 	whereClause := dbutil.BuildWhereClause(tq, nq, itq)
 	countClause := dbutil.BuildWhereClause(tq, itq)
 
-	q := fmt.Sprintf(`SELECT r.id, r.group_id, r.name, r.description, r.input_type, r.conditions, r.operator, r.actions
+	q := fmt.Sprintf(`SELECT r.id, r.group_id, r.name, r.description,
+		r.input_type, r.conditions, r.operator, r.actions
 		FROM rules r %s %s
 		ORDER BY r.%s %s %s;`, joinClause, whereClause, oq, dq, olq)
+
 	qc := fmt.Sprintf(`SELECT COUNT(*) FROM rules r %s %s;`, joinClause, countClause)
 
 	params := map[string]any{
@@ -141,7 +145,8 @@ func (rr ruleRepository) RetrieveByThing(ctx context.Context, thingID string, pm
 
 func (rr ruleRepository) RetrieveByID(ctx context.Context, id string) (rules.Rule, error) {
 	q := `SELECT id, group_id, name, description, input_type, conditions, operator, actions
-		FROM rules WHERE id = $1;`
+		FROM rules
+		WHERE id = $1;`
 
 	var dbr dbRule
 	if err := rr.db.QueryRowxContext(ctx, q, id).StructScan(&dbr); err != nil {
@@ -161,15 +166,9 @@ func (rr ruleRepository) RetrieveByID(ctx context.Context, id string) (rules.Rul
 }
 
 func (rr ruleRepository) Update(ctx context.Context, r rules.Rule) error {
-	tx, err := rr.db.BeginTxx(ctx, nil)
-	if err != nil {
-		return errors.Wrap(dbutil.ErrUpdateEntity, err)
-	}
-	defer tx.Rollback()
-
-	uq := `UPDATE rules
+	uq := `UPDATE rules 
 		SET name = :name, description = :description, input_type = :input_type,
-		    conditions = :conditions, operator = :operator, actions = :actions
+		conditions = :conditions, operator = :operator, actions = :actions
 		WHERE id = :id;`
 
 	dbr, err := toDBRule(r)
@@ -177,7 +176,7 @@ func (rr ruleRepository) Update(ctx context.Context, r rules.Rule) error {
 		return errors.Wrap(dbutil.ErrUpdateEntity, err)
 	}
 
-	res, err := tx.NamedExecContext(ctx, uq, dbr)
+	res, err := rr.db.NamedExecContext(ctx, uq, dbr)
 	if err != nil {
 		pgErr, ok := err.(*pgconn.PgError)
 		if ok {
@@ -195,19 +194,6 @@ func (rr ruleRepository) Update(ctx context.Context, r rules.Rule) error {
 	}
 	if cnt == 0 {
 		return dbutil.ErrNotFound
-	}
-
-	if _, err := tx.NamedExecContext(ctx, `DELETE FROM rules_things WHERE rule_id = :rule_id;`,
-		map[string]any{"rule_id": r.ID}); err != nil {
-		return errors.Wrap(dbutil.ErrUpdateEntity, err)
-	}
-
-	if err := insertRulesThings(ctx, tx, r.ID, r.Input.ThingIDs); err != nil {
-		return errors.Wrap(dbutil.ErrUpdateEntity, err)
-	}
-
-	if err = tx.Commit(); err != nil {
-		return errors.Wrap(dbutil.ErrUpdateEntity, err)
 	}
 
 	return nil
@@ -239,9 +225,46 @@ func (rr ruleRepository) RemoveByGroup(ctx context.Context, groupID string) erro
 
 func (rr ruleRepository) UnassignRulesFromThing(ctx context.Context, thingID string) error {
 	q := `DELETE FROM rules_things WHERE thing_id = :thing_id;`
-	
+
 	if _, err := rr.db.NamedExecContext(ctx, q, map[string]any{"thing_id": thingID}); err != nil {
 		return errors.Wrap(dbutil.ErrRemoveEntity, err)
+	}
+
+	return nil
+}
+
+func (rr ruleRepository) AssignThings(ctx context.Context, ruleID string, thingIDs ...string) error {
+	tx, err := rr.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(dbutil.ErrCreateEntity, err)
+	}
+	defer tx.Rollback()
+
+	if err := insertRulesThings(ctx, tx, ruleID, thingIDs); err != nil {
+		pgErr, ok := err.(*pgconn.PgError)
+		if ok && pgErr.Code == pgerrcode.UniqueViolation {
+			return errors.Wrap(dbutil.ErrConflict, err)
+		}
+		return errors.Wrap(dbutil.ErrCreateEntity, err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return errors.Wrap(dbutil.ErrCreateEntity, err)
+	}
+
+	return nil
+}
+
+func (rr ruleRepository) UnassignThings(ctx context.Context, ruleID string, thingIDs ...string) error {
+	q := `DELETE FROM rules_things WHERE rule_id = :rule_id AND thing_id = :thing_id;`
+
+	for _, thingID := range thingIDs {
+		if _, err := rr.db.NamedExecContext(ctx, q, map[string]any{
+			"rule_id":  ruleID,
+			"thing_id": thingID,
+		}); err != nil {
+			return errors.Wrap(dbutil.ErrRemoveEntity, err)
+		}
 	}
 
 	return nil
@@ -288,7 +311,13 @@ func (rr ruleRepository) fetchThingIDs(ctx context.Context, ruleID string) ([]st
 }
 
 func insertRulesThings(ctx context.Context, tx *sqlx.Tx, ruleID string, thingIDs []string) error {
+	if len(thingIDs) == 0 {
+		return nil
+	}
+
+	// TODO: replace with a single bulk INSERT for better performance.
 	q := `INSERT INTO rules_things (rule_id, thing_id) VALUES (:rule_id, :thing_id);`
+
 	for _, thingID := range thingIDs {
 		if _, err := tx.NamedExecContext(ctx, q, map[string]any{
 			"rule_id":  ruleID,
@@ -297,6 +326,7 @@ func insertRulesThings(ctx context.Context, tx *sqlx.Tx, ruleID string, thingIDs
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -35,7 +35,8 @@ func (rr ruleRepository) Save(ctx context.Context, rls ...rules.Rule) ([]rules.R
 	}
 	defer tx.Rollback()
 
-	q := `INSERT INTO rules (id, group_id, name, description, conditions, operator, actions) VALUES (:id, :group_id, :name, :description, :conditions, :operator, :actions);`
+	q := `INSERT INTO rules (id, group_id, name, description, input, conditions, operator, actions)
+		VALUES (:id, :group_id, :name, :description, :input, :conditions, :operator, :actions);`
 
 	for _, rule := range rls {
 		dbr, err := toDBRule(rule)
@@ -78,7 +79,9 @@ func (rr ruleRepository) RetrieveByGroup(ctx context.Context, groupID string, pm
 	nq, name := dbutil.GetNameQuery(pm.Name)
 	whereClause := dbutil.BuildWhereClause(gq, nq)
 
-	q := fmt.Sprintf(`SELECT id, group_id, name, description, conditions, operator, actions FROM rules %s ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
+	q := fmt.Sprintf(`SELECT id, group_id, name, description, input, conditions, operator, actions
+		FROM rules %s
+		ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
 	qc := fmt.Sprintf(`SELECT COUNT(*) FROM rules WHERE %s;`, gq)
 
 	params := map[string]any{
@@ -99,24 +102,14 @@ func (rr ruleRepository) RetrieveByThing(ctx context.Context, thingID string, pm
 	oq := dbutil.GetOrderQuery(pm.Order)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
-	tq := "rt.thing_id = :thing_id"
+	tq := "input->'thing_ids' @> jsonb_build_array(:thing_id::text)"
 	nq, name := dbutil.GetNameQuery(pm.Name)
 	whereClause := dbutil.BuildWhereClause(tq, nq)
 
-	q := fmt.Sprintf(`
-		SELECT r.id, r.group_id, r.name, r.description, r.conditions, r.operator, r.actions
-		FROM rules r
-		INNER JOIN rules_things rt ON r.id = rt.rule_id
-		%s
-		ORDER BY %s %s
-		%s;`,
-		whereClause, oq, dq, olq)
-
-	qc := fmt.Sprintf(`
-		SELECT COUNT(*)
-		FROM rules r
-		INNER JOIN rules_things rt ON r.id = rt.rule_id
-		%s;`, whereClause)
+	q := fmt.Sprintf(`SELECT id, group_id, name, description, input, conditions, operator, actions
+		FROM rules %s
+		ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
+	qc := fmt.Sprintf(`SELECT COUNT(*) FROM rules WHERE %s;`, tq)
 
 	params := map[string]any{
 		"thing_id": thingID,
@@ -129,7 +122,8 @@ func (rr ruleRepository) RetrieveByThing(ctx context.Context, thingID string, pm
 }
 
 func (rr ruleRepository) RetrieveByID(ctx context.Context, id string) (rules.Rule, error) {
-	q := `SELECT id, group_id, name, description, conditions, operator, actions FROM rules WHERE id = $1;`
+	q := `SELECT id, group_id, name, description, input, conditions, operator, actions
+		FROM rules WHERE id = $1;`
 
 	var dbr dbRule
 	if err := rr.db.QueryRowxContext(ctx, q, id).StructScan(&dbr); err != nil {
@@ -156,7 +150,9 @@ func (rr ruleRepository) RetrieveThingIDsByRule(ctx context.Context, ruleID stri
 }
 
 func (rr ruleRepository) Update(ctx context.Context, r rules.Rule) error {
-	q := `UPDATE rules SET name = :name, description = :description, conditions = :conditions, operator = :operator, actions = :actions WHERE id = :id;`
+	q := `UPDATE rules
+		SET name = :name, description = :description, input = :input, conditions = :conditions, operator = :operator, actions = :actions
+		WHERE id = :id;`
 
 	dbr, err := toDBRule(r)
 	if err != nil {
@@ -320,12 +316,18 @@ type dbRule struct {
 	GroupID     string `db:"group_id"`
 	Name        string `db:"name"`
 	Description string `db:"description"`
+	Input       []byte `db:"input"`
 	Conditions  []byte `db:"conditions"`
 	Operator    string `db:"operator"`
 	Actions     []byte `db:"actions"`
 }
 
 func toDBRule(r rules.Rule) (dbRule, error) {
+	input, err := json.Marshal(r.Input)
+	if err != nil {
+		return dbRule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
+	}
+
 	conditions, err := json.Marshal(r.Conditions)
 	if err != nil {
 		return dbRule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
@@ -341,6 +343,7 @@ func toDBRule(r rules.Rule) (dbRule, error) {
 		GroupID:     r.GroupID,
 		Name:        r.Name,
 		Description: r.Description,
+		Input:       input,
 		Conditions:  conditions,
 		Operator:    r.Operator,
 		Actions:     actions,
@@ -348,6 +351,11 @@ func toDBRule(r rules.Rule) (dbRule, error) {
 }
 
 func toRule(dbr dbRule) (rules.Rule, error) {
+	var input rules.Input
+	if err := json.Unmarshal(dbr.Input, &input); err != nil {
+		return rules.Rule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
+	}
+
 	var conditions []rules.Condition
 	if err := json.Unmarshal(dbr.Conditions, &conditions); err != nil {
 		return rules.Rule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
@@ -363,6 +371,7 @@ func toRule(dbr dbRule) (rules.Rule, error) {
 		GroupID:     dbr.GroupID,
 		Name:        dbr.Name,
 		Description: dbr.Description,
+		Input:       input,
 		Conditions:  conditions,
 		Operator:    dbr.Operator,
 		Actions:     actions,

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -162,7 +162,7 @@ func (rr ruleRepository) RetrieveByID(ctx context.Context, id string) (rules.Rul
 		return rules.Rule{}, err
 	}
 
-	return toRuleThings(dbr, thingIDs)
+	return toRule(dbr, thingIDs)
 }
 
 func (rr ruleRepository) Update(ctx context.Context, r rules.Rule) error {
@@ -283,7 +283,7 @@ func (rr ruleRepository) retrieveRules(ctx context.Context, query, cquery string
 		if err = rows.StructScan(&dbr); err != nil {
 			return rules.RulesPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
-		rule, err := toRule(dbr)
+		rule, err := toRule(dbr, nil)
 		if err != nil {
 			return rules.RulesPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
@@ -363,16 +363,7 @@ func toDBRule(r rules.Rule) (dbRule, error) {
 	}, nil
 }
 
-func toRuleThings(dbr dbRule, thingIDs []string) (rules.Rule, error) {
-	r, err := toRule(dbr)
-	if err != nil {
-		return rules.Rule{}, err
-	}
-	r.Input.ThingIDs = thingIDs
-	return r, nil
-}
-
-func toRule(dbr dbRule) (rules.Rule, error) {
+func toRule(dbr dbRule, thingIDs []string) (rules.Rule, error) {
 	var conditions []rules.Condition
 	if err := json.Unmarshal(dbr.Conditions, &conditions); err != nil {
 		return rules.Rule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
@@ -388,7 +379,7 @@ func toRule(dbr dbRule) (rules.Rule, error) {
 		GroupID:     dbr.GroupID,
 		Name:        dbr.Name,
 		Description: dbr.Description,
-		Input:       rules.Input{Type: dbr.InputType},
+		Input:       rules.Input{Type: dbr.InputType, ThingIDs: thingIDs},
 		Conditions:  conditions,
 		Operator:    dbr.Operator,
 		Actions:     actions,

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -157,9 +157,9 @@ func (rr ruleRepository) RetrieveByID(ctx context.Context, id string) (rules.Rul
 		return rules.Rule{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
-	thingIDs, err := rr.fetchThingIDs(ctx, dbr.ID)
-	if err != nil {
-		return rules.Rule{}, err
+	var thingIDs []string
+	if err := rr.db.SelectContext(ctx, &thingIDs, `SELECT thing_id FROM rules_things WHERE rule_id = $1;`, dbr.ID); err != nil {
+		return rules.Rule{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
 	return toRule(dbr, thingIDs)
@@ -277,13 +277,28 @@ func (rr ruleRepository) retrieveRules(ctx context.Context, query, cquery string
 	}
 	defer rows.Close()
 
-	var items []rules.Rule
+	var dbRules []dbRule
 	for rows.Next() {
 		var dbr dbRule
 		if err = rows.StructScan(&dbr); err != nil {
 			return rules.RulesPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
-		rule, err := toRule(dbr, nil)
+		dbRules = append(dbRules, dbr)
+	}
+
+	ruleIDs := make([]string, len(dbRules))
+	for i, dbr := range dbRules {
+		ruleIDs[i] = dbr.ID
+	}
+
+	thingIDs, err := rr.fetchThingIDsByRules(ctx, ruleIDs)
+	if err != nil {
+		return rules.RulesPage{}, err
+	}
+
+	var items []rules.Rule
+	for _, dbr := range dbRules {
+		rule, err := toRule(dbr, thingIDs[dbr.ID])
 		if err != nil {
 			return rules.RulesPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 		}
@@ -301,13 +316,26 @@ func (rr ruleRepository) retrieveRules(ctx context.Context, query, cquery string
 	}, nil
 }
 
-func (rr ruleRepository) fetchThingIDs(ctx context.Context, ruleID string) ([]string, error) {
-	q := `SELECT thing_id FROM rules_things WHERE rule_id = $1;`
-	var ids []string
-	if err := rr.db.SelectContext(ctx, &ids, q, ruleID); err != nil {
+func (rr ruleRepository) fetchThingIDsByRules(ctx context.Context, ruleIDs []string) (map[string][]string, error) {
+	result := make(map[string][]string, len(ruleIDs))
+	if len(ruleIDs) == 0 {
+		return result, nil
+	}
+
+	type ruleThing struct {
+		RuleID  string `db:"rule_id"`
+		ThingID string `db:"thing_id"`
+	}
+	var rows []ruleThing
+	if err := rr.db.SelectContext(ctx, &rows, `SELECT rule_id, thing_id FROM rules_things WHERE rule_id = ANY($1);`, ruleIDs); err != nil {
 		return nil, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
-	return ids, nil
+
+	for _, r := range rows {
+		result[r.RuleID] = append(result[r.RuleID], r.ThingID)
+	}
+
+	return result, nil
 }
 
 func insertRulesThings(ctx context.Context, tx *sqlx.Tx, ruleID string, thingIDs []string) error {

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -315,7 +315,6 @@ func insertRulesThings(ctx context.Context, tx *sqlx.Tx, ruleID string, thingIDs
 		return nil
 	}
 
-	// TODO: replace with a single bulk INSERT for better performance.
 	q := `INSERT INTO rules_things (rule_id, thing_id) VALUES (:rule_id, :thing_id);`
 
 	for _, thingID := range thingIDs {

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -12,11 +12,24 @@ import (
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 )
 
+const (
+	InputTypeMessage  = "message"
+	InputTypeAlarm    = "alarm"
+	InputTypeSchedule = "schedule"
+	InputTypeCommand  = "command"
+)
+
+type Input struct {
+	Type     string   `json:"type"`
+	ThingIDs []string `json:"thing_ids"`
+}
+
 type Rule struct {
 	ID          string
 	GroupID     string
 	Name        string
 	Description string
+	Input       Input
 	Conditions  []Condition
 	Operator    string
 	Actions     []Action

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -21,7 +21,7 @@ const (
 
 type Input struct {
 	Type     string   `json:"type"`
-	ThingIDs []string `json:"thing_ids"`
+	ThingIDs []string `json:"thing_ids,omitempty"`
 }
 
 type Rule struct {

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -15,7 +15,6 @@ import (
 const (
 	InputTypeMessage  = "message"
 	InputTypeAlarm    = "alarm"
-	InputTypeSchedule = "schedule"
 	InputTypeCommand  = "command"
 )
 

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -21,7 +21,7 @@ const (
 
 type Input struct {
 	Type     string   `json:"type"`
-	ThingIDs []string `json:"thing_ids,omitempty"`
+	ThingIDs []string `json:"thing_ids"`
 }
 
 type Rule struct {

--- a/rules/service.go
+++ b/rules/service.go
@@ -128,6 +128,12 @@ type ServiceRules interface {
 	// UpdateRule updates the rule identified by the provided ID.
 	UpdateRule(ctx context.Context, token string, rule Rule) error
 
+	// AssignThings assigns one or more things to a specific rule.
+	AssignThings(ctx context.Context, token, ruleID string, thingIDs ...string) error
+
+	// UnassignThings unassigns one or more things from a specific rule.
+	UnassignThings(ctx context.Context, token, ruleID string, thingIDs ...string) error
+
 	// RemoveRules removes the rules identified with the provided IDs.
 	RemoveRules(ctx context.Context, token string, ids ...string) error
 
@@ -253,6 +259,43 @@ func (rs *rulesService) UpdateRule(ctx context.Context, token string, rule Rule)
 	}
 
 	return rs.rules.Update(ctx, rule)
+}
+
+func (rs *rulesService) AssignThings(ctx context.Context, token, ruleID string, thingIDs ...string) error {
+	rule, err := rs.rules.RetrieveByID(ctx, ruleID)
+	if err != nil {
+		return err
+	}
+
+	if err := rs.things.CanUserAccessGroup(ctx, domain.UserAccessReq{Token: token, ID: rule.GroupID, Action: domain.GroupEditor}); err != nil {
+		return err
+	}
+	// TODO: replace with a single bulk gRPC call, e.g. CanUserAccessThings(ctx, groupID, thingIDs...)
+	// to avoid N round-trips to the things service.
+	for _, thingID := range thingIDs {
+		grID, err := rs.things.GetGroupIDByThing(ctx, thingID)
+		if err != nil {
+			return err
+		}
+		if grID != rule.GroupID {
+			return errors.ErrAuthorization
+		}
+	}
+
+	return rs.rules.AssignThings(ctx, ruleID, thingIDs...)
+}
+
+func (rs *rulesService) UnassignThings(ctx context.Context, token, ruleID string, thingIDs ...string) error {
+	rule, err := rs.rules.RetrieveByID(ctx, ruleID)
+	if err != nil {
+		return err
+	}
+
+	if err := rs.things.CanUserAccessGroup(ctx, domain.UserAccessReq{Token: token, ID: rule.GroupID, Action: domain.GroupEditor}); err != nil {
+		return err
+	}
+
+	return rs.rules.UnassignThings(ctx, ruleID, thingIDs...)
 }
 
 func (rs *rulesService) RemoveRules(ctx context.Context, token string, ids ...string) error {
@@ -498,6 +541,12 @@ type RepositoryRules interface {
 	// Update performs an update to the existing rule.
 	// A non-nil error is returned to indicate operation failure.
 	Update(ctx context.Context, r Rule) error
+
+	// AssignThings assigns one or more Things to a specific Rule.
+	AssignThings(ctx context.Context, ruleID string, thingIDs ...string) error
+
+	// UnassignThings unassigns one or more Things from a specific Rule.
+	UnassignThings(ctx context.Context, ruleID string, thingIDs ...string) error
 
 	// Remove removes rules having the provided IDs.
 	Remove(ctx context.Context, ids ...string) error

--- a/rules/service.go
+++ b/rules/service.go
@@ -133,6 +133,9 @@ type ServiceRules interface {
 
 	// RemoveRulesByGroup removes the rules identified with the provided IDs.
 	RemoveRulesByGroup(ctx context.Context, groupID string) error
+
+	// UnassignRulesFromThing unassigns all rules from the given thing.
+	UnassignRulesFromThing(ctx context.Context, thingID string) error
 }
 
 const (
@@ -269,6 +272,10 @@ func (rs *rulesService) RemoveRules(ctx context.Context, token string, ids ...st
 
 func (rs *rulesService) RemoveRulesByGroup(ctx context.Context, groupID string) error {
 	return rs.rules.RemoveByGroup(ctx, groupID)
+}
+
+func (rs *rulesService) UnassignRulesFromThing(ctx context.Context, thingID string) error {
+	return rs.rules.UnassignRulesFromThing(ctx, thingID)
 }
 
 func (rs *rulesService) CreateScripts(ctx context.Context, token, groupID string, scripts ...LuaScript) ([]LuaScript, error) {
@@ -498,6 +505,9 @@ type RepositoryRules interface {
 	// RemoveByGroup removes rules related to a certain group,
 	// identified by a given group ID.
 	RemoveByGroup(ctx context.Context, groupID string) error
+
+	// UnassignRulesFromThing unassigns all rules from the given thing in rules_things.
+	UnassignRulesFromThing(ctx context.Context, thingID string) error
 }
 
 type RepositoryScripts interface {

--- a/rules/service.go
+++ b/rules/service.go
@@ -124,15 +124,6 @@ type ServiceRules interface {
 
 	// RemoveRulesByGroup removes the rules identified with the provided IDs.
 	RemoveRulesByGroup(ctx context.Context, groupID string) error
-
-	// AssignRules assigns rules to a specific thing.
-	AssignRules(ctx context.Context, token, thingID string, ruleIDs ...string) error
-
-	// UnassignRules removes rule assignments from a specific thing.
-	UnassignRules(ctx context.Context, token, thingID string, ruleIDs ...string) error
-
-	// UnassignRulesByThing removes all rule assignments from a specific thing.
-	UnassignRulesByThing(ctx context.Context, thingID string) error
 }
 
 const (
@@ -223,7 +214,7 @@ func (rs *rulesService) ListThingIDsByRule(ctx context.Context, token, ruleID st
 		return []string{}, err
 	}
 
-	return rs.rules.RetrieveThingIDsByRule(ctx, ruleID)
+	return rule.Input.ThingIDs, nil
 }
 
 func (rs *rulesService) ViewRule(ctx context.Context, token, id string) (Rule, error) {
@@ -269,66 +260,6 @@ func (rs *rulesService) RemoveRules(ctx context.Context, token string, ids ...st
 
 func (rs *rulesService) RemoveRulesByGroup(ctx context.Context, groupID string) error {
 	return rs.rules.RemoveByGroup(ctx, groupID)
-}
-
-func (rs *rulesService) AssignRules(ctx context.Context, token, thingID string, ruleIDs ...string) error {
-	if err := rs.things.CanUserAccessThing(ctx, domain.UserAccessReq{Token: token, ID: thingID, Action: domain.GroupEditor}); err != nil {
-		return err
-	}
-
-	grID, err := rs.things.GetGroupIDByThing(ctx, thingID)
-	if err != nil {
-		return err
-	}
-
-	for _, id := range ruleIDs {
-		rule, err := rs.rules.RetrieveByID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		if rule.GroupID != grID {
-			return errors.ErrAuthorization
-		}
-	}
-
-	if err := rs.rules.Assign(ctx, thingID, ruleIDs...); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (rs *rulesService) UnassignRules(ctx context.Context, token, thingID string, ruleIDs ...string) error {
-	if err := rs.things.CanUserAccessThing(ctx, domain.UserAccessReq{Token: token, ID: thingID, Action: domain.GroupEditor}); err != nil {
-		return err
-	}
-
-	grID, err := rs.things.GetGroupIDByThing(ctx, thingID)
-	if err != nil {
-		return err
-	}
-
-	for _, id := range ruleIDs {
-		rule, err := rs.rules.RetrieveByID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		if rule.GroupID != grID {
-			return errors.ErrAuthorization
-		}
-	}
-
-	if err := rs.rules.Unassign(ctx, thingID, ruleIDs...); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (rs *rulesService) UnassignRulesByThing(ctx context.Context, thingID string) error {
-	return rs.rules.UnassignByThing(ctx, thingID)
 }
 
 func (rs *rulesService) CreateScripts(ctx context.Context, token, groupID string, scripts ...LuaScript) ([]LuaScript, error) {
@@ -506,8 +437,10 @@ func (rs *rulesService) ConsumeMessage(_ string, msg protomfx.Message) error {
 		return err
 	}
 
-	// Process simple rules assigned to Publisher
 	for _, rule := range rulesPage.Rules {
+		if rule.Input.Type != InputTypeMessage {
+			continue
+		}
 		if err := rs.processRule(&msg, payload, rule); err != nil {
 			rs.logger.Error(fmt.Sprintf("processing rule with id %s failed with error: %v", rule.ID, err))
 		}
@@ -522,11 +455,11 @@ func (rs *rulesService) ConsumeMessage(_ string, msg protomfx.Message) error {
 		return err
 	}
 
-	// Process Lua scripts assigned to Publisher
 	rs.processLuaScripts(ctx, &msg, payload, scriptsPage.Scripts...)
 
 	return nil
 }
+
 
 type Repository interface {
 	RepositoryRules
@@ -550,9 +483,6 @@ type RepositoryRules interface {
 	// identified by a given group ID.
 	RetrieveByGroup(ctx context.Context, groupID string, pm PageMetadata) (RulesPage, error)
 
-	// RetrieveThingIDsByRule retrieves all thing IDs that have the given rule assigned.
-	RetrieveThingIDsByRule(ctx context.Context, ruleID string) ([]string, error)
-
 	// Update performs an update to the existing rule.
 	// A non-nil error is returned to indicate operation failure.
 	Update(ctx context.Context, r Rule) error
@@ -563,16 +493,6 @@ type RepositoryRules interface {
 	// RemoveByGroup removes rules related to a certain group,
 	// identified by a given group ID.
 	RemoveByGroup(ctx context.Context, groupID string) error
-
-	// Assign assigns rules to the specified thing.
-	Assign(ctx context.Context, thingID string, ruleIDs ...string) error
-
-	// Unassign removes specific rule assignments from a given thing.
-	Unassign(ctx context.Context, thingID string, ruleIDs ...string) error
-
-	// UnassignByThing removes all rule assignments for a certain thing,
-	// identified by a given thing ID.
-	UnassignByThing(ctx context.Context, thingID string) error
 }
 
 type RepositoryScripts interface {

--- a/rules/service.go
+++ b/rules/service.go
@@ -26,12 +26,13 @@ var AllowedOrders = map[string]string{
 
 // PageMetadata contains page metadata that helps navigation.
 type PageMetadata struct {
-	Total  uint64 `json:"total,omitempty"`
-	Offset uint64 `json:"offset,omitempty"`
-	Limit  uint64 `json:"limit,omitempty"`
-	Order  string `json:"order,omitempty"`
-	Dir    string `json:"dir,omitempty"`
-	Name   string `json:"name,omitempty"`
+	Total     uint64 `json:"total,omitempty"`
+	Offset    uint64 `json:"offset,omitempty"`
+	Limit     uint64 `json:"limit,omitempty"`
+	Order     string `json:"order,omitempty"`
+	Dir       string `json:"dir,omitempty"`
+	Name      string `json:"name,omitempty"`
+	InputType string `json:"input_type,omitempty"`
 }
 
 // Validate validates the page metadata.
@@ -43,6 +44,14 @@ func (pm PageMetadata) Validate(maxLimitSize, maxNameSize int) error {
 
 	if len(pm.Name) > maxNameSize {
 		return apiutil.ErrNameSize
+	}
+
+	if pm.InputType != "" {
+		switch pm.InputType {
+		case InputTypeMessage, InputTypeAlarm, InputTypeSchedule, InputTypeCommand:
+		default:
+			return apiutil.ErrInvalidInputType
+		}
 	}
 
 	return nil
@@ -432,15 +441,12 @@ func (rs *rulesService) ConsumeMessage(_ string, msg protomfx.Message) error {
 		return err
 	}
 
-	rulesPage, err := rs.rules.RetrieveByThing(ctx, msg.Publisher, PageMetadata{})
+	page, err := rs.rules.RetrieveByThing(ctx, msg.Publisher, PageMetadata{InputType: InputTypeMessage})
 	if err != nil {
 		return err
 	}
 
-	for _, rule := range rulesPage.Rules {
-		if rule.Input.Type != InputTypeMessage {
-			continue
-		}
+	for _, rule := range page.Rules {
 		if err := rs.processRule(&msg, payload, rule); err != nil {
 			rs.logger.Error(fmt.Sprintf("processing rule with id %s failed with error: %v", rule.ID, err))
 		}
@@ -459,7 +465,6 @@ func (rs *rulesService) ConsumeMessage(_ string, msg protomfx.Message) error {
 
 	return nil
 }
-
 
 type Repository interface {
 	RepositoryRules

--- a/rules/service.go
+++ b/rules/service.go
@@ -542,10 +542,10 @@ type RepositoryRules interface {
 	// A non-nil error is returned to indicate operation failure.
 	Update(ctx context.Context, r Rule) error
 
-	// AssignThings assigns one or more Things to a specific Rule.
+	// AssignThings assigns one or more things to a specific rule.
 	AssignThings(ctx context.Context, ruleID string, thingIDs ...string) error
 
-	// UnassignThings unassigns one or more Things from a specific Rule.
+	// UnassignThings unassigns one or more things from a specific rule.
 	UnassignThings(ctx context.Context, ruleID string, thingIDs ...string) error
 
 	// Remove removes rules having the provided IDs.
@@ -555,7 +555,7 @@ type RepositoryRules interface {
 	// identified by a given group ID.
 	RemoveByGroup(ctx context.Context, groupID string) error
 
-	// UnassignRulesFromThing unassigns all rules from the given thing in rules_things.
+	// UnassignRulesFromThing unassigns all rules from the given thing.
 	UnassignRulesFromThing(ctx context.Context, thingID string) error
 }
 

--- a/rules/service.go
+++ b/rules/service.go
@@ -48,7 +48,7 @@ func (pm PageMetadata) Validate(maxLimitSize, maxNameSize int) error {
 
 	if pm.InputType != "" {
 		switch pm.InputType {
-		case InputTypeMessage, InputTypeAlarm, InputTypeSchedule, InputTypeCommand:
+		case InputTypeMessage, InputTypeAlarm, InputTypeCommand:
 		default:
 			return apiutil.ErrInvalidInputType
 		}

--- a/rules/service.go
+++ b/rules/service.go
@@ -270,8 +270,7 @@ func (rs *rulesService) AssignThings(ctx context.Context, token, ruleID string, 
 	if err := rs.things.CanUserAccessGroup(ctx, domain.UserAccessReq{Token: token, ID: rule.GroupID, Action: domain.GroupEditor}); err != nil {
 		return err
 	}
-	// TODO: replace with a single bulk gRPC call, e.g. CanUserAccessThings(ctx, groupID, thingIDs...)
-	// to avoid N round-trips to the things service.
+
 	for _, thingID := range thingIDs {
 		grID, err := rs.things.GetGroupIDByThing(ctx, thingID)
 		if err != nil {

--- a/rules/service_test.go
+++ b/rules/service_test.go
@@ -64,6 +64,7 @@ func saveRules(t *testing.T, svc rules.Service, n int) []rules.Rule {
 		rs = append(rs, rules.Rule{
 			Name:        fmt.Sprintf("rule-%d", i),
 			Description: fmt.Sprintf("desc-%d", i),
+			Input:       rules.Input{Type: rules.InputTypeMessage, ThingIDs: []string{thingID}},
 			Conditions: []rules.Condition{
 				{Field: "temperature", Comparator: ">", Threshold: threshold(25)},
 			},
@@ -77,13 +78,6 @@ func saveRules(t *testing.T, svc rules.Service, n int) []rules.Rule {
 	require.Len(t, saved, n)
 
 	return saved
-}
-
-func assignRules(t *testing.T, svc rules.Service, thID string, ruleIDs ...string) {
-	t.Helper()
-
-	err := svc.AssignRules(context.Background(), token, thID, ruleIDs...)
-	require.Nil(t, err)
 }
 
 func mustMarshal(t *testing.T, v any) []byte {
@@ -153,17 +147,6 @@ func TestConsumeMessage(t *testing.T) {
 					map[string]any{"name": "temperature", "value": float64(30)},
 				}),
 				ContentType: "application/senml+json",
-			},
-			err: nil,
-		},
-		{
-			desc:       "unknown publisher has no assigned rules",
-			conditions: defaultConditions,
-			operator:   rules.OperatorAND,
-			msg: protomfx.Message{
-				Publisher:   "2c8d1c97-6121-4c49-8a85-2baffd4e9e49",
-				Payload:     mustMarshal(t, map[string]any{"temperature": float64(30)}),
-				ContentType: "application/json",
 			},
 			err: nil,
 		},
@@ -270,14 +253,14 @@ func TestConsumeMessage(t *testing.T) {
 		svc := newService()
 
 		if len(tc.conditions) > 0 {
-			saved, err := svc.CreateRules(context.Background(), token, groupID, rules.Rule{
+			_, err := svc.CreateRules(context.Background(), token, groupID, rules.Rule{
 				Name:       "test-rule",
+				Input:      rules.Input{Type: rules.InputTypeMessage, ThingIDs: []string{thingID}},
 				Conditions: tc.conditions,
 				Operator:   tc.operator,
 				Actions:    []rules.Action{{Type: rules.ActionTypeAlarm}},
 			})
 			require.Nil(t, err)
-			assignRules(t, svc, thingID, saved[0].ID)
 		}
 
 		err := svc.ConsumeMessage(subject, tc.msg)
@@ -425,13 +408,7 @@ func TestListRulesByGroup(t *testing.T) {
 func TestListRulesByThing(t *testing.T) {
 	svc := newService()
 	n := 10
-	saved := saveRules(t, svc, n)
-
-	var ruleIDs []string
-	for _, r := range saved {
-		ruleIDs = append(ruleIDs, r.ID)
-	}
-	assignRules(t, svc, thingID, ruleIDs...)
+	saveRules(t, svc, n)
 
 	cases := []struct {
 		desc         string
@@ -520,7 +497,6 @@ func TestListThingIDsByRule(t *testing.T) {
 	svc := newService()
 	saved := saveRules(t, svc, 1)
 	ruleID := saved[0].ID
-	assignRules(t, svc, thingID, ruleID)
 
 	cases := []struct {
 		desc   string
@@ -708,123 +684,6 @@ func TestRemoveRulesByGroup(t *testing.T) {
 
 	for _, tc := range cases {
 		err := svc.RemoveRulesByGroup(context.Background(), tc.groupID)
-		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.err, err))
-	}
-}
-
-func TestAssignRules(t *testing.T) {
-	svc := newService()
-	saved := saveRules(t, svc, 1)
-	ruleID := saved[0].ID
-
-	cases := []struct {
-		desc    string
-		token   string
-		thingID string
-		ruleIDs []string
-		err     error
-	}{
-		{
-			desc:    "assign rules to thing",
-			token:   token,
-			thingID: thingID,
-			ruleIDs: []string{ruleID},
-			err:     nil,
-		},
-		{
-			desc:    "assign rules with invalid token",
-			token:   wrongValue,
-			thingID: thingID,
-			ruleIDs: []string{ruleID},
-			err:     errors.ErrAuthentication,
-		},
-		{
-			desc:    "assign non-existing rule to thing",
-			token:   token,
-			thingID: thingID,
-			ruleIDs: []string{wrongValue},
-			err:     dbutil.ErrNotFound,
-		},
-	}
-
-	for _, tc := range cases {
-		err := svc.AssignRules(context.Background(), tc.token, tc.thingID, tc.ruleIDs...)
-		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.err, err))
-	}
-}
-
-func TestUnassignRules(t *testing.T) {
-	svc := newService()
-	saved := saveRules(t, svc, 1)
-	ruleID := saved[0].ID
-	assignRules(t, svc, thingID, ruleID)
-
-	cases := []struct {
-		desc    string
-		token   string
-		thingID string
-		ruleIDs []string
-		err     error
-	}{
-		{
-			desc:    "unassign rules with invalid token",
-			token:   wrongValue,
-			thingID: thingID,
-			ruleIDs: []string{ruleID},
-			err:     errors.ErrAuthentication,
-		},
-		{
-			desc:    "unassign rules from thing",
-			token:   token,
-			thingID: thingID,
-			ruleIDs: []string{ruleID},
-			err:     nil,
-		},
-		{
-			desc:    "unassign non-existing rule from thing",
-			token:   token,
-			thingID: thingID,
-			ruleIDs: []string{wrongValue},
-			err:     dbutil.ErrNotFound,
-		},
-	}
-
-	for _, tc := range cases {
-		err := svc.UnassignRules(context.Background(), tc.token, tc.thingID, tc.ruleIDs...)
-		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.err, err))
-	}
-}
-
-func TestUnassignRulesByThing(t *testing.T) {
-	svc := newService()
-	n := 3
-	saved := saveRules(t, svc, n)
-
-	var ruleIDs []string
-	for _, r := range saved {
-		ruleIDs = append(ruleIDs, r.ID)
-	}
-	assignRules(t, svc, thingID, ruleIDs...)
-
-	cases := []struct {
-		desc    string
-		thingID string
-		err     error
-	}{
-		{
-			desc:    "unassign all rules from thing",
-			thingID: thingID,
-			err:     nil,
-		},
-		{
-			desc:    "unassign rules from non-existing thing",
-			thingID: wrongValue,
-			err:     nil,
-		},
-	}
-
-	for _, tc := range cases {
-		err := svc.UnassignRulesByThing(context.Background(), tc.thingID)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.err, err))
 	}
 }

--- a/rules/service_test.go
+++ b/rules/service_test.go
@@ -687,3 +687,30 @@ func TestRemoveRulesByGroup(t *testing.T) {
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.err, err))
 	}
 }
+func TestUnassignRulesFromThing(t *testing.T) {
+	svc := newService()
+	n := 3
+	saveRules(t, svc, n)
+
+	cases := []struct {
+		desc    string
+		thingID string
+		err     error
+	}{
+		{
+			desc:    "unassign all rules from thing",
+			thingID: thingID,
+			err:     nil,
+		},
+		{
+			desc:    "unassign rules from non-existing thing",
+			thingID: wrongValue,
+			err:     nil,
+		},
+	}
+
+	for _, tc := range cases {
+		err := svc.UnassignRulesFromThing(context.Background(), tc.thingID)
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.err, err))
+	}
+}

--- a/rules/tracing/rules.go
+++ b/rules/tracing/rules.go
@@ -14,6 +14,8 @@ const (
 	retrieveRulesByThing   = "retrieve_rules_by_thing"
 	retrieveRulesByGroup   = "retrieve_rules_by_group"
 	updateRule             = "update_rule"
+	assignThings           = "assign_things"
+	unassignThings         = "unassign_things"
 	removeRules            = "remove_rules"
 	removeRulesByGroup     = "remove_rules_by_group"
 	unassignRulesFromThing = "unassign_rules_from_thing"
@@ -74,6 +76,22 @@ func (rpm ruleRepositoryMiddleware) Update(ctx context.Context, rule rules.Rule)
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
 	return rpm.repo.Update(ctx, rule)
+}
+
+func (rpm ruleRepositoryMiddleware) AssignThings(ctx context.Context, ruleID string, thingIDs ...string) error {
+	span := dbutil.CreateSpan(ctx, rpm.tracer, assignThings)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return rpm.repo.AssignThings(ctx, ruleID, thingIDs...)
+}
+
+func (rpm ruleRepositoryMiddleware) UnassignThings(ctx context.Context, ruleID string, thingIDs ...string) error {
+	span := dbutil.CreateSpan(ctx, rpm.tracer, unassignThings)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return rpm.repo.UnassignThings(ctx, ruleID, thingIDs...)
 }
 
 func (rpm ruleRepositoryMiddleware) Remove(ctx context.Context, ids ...string) error {

--- a/rules/tracing/rules.go
+++ b/rules/tracing/rules.go
@@ -9,17 +9,13 @@ import (
 )
 
 const (
-	saveRule               = "save_rule"
-	retrieveRuleByID       = "retrieve_rule_by_id"
-	retrieveRulesByThing   = "retrieve_rules_by_thing"
-	retrieveRulesByGroup   = "retrieve_rules_by_group"
-	retrieveThingIDsByRule = "retrieve_thing_ids_by_rule"
-	updateRule             = "update_rule"
-	removeRules            = "remove_rules"
-	removeRulesByGroup     = "remove_rules_by_group"
-	assignRules            = "assign_rules"
-	unassignRules          = "unassign_rules"
-	unassignRulesByThing   = "unassign_rules_by_thing"
+	saveRule             = "save_rule"
+	retrieveRuleByID     = "retrieve_rule_by_id"
+	retrieveRulesByThing = "retrieve_rules_by_thing"
+	retrieveRulesByGroup = "retrieve_rules_by_group"
+	updateRule           = "update_rule"
+	removeRules          = "remove_rules"
+	removeRulesByGroup   = "remove_rules_by_group"
 )
 
 var (
@@ -71,14 +67,6 @@ func (rpm ruleRepositoryMiddleware) RetrieveByGroup(ctx context.Context, groupID
 	return rpm.repo.RetrieveByGroup(ctx, groupID, pm)
 }
 
-func (rpm ruleRepositoryMiddleware) RetrieveThingIDsByRule(ctx context.Context, ruleID string) ([]string, error) {
-	span := dbutil.CreateSpan(ctx, rpm.tracer, retrieveThingIDsByRule)
-	defer span.Finish()
-	ctx = opentracing.ContextWithSpan(ctx, span)
-
-	return rpm.repo.RetrieveThingIDsByRule(ctx, ruleID)
-}
-
 func (rpm ruleRepositoryMiddleware) Update(ctx context.Context, rule rules.Rule) error {
 	span := dbutil.CreateSpan(ctx, rpm.tracer, updateRule)
 	defer span.Finish()
@@ -103,26 +91,3 @@ func (rpm ruleRepositoryMiddleware) RemoveByGroup(ctx context.Context, groupID s
 	return rpm.repo.RemoveByGroup(ctx, groupID)
 }
 
-func (rpm ruleRepositoryMiddleware) Assign(ctx context.Context, thingID string, ruleIDs ...string) error {
-	span := dbutil.CreateSpan(ctx, rpm.tracer, assignRules)
-	defer span.Finish()
-	ctx = opentracing.ContextWithSpan(ctx, span)
-
-	return rpm.repo.Assign(ctx, thingID, ruleIDs...)
-}
-
-func (rpm ruleRepositoryMiddleware) Unassign(ctx context.Context, thingID string, ruleIDs ...string) error {
-	span := dbutil.CreateSpan(ctx, rpm.tracer, unassignRules)
-	defer span.Finish()
-	ctx = opentracing.ContextWithSpan(ctx, span)
-
-	return rpm.repo.Unassign(ctx, thingID, ruleIDs...)
-}
-
-func (rpm ruleRepositoryMiddleware) UnassignByThing(ctx context.Context, thingID string) error {
-	span := dbutil.CreateSpan(ctx, rpm.tracer, unassignRulesByThing)
-	defer span.Finish()
-	ctx = opentracing.ContextWithSpan(ctx, span)
-
-	return rpm.repo.UnassignByThing(ctx, thingID)
-}

--- a/rules/tracing/rules.go
+++ b/rules/tracing/rules.go
@@ -9,13 +9,14 @@ import (
 )
 
 const (
-	saveRule             = "save_rule"
-	retrieveRuleByID     = "retrieve_rule_by_id"
-	retrieveRulesByThing = "retrieve_rules_by_thing"
-	retrieveRulesByGroup = "retrieve_rules_by_group"
-	updateRule           = "update_rule"
-	removeRules          = "remove_rules"
-	removeRulesByGroup   = "remove_rules_by_group"
+	saveRule               = "save_rule"
+	retrieveRuleByID       = "retrieve_rule_by_id"
+	retrieveRulesByThing   = "retrieve_rules_by_thing"
+	retrieveRulesByGroup   = "retrieve_rules_by_group"
+	updateRule             = "update_rule"
+	removeRules            = "remove_rules"
+	removeRulesByGroup     = "remove_rules_by_group"
+	unassignRulesFromThing = "unassign_rules_from_thing"
 )
 
 var (
@@ -91,3 +92,10 @@ func (rpm ruleRepositoryMiddleware) RemoveByGroup(ctx context.Context, groupID s
 	return rpm.repo.RemoveByGroup(ctx, groupID)
 }
 
+func (rpm ruleRepositoryMiddleware) UnassignRulesFromThing(ctx context.Context, thingID string) error {
+	span := dbutil.CreateSpan(ctx, rpm.tracer, unassignRulesFromThing)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return rpm.repo.UnassignRulesFromThing(ctx, thingID)
+}


### PR DESCRIPTION
Closes #1197

This PR introduces the `Input` model for rules, which explicitly defines the event source type and the list of thing IDs a rule applies to. It also refactors the assign/unassign endpoints.

### What was implemented

- Added `input_type` column to the `rules` table with an index on `(group_id, input_type)` for efficient filtering
- `thing_ids` are required when **creating** a rule — a rule without any assigned things has no meaningful trigger
- Retained and refactored assign/unassign endpoints (`POST /rules/:id/things`, `PATCH /rules/:id/things`) for managing rule-thing relationships after creation; added an index on `rules_things(thing_id)` for efficient lookups
- Extracted shared validation helpers (`validateThingIDs`, `validateInputType`, `validateConditions`, `validateActions`) to eliminate duplication between create and update request validation
- Update request (`PUT /rules/:id`) uses a dedicated `updateRuleInput` struct that does not accept `thing_ids`, keeping rule property updates and thing assignment as separate operations

