### PR TITLE
NOISSUE - Fix webhook forwarder to send raw payload instead of marshaled JSON

### DIFF
--- a/webhooks/forwarder.go
+++ b/webhooks/forwarder.go
@@ -25,8 +25,7 @@ func NewForwarder() Forwarder {
 }
 
 func (fw *forwarder) Forward(_ context.Context, msg protomfx.Message, wh Webhook) error {
-	_, err := clientshttp.SendRequest(http.MethodPost, wh.Url, msg.Payload, wh.Headers)
-	if err != nil {
+	if _, err := clientshttp.SendRequest(http.MethodPost, wh.Url, msg.Payload, wh.Headers); err != nil {
 		return errors.Wrap(errForward, err)
 	}
 

--- a/webhooks/forwarder.go
+++ b/webhooks/forwarder.go
@@ -2,7 +2,6 @@ package webhooks
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 
 	clientshttp "github.com/MainfluxLabs/mainflux/pkg/clients/http"
@@ -26,12 +25,7 @@ func NewForwarder() Forwarder {
 }
 
 func (fw *forwarder) Forward(_ context.Context, msg protomfx.Message, wh Webhook) error {
-	body, err := json.Marshal(msg.Payload)
-	if err != nil {
-		return err
-	}
-
-	_, err = clientshttp.SendRequest(http.MethodPost, wh.Url, body, wh.Headers)
+	_, err := clientshttp.SendRequest(http.MethodPost, wh.Url, msg.Payload, wh.Headers)
 	if err != nil {
 		return errors.Wrap(errForward, err)
 	}


### PR DESCRIPTION
Fixes issues where external integrations expected a specific payload format and failed to parse double-encoded payloads.