### PR TITLE
NOISSUE - rename pkg/auth to pkg/authn

### DIFF
--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/auth"
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 )
 
 var _ auth.Service = (*loggingMiddleware)(nil)
@@ -29,7 +29,7 @@ func LoggingMiddleware(svc auth.Service, logger log.Logger) auth.Service {
 
 func (lm *loggingMiddleware) Issue(ctx context.Context, token string, newKey auth.Key) (key auth.Key, _ string, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		d := "infinite duration"
 		if !key.ExpiresAt.IsZero() {
 			d = fmt.Sprintf("the key with expiration date %v", key.ExpiresAt)
@@ -47,7 +47,7 @@ func (lm *loggingMiddleware) Issue(ctx context.Context, token string, newKey aut
 
 func (lm *loggingMiddleware) Revoke(ctx context.Context, token, id string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method revoke by user %s, id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -61,7 +61,7 @@ func (lm *loggingMiddleware) Revoke(ctx context.Context, token, id string) (err 
 
 func (lm *loggingMiddleware) RetrieveKey(ctx context.Context, token, id string) (_ auth.Key, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method retrieve_key by user %s, id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -75,7 +75,7 @@ func (lm *loggingMiddleware) RetrieveKey(ctx context.Context, token, id string) 
 
 func (lm *loggingMiddleware) ListAPIKeys(ctx context.Context, token string, pm auth.PageMetadata) (_ auth.KeysPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_api_keys by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -114,7 +114,7 @@ func (lm *loggingMiddleware) Authorize(ctx context.Context, ar auth.AuthzReq) (e
 
 func (lm *loggingMiddleware) CreateOrg(ctx context.Context, token string, org auth.Org) (_ auth.Org, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_org by user %s, name %s took %s to complete", email, org.Name, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -128,7 +128,7 @@ func (lm *loggingMiddleware) CreateOrg(ctx context.Context, token string, org au
 
 func (lm *loggingMiddleware) UpdateOrg(ctx context.Context, token string, org auth.Org) (_ auth.Org, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_org by user %s, name %s took %s to complete", email, org.Name, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -142,7 +142,7 @@ func (lm *loggingMiddleware) UpdateOrg(ctx context.Context, token string, org au
 
 func (lm *loggingMiddleware) RemoveOrgs(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_orgs by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -156,7 +156,7 @@ func (lm *loggingMiddleware) RemoveOrgs(ctx context.Context, token string, ids .
 
 func (lm *loggingMiddleware) ViewOrg(ctx context.Context, token, id string) (_ auth.Org, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_org by user %s, id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -170,7 +170,7 @@ func (lm *loggingMiddleware) ViewOrg(ctx context.Context, token, id string) (_ a
 
 func (lm *loggingMiddleware) ListOrgs(ctx context.Context, token string, pm auth.PageMetadata) (_ auth.OrgsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_orgs by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -197,7 +197,7 @@ func (lm *loggingMiddleware) GetOwnerIDByOrg(ctx context.Context, orgID string) 
 
 func (lm *loggingMiddleware) CreateOrgMemberships(ctx context.Context, token, orgID string, oms ...auth.OrgMembership) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_org_memberships by user %s, org id %s took %s to complete", email, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -211,7 +211,7 @@ func (lm *loggingMiddleware) CreateOrgMemberships(ctx context.Context, token, or
 
 func (lm *loggingMiddleware) ViewOrgMembership(ctx context.Context, token, orgID, memberID string) (_ auth.OrgMembership, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_org_membership by user %s, org id %s and member id %s took %s to complete", email, orgID, memberID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -225,7 +225,7 @@ func (lm *loggingMiddleware) ViewOrgMembership(ctx context.Context, token, orgID
 
 func (lm *loggingMiddleware) ListOrgMemberships(ctx context.Context, token, orgID string, pm auth.PageMetadata) (_ auth.OrgMembershipsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_org_memberships by user %s, org id %s took %s to complete", email, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -239,7 +239,7 @@ func (lm *loggingMiddleware) ListOrgMemberships(ctx context.Context, token, orgI
 
 func (lm *loggingMiddleware) UpdateOrgMemberships(ctx context.Context, token, orgID string, oms ...auth.OrgMembership) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_org_memberships by user %s, org id %s took %s to complete", email, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -253,7 +253,7 @@ func (lm *loggingMiddleware) UpdateOrgMemberships(ctx context.Context, token, or
 
 func (lm *loggingMiddleware) RemoveOrgMemberships(ctx context.Context, token string, orgID string, memberIDs ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_org_memberships by user %s, member ids %s and org id %s took %s to complete", email, memberIDs, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -267,7 +267,7 @@ func (lm *loggingMiddleware) RemoveOrgMemberships(ctx context.Context, token str
 
 func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (backup auth.Backup, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method backup by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -281,7 +281,7 @@ func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (backup a
 
 func (lm *loggingMiddleware) Restore(ctx context.Context, token string, backup auth.Backup) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method restore by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -321,7 +321,7 @@ func (lm *loggingMiddleware) RetrieveRole(ctx context.Context, id string) (_ str
 
 func (lm *loggingMiddleware) CreateOrgInvite(ctx context.Context, token string, oi auth.OrgInvite, invRedirectPath string) (_ auth.OrgInvite, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_org_invite by user %s, org id %s, role %s and user email %s took %s to complete", email, oi.OrgID, oi.InviteeRole, oi.InviteeEmail, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -336,7 +336,7 @@ func (lm *loggingMiddleware) CreateOrgInvite(ctx context.Context, token string, 
 
 func (lm *loggingMiddleware) CreateDormantOrgInvite(ctx context.Context, token string, oi auth.OrgInvite, platformInviteID string) (_ auth.OrgInvite, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_dormant_org_invite by user %s, org id %s, role %s and platform invite id %s took %s to complete",
 			email, oi.OrgID, oi.InviteeRole, platformInviteID, time.Since(begin))
 
@@ -353,7 +353,7 @@ func (lm *loggingMiddleware) CreateDormantOrgInvite(ctx context.Context, token s
 
 func (lm *loggingMiddleware) RevokeOrgInvite(ctx context.Context, token, inviteID string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method revoke_org_invite by user %s, invite id %s took %s to complete", email, inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -368,7 +368,7 @@ func (lm *loggingMiddleware) RevokeOrgInvite(ctx context.Context, token, inviteI
 
 func (lm *loggingMiddleware) RespondOrgInvite(ctx context.Context, token, inviteID string, accept bool) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method respond_org_invite by user %s, invite id %s and accept %t took %s to complete", email, inviteID, accept, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -383,7 +383,7 @@ func (lm *loggingMiddleware) RespondOrgInvite(ctx context.Context, token, invite
 
 func (lm *loggingMiddleware) ListOrgInvitesByUser(ctx context.Context, token, userType, userID string, pm auth.PageMetadata) (_ auth.OrgInvitesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_org_invites_by_user by user %s, type %s and user id %s took %s to complete", email, userType, userID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -398,7 +398,7 @@ func (lm *loggingMiddleware) ListOrgInvitesByUser(ctx context.Context, token, us
 
 func (lm *loggingMiddleware) ListOrgInvitesByOrg(ctx context.Context, token string, orgID string, pm auth.PageMetadata) (_ auth.OrgInvitesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_org_invites_by_org by user %s, org id %s took %s to complete", email, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -427,7 +427,7 @@ func (lm *loggingMiddleware) SendOrgInviteEmail(ctx context.Context, invite auth
 
 func (lm *loggingMiddleware) ViewOrgInvite(ctx context.Context, token, inviteID string) (_ auth.OrgInvite, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_org_invite by user %s, invite id %s took %s to complete", email, inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/certs/api/logging.go
+++ b/certs/api/logging.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/certs"
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 )
 
@@ -30,7 +30,7 @@ func NewLoggingMiddleware(svc certs.Service, logger log.Logger) certs.Service {
 
 func (lm *loggingMiddleware) IssueCert(ctx context.Context, token, thingID, ttl string, keyBits int, keyType string) (_ certs.Cert, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method issue_cert by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -44,7 +44,7 @@ func (lm *loggingMiddleware) IssueCert(ctx context.Context, token, thingID, ttl 
 
 func (lm *loggingMiddleware) RotateCert(ctx context.Context, token, serial, thingID, ttl string, keyBits int, keyType string) (_ certs.Cert, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method rotate_cert by user %s, serial %s and thing id %s took %s to complete", email, serial, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -58,7 +58,7 @@ func (lm *loggingMiddleware) RotateCert(ctx context.Context, token, serial, thin
 
 func (lm *loggingMiddleware) ListCerts(ctx context.Context, token, thingID string, offset, limit uint64) (_ certs.Page, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_certs by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -72,7 +72,7 @@ func (lm *loggingMiddleware) ListCerts(ctx context.Context, token, thingID strin
 
 func (lm *loggingMiddleware) ListSerials(ctx context.Context, token, thingID string, offset, limit uint64) (_ certs.Page, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_serials by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -86,7 +86,7 @@ func (lm *loggingMiddleware) ListSerials(ctx context.Context, token, thingID str
 
 func (lm *loggingMiddleware) ViewCert(ctx context.Context, token, serial string) (_ certs.Cert, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_cert by user %s, serial %s took %s to complete", email, serial, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -100,7 +100,7 @@ func (lm *loggingMiddleware) ViewCert(ctx context.Context, token, serial string)
 
 func (lm *loggingMiddleware) RevokeCert(ctx context.Context, token, serial string) (_ certs.Revoke, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method revoke_cert by user %s, serial %s took %s to complete", email, serial, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -127,7 +127,7 @@ func (lm *loggingMiddleware) DownloadCert(ctx context.Context, thingKey domain.T
 
 func (lm *loggingMiddleware) RenewCert(ctx context.Context, token, serial string) (_ certs.Cert, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method renew_cert by user %s, serial %s took %s to complete", email, serial, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/consumers/alarms/api/logging.go
+++ b/consumers/alarms/api/logging.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/consumers/alarms"
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 )
 
@@ -25,7 +25,7 @@ func LoggingMiddleware(svc alarms.Service, logger log.Logger) alarms.Service {
 
 func (lm loggingMiddleware) ListAlarmsByGroup(ctx context.Context, token, groupID string, pm alarms.PageMetadata) (_ alarms.AlarmsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_alarms_by_group by user %s, group id %s took %s to complete", email, groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -39,7 +39,7 @@ func (lm loggingMiddleware) ListAlarmsByGroup(ctx context.Context, token, groupI
 
 func (lm loggingMiddleware) ListAlarmsByThing(ctx context.Context, token, thingID string, pm alarms.PageMetadata) (_ alarms.AlarmsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_alarms_by_thing by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -53,7 +53,7 @@ func (lm loggingMiddleware) ListAlarmsByThing(ctx context.Context, token, thingI
 
 func (lm loggingMiddleware) ListAlarmsByOrg(ctx context.Context, token, orgID string, pm alarms.PageMetadata) (_ alarms.AlarmsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_alarms_by_org by user %s, org id %s took %s to complete", email, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -67,7 +67,7 @@ func (lm loggingMiddleware) ListAlarmsByOrg(ctx context.Context, token, orgID st
 
 func (lm loggingMiddleware) ViewAlarm(ctx context.Context, token, id string) (_ alarms.Alarm, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_alarm by user %s, alarm id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -81,7 +81,7 @@ func (lm loggingMiddleware) ViewAlarm(ctx context.Context, token, id string) (_ 
 
 func (lm loggingMiddleware) UpdateAlarmStatus(ctx context.Context, token, id, status string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_alarm_status by user %s, alarm id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -95,7 +95,7 @@ func (lm loggingMiddleware) UpdateAlarmStatus(ctx context.Context, token, id, st
 
 func (lm loggingMiddleware) RemoveAlarms(ctx context.Context, token string, id ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_alarms by user %s, alarm id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -135,7 +135,7 @@ func (lm loggingMiddleware) RemoveAlarmsByGroup(ctx context.Context, groupID str
 
 func (lm loggingMiddleware) ExportAlarmsByThing(ctx context.Context, token, thingID string, pm alarms.PageMetadata) (_ alarms.AlarmsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method export_alarms_by_thing by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/consumers/notifiers/api/logging.go
+++ b/consumers/notifiers/api/logging.go
@@ -10,11 +10,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 
 	notifiers "github.com/MainfluxLabs/mainflux/consumers/notifiers"
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
 )
 
 var _ notifiers.Service = (*loggingMiddleware)(nil)
@@ -31,7 +31,7 @@ func LoggingMiddleware(svc notifiers.Service, logger log.Logger) notifiers.Servi
 
 func (lm *loggingMiddleware) CreateNotifiers(ctx context.Context, token, groupID string, notifiers ...notifiers.Notifier) (response []notifiers.Notifier, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_notifiers by user %s, notifiers %v took %s to complete", email, response, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -45,7 +45,7 @@ func (lm *loggingMiddleware) CreateNotifiers(ctx context.Context, token, groupID
 
 func (lm *loggingMiddleware) ListNotifiersByGroup(ctx context.Context, token string, groupID string, pm notifiers.PageMetadata) (_ notifiers.NotifiersPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_notifiers_by_group by user %s, group id %s took %s to complete", email, groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -59,7 +59,7 @@ func (lm *loggingMiddleware) ListNotifiersByGroup(ctx context.Context, token str
 
 func (lm *loggingMiddleware) ViewNotifier(ctx context.Context, token, id string) (_ notifiers.Notifier, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_notifier by user %s, notifier id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -73,7 +73,7 @@ func (lm *loggingMiddleware) ViewNotifier(ctx context.Context, token, id string)
 
 func (lm *loggingMiddleware) UpdateNotifier(ctx context.Context, token string, notifier notifiers.Notifier) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_notifier by user %s, notifier id %s took %s to complete", email, notifier.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -87,7 +87,7 @@ func (lm *loggingMiddleware) UpdateNotifier(ctx context.Context, token string, n
 
 func (lm *loggingMiddleware) RemoveNotifiers(ctx context.Context, token string, id ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_notifiers by user %s, notifier ids %v took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/converters/api/logging.go
+++ b/converters/api/logging.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/converters"
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 )
 
 var _ converters.Service = (*loggingMiddleware)(nil)
@@ -29,7 +29,7 @@ func LoggingMiddleware(svc converters.Service, logger log.Logger) converters.Ser
 
 func (lm *loggingMiddleware) PublishJSONMessages(ctx context.Context, token string, csvLines [][]string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method publish_json_messages by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -43,7 +43,7 @@ func (lm *loggingMiddleware) PublishJSONMessages(ctx context.Context, token stri
 
 func (lm *loggingMiddleware) PublishSenMLMessages(ctx context.Context, token string, csvLines [][]string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method publish_senml_messages by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/downlinks/api/logging.go
+++ b/downlinks/api/logging.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/downlinks"
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 )
 
@@ -31,7 +31,7 @@ func LoggingMiddleware(svc downlinks.Service, logger log.Logger) downlinks.Servi
 
 func (lm *loggingMiddleware) CreateDownlinks(ctx context.Context, token, thingID string, downlinks ...downlinks.Downlink) (response []downlinks.Downlink, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_downlinks by user %s, downlinks %v took %s to complete", email, response, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -45,7 +45,7 @@ func (lm *loggingMiddleware) CreateDownlinks(ctx context.Context, token, thingID
 
 func (lm *loggingMiddleware) ListDownlinksByThing(ctx context.Context, token, thingID string, pm downlinks.PageMetadata) (response downlinks.DownlinksPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_downlinks_by_thing by user %s, id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -59,7 +59,7 @@ func (lm *loggingMiddleware) ListDownlinksByThing(ctx context.Context, token, th
 
 func (lm *loggingMiddleware) ListDownlinksByGroup(ctx context.Context, token, groupID string, pm downlinks.PageMetadata) (response downlinks.DownlinksPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_downlinks_by_group by user %s, id %s took %s to complete", email, groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -73,7 +73,7 @@ func (lm *loggingMiddleware) ListDownlinksByGroup(ctx context.Context, token, gr
 
 func (lm *loggingMiddleware) ViewDownlink(ctx context.Context, token, id string) (response downlinks.Downlink, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_downlink by user %s, id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -87,7 +87,7 @@ func (lm *loggingMiddleware) ViewDownlink(ctx context.Context, token, id string)
 
 func (lm *loggingMiddleware) UpdateDownlink(ctx context.Context, token string, downlink downlinks.Downlink) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_downlink by user %s, id %s took %s to complete", email, downlink.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -101,7 +101,7 @@ func (lm *loggingMiddleware) UpdateDownlink(ctx context.Context, token string, d
 
 func (lm *loggingMiddleware) RemoveDownlinks(ctx context.Context, token string, id ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_downlinks by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -167,7 +167,7 @@ func (lm *loggingMiddleware) LoadAndScheduleTasks(ctx context.Context) (err erro
 
 func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (response []downlinks.Downlink, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method backup by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -181,7 +181,7 @@ func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (response
 
 func (lm *loggingMiddleware) Restore(ctx context.Context, token string, dls []downlinks.Downlink) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method restore by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/filestore/api/logging.go
+++ b/filestore/api/logging.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/filestore"
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 )
 
 var _ filestore.Service = (*loggingMiddleware)(nil)
@@ -109,7 +109,7 @@ func (lm *loggingMiddleware) RemoveFiles(ctx context.Context, thingID string) (e
 
 func (lm *loggingMiddleware) SaveGroupFile(ctx context.Context, file io.Reader, token, groupID string, fi filestore.FileInfo) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method save_group_file by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -123,7 +123,7 @@ func (lm *loggingMiddleware) SaveGroupFile(ctx context.Context, file io.Reader, 
 
 func (lm *loggingMiddleware) UpdateGroupFile(ctx context.Context, token, groupID string, fi filestore.FileInfo) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_group_file by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -137,7 +137,7 @@ func (lm *loggingMiddleware) UpdateGroupFile(ctx context.Context, token, groupID
 
 func (lm *loggingMiddleware) ViewGroupFile(ctx context.Context, token, groupID string, fi filestore.FileInfo) (data []byte, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_group_file by user %s, file name %s took %s to complete", email, fi.Name, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -151,7 +151,7 @@ func (lm *loggingMiddleware) ViewGroupFile(ctx context.Context, token, groupID s
 
 func (lm *loggingMiddleware) ListGroupFiles(ctx context.Context, token, groupID string, fi filestore.FileInfo, pm filestore.PageMetadata) (files filestore.FileGroupsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_group_files by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -165,7 +165,7 @@ func (lm *loggingMiddleware) ListGroupFiles(ctx context.Context, token, groupID 
 
 func (lm *loggingMiddleware) RemoveGroupFile(ctx context.Context, token, groupID string, fi filestore.FileInfo) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_group_file by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/modbus/api/logging.go
+++ b/modbus/api/logging.go
@@ -10,7 +10,7 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/modbus"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 )
 
@@ -28,7 +28,7 @@ func LoggingMiddleware(svc modbus.Service, logger log.Logger) modbus.Service {
 
 func (lm *loggingMiddleware) CreateClients(ctx context.Context, token, thingID string, clients ...modbus.Client) (response []modbus.Client, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_clients by user %s, clients %v took %s to complete", email, response, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -42,7 +42,7 @@ func (lm *loggingMiddleware) CreateClients(ctx context.Context, token, thingID s
 
 func (lm *loggingMiddleware) ListClientsByThing(ctx context.Context, token, thingID string, pm modbus.PageMetadata) (response modbus.ClientsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_clients_by_thing by user %s, id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -56,7 +56,7 @@ func (lm *loggingMiddleware) ListClientsByThing(ctx context.Context, token, thin
 
 func (lm *loggingMiddleware) ListClientsByGroup(ctx context.Context, token, groupID string, pm modbus.PageMetadata) (response modbus.ClientsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_clients_by_group by user %s, id %s took %s to complete", email, groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -70,7 +70,7 @@ func (lm *loggingMiddleware) ListClientsByGroup(ctx context.Context, token, grou
 
 func (lm *loggingMiddleware) ViewClient(ctx context.Context, token, id string) (response modbus.Client, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_client by user %s, id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -84,7 +84,7 @@ func (lm *loggingMiddleware) ViewClient(ctx context.Context, token, id string) (
 
 func (lm *loggingMiddleware) UpdateClient(ctx context.Context, token string, client modbus.Client) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_client by user %s, id %s took %s to complete", email, client.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -98,7 +98,7 @@ func (lm *loggingMiddleware) UpdateClient(ctx context.Context, token string, cli
 
 func (lm *loggingMiddleware) RemoveClients(ctx context.Context, token string, id ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_clients by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/mqtt/api/logging.go
+++ b/mqtt/api/logging.go
@@ -13,7 +13,7 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/mqtt"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 )
 
 var _ mqtt.Service = (*loggingMiddleware)(nil)
@@ -30,7 +30,7 @@ func LoggingMiddleware(svc mqtt.Service, logger log.Logger) mqtt.Service {
 
 func (lm *loggingMiddleware) ListSubscriptions(ctx context.Context, groupID, token string, pm mqtt.PageMetadata) (_ mqtt.Page, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_subscriptions by user %s, group id %s took %s to complete", email, groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/pkg/authn/decode.go
+++ b/pkg/authn/decode.go
@@ -1,7 +1,7 @@
 // Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
 
-package auth
+package authn
 
 import (
 	"encoding/base64"

--- a/readers/api/logging.go
+++ b/readers/api/logging.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/readers"
 )
@@ -33,7 +33,7 @@ func LoggingMiddleware(svc readers.Service, logger logger.Logger) readers.Servic
 
 func (lm *loggingMiddleware) ListJSONMessages(ctx context.Context, token string, key domain.ThingKey, rpm readers.JSONPageMetadata) (_ readers.JSONMessagesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_json_messages by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -47,7 +47,7 @@ func (lm *loggingMiddleware) ListJSONMessages(ctx context.Context, token string,
 
 func (lm *loggingMiddleware) ListSenMLMessages(ctx context.Context, token string, key domain.ThingKey, rpm readers.SenMLPageMetadata) (_ readers.SenMLMessagesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_senml_messages by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -61,7 +61,7 @@ func (lm *loggingMiddleware) ListSenMLMessages(ctx context.Context, token string
 
 func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (_ readers.Backup, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method backup by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -75,7 +75,7 @@ func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (_ reader
 
 func (lm *loggingMiddleware) Restore(ctx context.Context, token string, backup readers.Backup) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method restore by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -89,7 +89,7 @@ func (lm *loggingMiddleware) Restore(ctx context.Context, token string, backup r
 
 func (lm *loggingMiddleware) ExportJSONMessages(ctx context.Context, token string, rpm readers.JSONPageMetadata) (_ readers.JSONMessagesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method export_json_messages by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -103,7 +103,7 @@ func (lm *loggingMiddleware) ExportJSONMessages(ctx context.Context, token strin
 
 func (lm *loggingMiddleware) ExportSenMLMessages(ctx context.Context, token string, rpm readers.SenMLPageMetadata) (_ readers.SenMLMessagesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method export_senml_messages by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -117,7 +117,7 @@ func (lm *loggingMiddleware) ExportSenMLMessages(ctx context.Context, token stri
 
 func (lm *loggingMiddleware) DeleteJSONMessages(ctx context.Context, token string, rpm readers.JSONPageMetadata) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method delete_json_messages by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -131,7 +131,7 @@ func (lm *loggingMiddleware) DeleteJSONMessages(ctx context.Context, token strin
 
 func (lm *loggingMiddleware) DeleteSenMLMessages(ctx context.Context, token string, rpm readers.SenMLPageMetadata) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method delete_senml_messages by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -145,7 +145,7 @@ func (lm *loggingMiddleware) DeleteSenMLMessages(ctx context.Context, token stri
 
 func (lm *loggingMiddleware) DeleteAllJSONMessages(ctx context.Context, token string, rpm readers.JSONPageMetadata) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method delete_all_json_messages by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -159,7 +159,7 @@ func (lm *loggingMiddleware) DeleteAllJSONMessages(ctx context.Context, token st
 
 func (lm *loggingMiddleware) DeleteAllSenMLMessages(ctx context.Context, token string, rpm readers.SenMLPageMetadata) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method delete_all_senml_messages by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/rules/api/logging.go
+++ b/rules/api/logging.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
 	"github.com/MainfluxLabs/mainflux/rules"
 )
 
@@ -26,7 +26,7 @@ func LoggingMiddleware(svc rules.Service, logger log.Logger) rules.Service {
 
 func (lm loggingMiddleware) CreateRules(ctx context.Context, token, groupID string, rules ...rules.Rule) (saved []rules.Rule, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_rules by user %s, rules %v took %s to complete", email, saved, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -40,7 +40,7 @@ func (lm loggingMiddleware) CreateRules(ctx context.Context, token, groupID stri
 
 func (lm loggingMiddleware) ListRulesByThing(ctx context.Context, token, thingID string, pm rules.PageMetadata) (_ rules.RulesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_rules_by_thing by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -54,7 +54,7 @@ func (lm loggingMiddleware) ListRulesByThing(ctx context.Context, token, thingID
 
 func (lm loggingMiddleware) ListRulesByGroup(ctx context.Context, token, groupID string, pm rules.PageMetadata) (_ rules.RulesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_rules_by_group by user %s, group id %s took %s to complete", email, groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -68,7 +68,7 @@ func (lm loggingMiddleware) ListRulesByGroup(ctx context.Context, token, groupID
 
 func (lm loggingMiddleware) ListThingIDsByRule(ctx context.Context, token, ruleID string) (_ []string, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_thing_ids_by_rule by user %s, rule id %s took %s to complete", email, ruleID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -82,7 +82,7 @@ func (lm loggingMiddleware) ListThingIDsByRule(ctx context.Context, token, ruleI
 
 func (lm loggingMiddleware) ViewRule(ctx context.Context, token, id string) (_ rules.Rule, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_rule by user %s, rule id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -96,7 +96,7 @@ func (lm loggingMiddleware) ViewRule(ctx context.Context, token, id string) (_ r
 
 func (lm loggingMiddleware) UpdateRule(ctx context.Context, token string, rule rules.Rule) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_rule by user %s, rule id %s took %s to complete", email, rule.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -110,7 +110,7 @@ func (lm loggingMiddleware) UpdateRule(ctx context.Context, token string, rule r
 
 func (lm loggingMiddleware) AssignThings(ctx context.Context, token, ruleID string, thingIDs ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method assign_things for rule id %s by user %s took %s to complete", ruleID, email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -124,7 +124,7 @@ func (lm loggingMiddleware) AssignThings(ctx context.Context, token, ruleID stri
 
 func (lm loggingMiddleware) UnassignThings(ctx context.Context, token, ruleID string, thingIDs ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method unassign_things for rule id %s by user %s took %s to complete", ruleID, email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -138,7 +138,7 @@ func (lm loggingMiddleware) UnassignThings(ctx context.Context, token, ruleID st
 
 func (lm loggingMiddleware) RemoveRules(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_rules by user %s, rule ids %v took %s to complete", email, ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -191,7 +191,7 @@ func (lm loggingMiddleware) ConsumeMessage(subject string, msg protomfx.Message)
 
 func (lm loggingMiddleware) CreateScripts(ctx context.Context, token, groupID string, scripts ...rules.LuaScript) (_ []rules.LuaScript, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_scripts by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -205,7 +205,7 @@ func (lm loggingMiddleware) CreateScripts(ctx context.Context, token, groupID st
 
 func (lm loggingMiddleware) ListScriptsByThing(ctx context.Context, token, thingID string, pm rules.PageMetadata) (_ rules.LuaScriptsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_scripts_by_thing by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -219,7 +219,7 @@ func (lm loggingMiddleware) ListScriptsByThing(ctx context.Context, token, thing
 
 func (lm loggingMiddleware) ListScriptsByGroup(ctx context.Context, token, groupID string, pm rules.PageMetadata) (_ rules.LuaScriptsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_scripts_by_group by user %s, group id %s took %s to complete", email, groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -233,7 +233,7 @@ func (lm loggingMiddleware) ListScriptsByGroup(ctx context.Context, token, group
 
 func (lm loggingMiddleware) ListThingIDsByScript(ctx context.Context, token, scriptID string) (_ []string, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_thing_ids_by_script by user %s, script id %s took %s to complete", email, scriptID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -247,7 +247,7 @@ func (lm loggingMiddleware) ListThingIDsByScript(ctx context.Context, token, scr
 
 func (lm loggingMiddleware) ViewScript(ctx context.Context, token, id string) (_ rules.LuaScript, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_script by user %s, script id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -261,7 +261,7 @@ func (lm loggingMiddleware) ViewScript(ctx context.Context, token, id string) (_
 
 func (lm loggingMiddleware) UpdateScript(ctx context.Context, token string, script rules.LuaScript) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_script by user %s, script id %s took %s to complete", email, script.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -275,7 +275,7 @@ func (lm loggingMiddleware) UpdateScript(ctx context.Context, token string, scri
 
 func (lm loggingMiddleware) RemoveScripts(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_scripts by user %s, script ids %v took %s to complete", email, ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -302,7 +302,7 @@ func (lm loggingMiddleware) RemoveScriptsByGroup(ctx context.Context, groupID st
 
 func (lm loggingMiddleware) AssignScripts(ctx context.Context, token, thingID string, scriptIDs ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method assign_scripts by user %s, thing id %s and script ids %v took %s to complete", email, thingID, scriptIDs, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -316,7 +316,7 @@ func (lm loggingMiddleware) AssignScripts(ctx context.Context, token, thingID st
 
 func (lm loggingMiddleware) UnassignScripts(ctx context.Context, token, thingID string, scriptIDs ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method unassign_scripts by user %s, thing id %s and script ids %v took %s to complete", email, thingID, scriptIDs, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -343,7 +343,7 @@ func (lm loggingMiddleware) UnassignScriptsFromThing(ctx context.Context, thingI
 
 func (lm loggingMiddleware) ListScriptRunsByThing(ctx context.Context, token, thingID string, pm rules.PageMetadata) (_ rules.ScriptRunsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_script_runs_by_thing by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -358,7 +358,7 @@ func (lm loggingMiddleware) ListScriptRunsByThing(ctx context.Context, token, th
 
 func (lm loggingMiddleware) RemoveScriptRuns(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_script_runs by user %s, run ids %v took %s to complete", email, ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/things"
 )
@@ -30,7 +30,7 @@ func LoggingMiddleware(svc things.Service, logger log.Logger) things.Service {
 
 func (lm *loggingMiddleware) CreateThings(ctx context.Context, token, profileID string, ths ...things.Thing) (saved []things.Thing, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_things by user %s, things %s took %s to complete", email, saved, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -44,7 +44,7 @@ func (lm *loggingMiddleware) CreateThings(ctx context.Context, token, profileID 
 
 func (lm *loggingMiddleware) UpdateThing(ctx context.Context, token string, thing things.Thing) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_thing by user %s, thing id %s took %s to complete", email, thing.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -58,7 +58,7 @@ func (lm *loggingMiddleware) UpdateThing(ctx context.Context, token string, thin
 
 func (lm *loggingMiddleware) UpdateThingsMetadata(ctx context.Context, token string, things ...things.Thing) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		var ids []string
 		for _, thing := range things {
 			ids = append(ids, thing.ID)
@@ -76,7 +76,7 @@ func (lm *loggingMiddleware) UpdateThingsMetadata(ctx context.Context, token str
 
 func (lm *loggingMiddleware) UpdateThingGroupAndProfile(ctx context.Context, token string, thing things.Thing) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_thing_group_and_profile by user %s, thing id %s took %s to complete", email, thing.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -90,7 +90,7 @@ func (lm *loggingMiddleware) UpdateThingGroupAndProfile(ctx context.Context, tok
 
 func (lm *loggingMiddleware) ViewThing(ctx context.Context, token, id string) (_ things.Thing, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_thing by user %s, thing id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -117,7 +117,7 @@ func (lm *loggingMiddleware) ViewMetadataByKey(ctx context.Context, key things.T
 
 func (lm *loggingMiddleware) ListThings(ctx context.Context, token string, pm things.PageMetadata) (_ things.ThingsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_things by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -131,7 +131,7 @@ func (lm *loggingMiddleware) ListThings(ctx context.Context, token string, pm th
 
 func (lm *loggingMiddleware) ListThingsByProfile(ctx context.Context, token, prID string, pm things.PageMetadata) (_ things.ThingsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_things_by_profile by user %s, profile id %s took %s to complete", email, prID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -145,7 +145,7 @@ func (lm *loggingMiddleware) ListThingsByProfile(ctx context.Context, token, prI
 
 func (lm *loggingMiddleware) ListThingsByOrg(ctx context.Context, token string, orgID string, pm things.PageMetadata) (_ things.ThingsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_things_by_org by user %s, org id %s took %s to complete", email, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -159,7 +159,7 @@ func (lm *loggingMiddleware) ListThingsByOrg(ctx context.Context, token string, 
 
 func (lm *loggingMiddleware) RemoveThings(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_things by user %s, thing ids %v took %s to complete", email, ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -173,7 +173,7 @@ func (lm *loggingMiddleware) RemoveThings(ctx context.Context, token string, ids
 
 func (lm *loggingMiddleware) CreateProfiles(ctx context.Context, token, grID string, profiles ...things.Profile) (saved []things.Profile, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_profiles by user %s, profiles %v took %s to complete", email, saved, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -187,7 +187,7 @@ func (lm *loggingMiddleware) CreateProfiles(ctx context.Context, token, grID str
 
 func (lm *loggingMiddleware) UpdateProfile(ctx context.Context, token string, profile things.Profile) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_profile by user %s, profile id %s took %s to complete", email, profile.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -201,7 +201,7 @@ func (lm *loggingMiddleware) UpdateProfile(ctx context.Context, token string, pr
 
 func (lm *loggingMiddleware) ViewProfile(ctx context.Context, token, id string) (_ things.Profile, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_profile by user %s, profile id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -215,7 +215,7 @@ func (lm *loggingMiddleware) ViewProfile(ctx context.Context, token, id string) 
 
 func (lm *loggingMiddleware) ListProfiles(ctx context.Context, token string, pm things.PageMetadata) (_ things.ProfilesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_profiles by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -229,7 +229,7 @@ func (lm *loggingMiddleware) ListProfiles(ctx context.Context, token string, pm 
 
 func (lm *loggingMiddleware) ListProfilesByOrg(ctx context.Context, token string, orgID string, pm things.PageMetadata) (_ things.ProfilesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_profiles_by_org by user %s, org id %s took %s to complete", email, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -243,7 +243,7 @@ func (lm *loggingMiddleware) ListProfilesByOrg(ctx context.Context, token string
 
 func (lm *loggingMiddleware) ViewProfileByThing(ctx context.Context, token, thID string) (_ things.Profile, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_profile_by_thing by user %s, thing id %s took %s to complete", email, thID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -257,7 +257,7 @@ func (lm *loggingMiddleware) ViewProfileByThing(ctx context.Context, token, thID
 
 func (lm *loggingMiddleware) RemoveProfiles(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_profiles by user %s, profile ids %v took %s to complete", email, ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -426,7 +426,7 @@ func (lm *loggingMiddleware) GetGroupIDByProfile(ctx context.Context, profileID 
 
 func (lm *loggingMiddleware) GetGroupIDsByOrg(ctx context.Context, orgID string, token string) (_ []string, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method get_group_ids_by_org by user %s, org id %s took %s to complete", email, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -440,7 +440,7 @@ func (lm *loggingMiddleware) GetGroupIDsByOrg(ctx context.Context, orgID string,
 
 func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (_ things.Backup, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method backup by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -454,7 +454,7 @@ func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (_ things
 
 func (lm *loggingMiddleware) Restore(ctx context.Context, token string, backup things.Backup) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method restore by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -468,7 +468,7 @@ func (lm *loggingMiddleware) Restore(ctx context.Context, token string, backup t
 
 func (lm *loggingMiddleware) CreateGroups(ctx context.Context, token, orgID string, grs ...things.Group) (saved []things.Group, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_groups by user %s, groups %s took %s to complete", email, saved, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -482,7 +482,7 @@ func (lm *loggingMiddleware) CreateGroups(ctx context.Context, token, orgID stri
 
 func (lm *loggingMiddleware) UpdateGroup(ctx context.Context, token string, gr things.Group) (_ things.Group, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_group by user %s, group id %s took %s to complete", email, gr.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -496,7 +496,7 @@ func (lm *loggingMiddleware) UpdateGroup(ctx context.Context, token string, gr t
 
 func (lm *loggingMiddleware) ViewGroup(ctx context.Context, token, id string) (_ things.Group, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_group by user %s, group id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -523,7 +523,7 @@ func (lm *loggingMiddleware) ViewGroupInternal(ctx context.Context, id string) (
 
 func (lm *loggingMiddleware) ListGroups(ctx context.Context, token string, pm things.PageMetadata) (_ things.GroupPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_groups by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -537,7 +537,7 @@ func (lm *loggingMiddleware) ListGroups(ctx context.Context, token string, pm th
 
 func (lm *loggingMiddleware) ListGroupsByOrg(ctx context.Context, token, orgID string, pm things.PageMetadata) (_ things.GroupPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_groups_by_org by user %s, org id %s took %s to complete", email, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -551,7 +551,7 @@ func (lm *loggingMiddleware) ListGroupsByOrg(ctx context.Context, token, orgID s
 
 func (lm *loggingMiddleware) ListThingsByGroup(ctx context.Context, token, groupID string, pm things.PageMetadata) (_ things.ThingsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_things_by_group by user %s, group id %s took %s to complete", email, groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -565,7 +565,7 @@ func (lm *loggingMiddleware) ListThingsByGroup(ctx context.Context, token, group
 
 func (lm *loggingMiddleware) ViewGroupByThing(ctx context.Context, token, thingID string) (_ things.Group, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_group_by_thing by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -579,7 +579,7 @@ func (lm *loggingMiddleware) ViewGroupByThing(ctx context.Context, token, thingI
 
 func (lm *loggingMiddleware) RemoveGroups(ctx context.Context, token string, ids ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_groups by user %s, group ids %v took %s to complete", email, ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -606,7 +606,7 @@ func (lm *loggingMiddleware) RemoveGroupsByOrg(ctx context.Context, orgID string
 
 func (lm *loggingMiddleware) ViewGroupByProfile(ctx context.Context, token, profileID string) (_ things.Group, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_group_by_profile by user %s, profile id %s took %s to complete", email, profileID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -620,7 +620,7 @@ func (lm *loggingMiddleware) ViewGroupByProfile(ctx context.Context, token, prof
 
 func (lm *loggingMiddleware) ListProfilesByGroup(ctx context.Context, token, groupID string, pm things.PageMetadata) (_ things.ProfilesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_profiles_by_group by user %s, group id %s took %s to complete", email, groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -634,7 +634,7 @@ func (lm *loggingMiddleware) ListProfilesByGroup(ctx context.Context, token, gro
 
 func (lm *loggingMiddleware) CreateGroupMemberships(ctx context.Context, token, redirectPath string, gms ...things.GroupMembership) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_group_memberships by user %s, memberships %v took %s to complete", email, gms, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -661,7 +661,7 @@ func (lm *loggingMiddleware) CreateGroupMembershipsInternal(ctx context.Context,
 
 func (lm *loggingMiddleware) ListGroupMemberships(ctx context.Context, token, groupID string, pm things.PageMetadata) (_ things.GroupMembershipsPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_group_memberships by user %s, group id %s and email %s took %s to complete", email, groupID, pm.Email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -675,7 +675,7 @@ func (lm *loggingMiddleware) ListGroupMemberships(ctx context.Context, token, gr
 
 func (lm *loggingMiddleware) UpdateGroupMemberships(ctx context.Context, token string, gms ...things.GroupMembership) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_group_memberships by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -689,7 +689,7 @@ func (lm *loggingMiddleware) UpdateGroupMemberships(ctx context.Context, token s
 
 func (lm *loggingMiddleware) RemoveGroupMemberships(ctx context.Context, token, groupID string, memberIDs ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_group_memberships by user %s, group id %s and member ids %v took %s to complete", email, groupID, memberIDs, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -703,7 +703,7 @@ func (lm *loggingMiddleware) RemoveGroupMemberships(ctx context.Context, token, 
 
 func (lm *loggingMiddleware) UpdateExternalKey(ctx context.Context, token, key, thingID string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_external_key by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -717,7 +717,7 @@ func (lm *loggingMiddleware) UpdateExternalKey(ctx context.Context, token, key, 
 
 func (lm *loggingMiddleware) RemoveExternalKey(ctx context.Context, token, thingID string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_external_key by user %s, thing id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/uiconfigs/api/logging.go
+++ b/uiconfigs/api/logging.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/uiconfigs"
 )
 
@@ -31,7 +31,7 @@ func LoggingMiddleware(svc uiconfigs.Service, logger log.Logger) uiconfigs.Servi
 
 func (lm *loggingMiddleware) ViewOrgConfig(ctx context.Context, token, orgID string) (response uiconfigs.OrgConfig, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_org_config by user %s, org %v took %s to complete", email, orgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -45,7 +45,7 @@ func (lm *loggingMiddleware) ViewOrgConfig(ctx context.Context, token, orgID str
 
 func (lm *loggingMiddleware) ListOrgsConfigs(ctx context.Context, token string, pm apiutil.PageMetadata) (response uiconfigs.OrgConfigPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_orgs_configs by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -59,7 +59,7 @@ func (lm *loggingMiddleware) ListOrgsConfigs(ctx context.Context, token string, 
 
 func (lm *loggingMiddleware) UpdateOrgConfig(ctx context.Context, token string, orgConfig uiconfigs.OrgConfig) (response uiconfigs.OrgConfig, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_org_config by user %s, org %v took %s to complete", email, orgConfig.OrgID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -86,7 +86,7 @@ func (lm *loggingMiddleware) RemoveOrgConfig(ctx context.Context, orgID string) 
 
 func (lm *loggingMiddleware) BackupOrgsConfigs(ctx context.Context, token string) (response uiconfigs.OrgConfigBackup, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method backup_orgs_configs by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -100,7 +100,7 @@ func (lm *loggingMiddleware) BackupOrgsConfigs(ctx context.Context, token string
 
 func (lm *loggingMiddleware) ViewThingConfig(ctx context.Context, token, thingID string) (response uiconfigs.ThingConfig, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_thing_config by user %s, thing %v took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -114,7 +114,7 @@ func (lm *loggingMiddleware) ViewThingConfig(ctx context.Context, token, thingID
 
 func (lm *loggingMiddleware) ListThingsConfigs(ctx context.Context, token string, pm apiutil.PageMetadata) (response uiconfigs.ThingConfigPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_things_configs by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -128,7 +128,7 @@ func (lm *loggingMiddleware) ListThingsConfigs(ctx context.Context, token string
 
 func (lm *loggingMiddleware) UpdateThingConfig(ctx context.Context, token string, thingConfig uiconfigs.ThingConfig) (response uiconfigs.ThingConfig, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_thing_config by user %s, thing %v took %s to complete", email, thingConfig.ThingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -168,7 +168,7 @@ func (lm *loggingMiddleware) RemoveThingConfigByGroup(ctx context.Context, group
 
 func (lm *loggingMiddleware) BackupThingsConfigs(ctx context.Context, token string) (response uiconfigs.ThingConfigBackup, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method backup_things_configs by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -182,7 +182,7 @@ func (lm *loggingMiddleware) BackupThingsConfigs(ctx context.Context, token stri
 
 func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (response uiconfigs.Backup, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method backup by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -196,7 +196,7 @@ func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (response
 
 func (lm *loggingMiddleware) Restore(ctx context.Context, token string, backup uiconfigs.Backup) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method restore by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/users/api/logging.go
+++ b/users/api/logging.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/users"
 )
@@ -86,7 +86,7 @@ func (lm *loggingMiddleware) RegisterAdmin(ctx context.Context, user users.User)
 
 func (lm *loggingMiddleware) Register(ctx context.Context, token string, user users.User) (_ string, err error) {
 	defer func(begin time.Time) {
-		callerEmail := pkgauth.EmailFromToken(token)
+		callerEmail := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method register by user %s for user %s took %s to complete", callerEmail, user.Email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -140,7 +140,7 @@ func (lm *loggingMiddleware) OAuthCallback(ctx context.Context, data users.OAuth
 
 func (lm *loggingMiddleware) ViewUser(ctx context.Context, token, id string) (u users.User, err error) {
 	defer func(begin time.Time) {
-		callerEmail := pkgauth.EmailFromToken(token)
+		callerEmail := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_user by user %s, for user %s took %s to complete", callerEmail, u.Email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -154,7 +154,7 @@ func (lm *loggingMiddleware) ViewUser(ctx context.Context, token, id string) (u 
 
 func (lm *loggingMiddleware) ViewProfile(ctx context.Context, token string) (u users.User, err error) {
 	defer func(begin time.Time) {
-		callerEmail := pkgauth.EmailFromToken(token)
+		callerEmail := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_profile by user %s, for user %s took %s to complete", callerEmail, u.Email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -168,7 +168,7 @@ func (lm *loggingMiddleware) ViewProfile(ctx context.Context, token string) (u u
 
 func (lm *loggingMiddleware) ListUsers(ctx context.Context, token string, pm users.PageMetadata) (_ users.UsersPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_users by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -208,7 +208,7 @@ func (lm *loggingMiddleware) ListUsersByEmails(ctx context.Context, emails []str
 
 func (lm *loggingMiddleware) UpdateUser(ctx context.Context, token string, u users.User) (err error) {
 	defer func(begin time.Time) {
-		callerEmail := pkgauth.EmailFromToken(token)
+		callerEmail := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_user by user %s, for user %s took %s to complete", callerEmail, u.Email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -235,7 +235,7 @@ func (lm *loggingMiddleware) GenerateResetToken(ctx context.Context, email, redi
 
 func (lm *loggingMiddleware) ChangePassword(ctx context.Context, token, email, password, oldPassword string) (err error) {
 	defer func(begin time.Time) {
-		callerEmail := pkgauth.EmailFromToken(token)
+		callerEmail := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method change_password by user %s, for user %s took %s to complete", callerEmail, email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -262,7 +262,7 @@ func (lm *loggingMiddleware) ResetPassword(ctx context.Context, email, password 
 
 func (lm *loggingMiddleware) SendPasswordReset(ctx context.Context, redirectPath, email, token string) (err error) {
 	defer func(begin time.Time) {
-		callerEmail := pkgauth.EmailFromToken(token)
+		callerEmail := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method send_password_reset by user %s, for user %s took %s to complete", callerEmail, email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -276,7 +276,7 @@ func (lm *loggingMiddleware) SendPasswordReset(ctx context.Context, redirectPath
 
 func (lm *loggingMiddleware) EnableUser(ctx context.Context, token string, id string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method enable_user by user %s, for user id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -290,7 +290,7 @@ func (lm *loggingMiddleware) EnableUser(ctx context.Context, token string, id st
 
 func (lm *loggingMiddleware) DisableUser(ctx context.Context, token string, id string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method disable_user by user %s, for user id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -304,7 +304,7 @@ func (lm *loggingMiddleware) DisableUser(ctx context.Context, token string, id s
 
 func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (users.User, []users.User, []users.Identity, error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method backup by user %s took %s to complete", email, time.Since(begin))
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
@@ -314,7 +314,7 @@ func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (users.Us
 
 func (lm *loggingMiddleware) Restore(ctx context.Context, token string, admin users.User, users []users.User, identities []users.Identity) error {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method restore by user %s took %s to complete", email, time.Since(begin))
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
@@ -324,7 +324,7 @@ func (lm *loggingMiddleware) Restore(ctx context.Context, token string, admin us
 
 func (lm *loggingMiddleware) CreatePlatformInvite(ctx context.Context, token, redirectPath, email string, orgInvite domain.OrgInvite) (_ users.PlatformInvite, err error) {
 	defer func(begin time.Time) {
-		callerEmail := pkgauth.EmailFromToken(token)
+		callerEmail := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_platform_invite by user %s, for email %s took %s to complete", callerEmail, email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -339,7 +339,7 @@ func (lm *loggingMiddleware) CreatePlatformInvite(ctx context.Context, token, re
 
 func (lm *loggingMiddleware) RevokePlatformInvite(ctx context.Context, token, inviteID string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method revoke_platform_invite by user %s, for invite id %s took %s to complete", email, inviteID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -368,7 +368,7 @@ func (lm *loggingMiddleware) ViewPlatformInvite(ctx context.Context, inviteID st
 
 func (lm *loggingMiddleware) ListPlatformInvites(ctx context.Context, token string, pm users.PageMetadata) (_ users.PlatformInvitesPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_platform_invites by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))

--- a/webhooks/api/logging.go
+++ b/webhooks/api/logging.go
@@ -11,10 +11,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 
 	log "github.com/MainfluxLabs/mainflux/logger"
-	pkgauth "github.com/MainfluxLabs/mainflux/pkg/auth"
 	"github.com/MainfluxLabs/mainflux/webhooks"
 )
 
@@ -32,7 +32,7 @@ func LoggingMiddleware(svc webhooks.Service, logger log.Logger) webhooks.Service
 
 func (lm *loggingMiddleware) CreateWebhooks(ctx context.Context, token, thingID string, webhooks ...webhooks.Webhook) (response []webhooks.Webhook, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method create_webhooks by user %s, webhooks %s took %s to complete", email, response, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -46,7 +46,7 @@ func (lm *loggingMiddleware) CreateWebhooks(ctx context.Context, token, thingID 
 
 func (lm *loggingMiddleware) ListWebhooksByGroup(ctx context.Context, token, groupID string, pm webhooks.PageMetadata) (response webhooks.WebhooksPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_webhooks_by_group by user %s, id %s took %s to complete", email, groupID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -60,7 +60,7 @@ func (lm *loggingMiddleware) ListWebhooksByGroup(ctx context.Context, token, gro
 
 func (lm *loggingMiddleware) ListWebhooksByThing(ctx context.Context, token, thingID string, pm webhooks.PageMetadata) (response webhooks.WebhooksPage, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method list_webhooks_by_thing by user %s, id %s took %s to complete", email, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -74,7 +74,7 @@ func (lm *loggingMiddleware) ListWebhooksByThing(ctx context.Context, token, thi
 
 func (lm *loggingMiddleware) ViewWebhook(ctx context.Context, token, id string) (response webhooks.Webhook, err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method view_webhook by user %s, id %s took %s to complete", email, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -88,7 +88,7 @@ func (lm *loggingMiddleware) ViewWebhook(ctx context.Context, token, id string) 
 
 func (lm *loggingMiddleware) UpdateWebhook(ctx context.Context, token string, webhook webhooks.Webhook) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method update_webhook by user %s, id %s took %s to complete", email, webhook.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
@@ -102,7 +102,7 @@ func (lm *loggingMiddleware) UpdateWebhook(ctx context.Context, token string, we
 
 func (lm *loggingMiddleware) RemoveWebhooks(ctx context.Context, token string, id ...string) (err error) {
 	defer func(begin time.Time) {
-		email := pkgauth.EmailFromToken(token)
+		email := authn.EmailFromToken(token)
 		message := fmt.Sprintf("Method remove_webhooks by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))


### PR DESCRIPTION
`pkg/auth` deals only with authe**n**tication-related code, as such I've renamed it to `pkg/authn`, as when other packages import it as `auth` it could be confused with the top-level `auth` service package