### PR TITLE
MF-1232 - attach user identity information to contexts originating from HTTP requests

### DIFF
--- a/auth/api/http/backup/endpoint_test.go
+++ b/auth/api/http/backup/endpoint_test.go
@@ -102,7 +102,7 @@ func newService() auth.Service {
 
 func newServer(svc auth.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, thmocks.NewAuthService("", nil, nil), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 

--- a/auth/api/http/backup/transport.go
+++ b/auth/api/http/backup/transport.go
@@ -8,8 +8,10 @@ import (
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -17,20 +19,29 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc auth.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
+func MakeHandler(svc auth.Service, ac auth.Authn, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Get("/backup", kithttp.NewServer(
-		kitot.TraceServer(tracer, "backup")(backupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "backup"),
+			withIdentity,
+		)(backupEndpoint(svc)),
 		decodeBackup,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/restore", kithttp.NewServer(
-		kitot.TraceServer(tracer, "restore")(restoreEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "restore"),
+			withIdentity,
+		)(restoreEndpoint(svc)),
 		decodeRestore,
 		encodeResponse,
 		opts...,

--- a/auth/api/http/invites/endpoint_test.go
+++ b/auth/api/http/invites/endpoint_test.go
@@ -113,7 +113,7 @@ func newService() auth.Service {
 
 func newServer(svc auth.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, thmocks.NewAuthService("", nil, nil), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 

--- a/auth/api/http/invites/transport.go
+++ b/auth/api/http/invites/transport.go
@@ -9,7 +9,9 @@ import (
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -21,55 +23,79 @@ const (
 	stateKey          = "state"
 )
 
-func MakeHandler(svc auth.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
+func MakeHandler(svc auth.Service, ac auth.Authn, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/orgs/:id/invites", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_org_invite")(createOrgInviteEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_org_invite"),
+			withIdentity,
+		)(createOrgInviteEndpoint(svc)),
 		decodeCreateOrgInviteRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/orgs/:id/invites", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_org_invites_by_org")(listOrgInvitesByOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_org_invites_by_org"),
+			withIdentity,
+		)(listOrgInvitesByOrgEndpoint(svc)),
 		decodeListOrgInvitesByOrgRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/invites/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_org_invite")(viewOrgInviteEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_org_invite"),
+			withIdentity,
+		)(viewOrgInviteEndpoint(svc)),
 		decodeInviteRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Delete("/invites/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "revoke_org_invite")(revokeOrgInviteEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "revoke_org_invite"),
+			withIdentity,
+		)(revokeOrgInviteEndpoint(svc)),
 		decodeInviteRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/invites/:id/:action", kithttp.NewServer(
-		kitot.TraceServer(tracer, "respond_org_invite")(respondOrgInviteEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "respond_org_invite"),
+			withIdentity,
+		)(respondOrgInviteEndpoint(svc)),
 		decodeRespondOrgInviteRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/users/:id/invites/received", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_org_invites_by_invitee")(listOrgInvitesByUserEndpoint(svc, auth.UserTypeInvitee)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_org_invites_by_invitee"),
+			withIdentity,
+		)(listOrgInvitesByUserEndpoint(svc, auth.UserTypeInvitee)),
 		decodeListOrgInvitesByUserRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/users/:id/invites/sent", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_org_invites_by_inviter")(listOrgInvitesByUserEndpoint(svc, auth.UserTypeInviter)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_org_invites_by_inviter"),
+			withIdentity,
+		)(listOrgInvitesByUserEndpoint(svc, auth.UserTypeInviter)),
 		decodeListOrgInvitesByUserRequest,
 		encodeResponse,
 		opts...,

--- a/auth/api/http/keys/endpoint_test.go
+++ b/auth/api/http/keys/endpoint_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/MainfluxLabs/mainflux/auth/mocks"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	pkgmocks "github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
@@ -74,7 +75,7 @@ func newService() auth.Service {
 
 func newServer(svc auth.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, pkgmocks.NewAuthService("", nil, nil), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 

--- a/auth/api/http/keys/transport.go
+++ b/auth/api/http/keys/transport.go
@@ -12,7 +12,9 @@ import (
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -20,33 +22,49 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc auth.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
+func MakeHandler(svc auth.Service, ac auth.Authn, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
+
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/keys", kithttp.NewServer(
-		kitot.TraceServer(tracer, "issue")(issueEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "issue"),
+			withIdentity,
+		)(issueEndpoint(svc)),
 		decodeIssue,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/keys", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_api_keys")(listAPIKeysEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_api_keys"),
+			withIdentity,
+		)(listAPIKeysEndpoint(svc)),
 		decodeListAPIKeys,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/keys/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "retrieve")(retrieveEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "retrieve"),
+			withIdentity,
+		)(retrieveEndpoint(svc)),
 		decodeKeyReq,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Delete("/keys/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "revoke")(revokeEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "revoke"),
+			withIdentity,
+		)(revokeEndpoint(svc)),
 		decodeKeyReq,
 		encodeResponse,
 		opts...,

--- a/auth/api/http/memberships/endpoint_test.go
+++ b/auth/api/http/memberships/endpoint_test.go
@@ -106,7 +106,7 @@ func newService() auth.Service {
 
 func newServer(svc auth.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, thmocks.NewAuthService("", nil, nil), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 

--- a/auth/api/http/memberships/transport.go
+++ b/auth/api/http/memberships/transport.go
@@ -8,7 +8,9 @@ import (
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -22,41 +24,59 @@ const (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc auth.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
+func MakeHandler(svc auth.Service, ac auth.Authn, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/orgs/:id/memberships", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_org_memberships")(createOrgMembershipsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_org_memberships"),
+			withIdentity,
+		)(createOrgMembershipsEndpoint(svc)),
 		decodeOrgMembershipsRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/orgs/:orgID/members/:memberID", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_org_membership")(viewOrgMembershipEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_org_membership"),
+			withIdentity,
+		)(viewOrgMembershipEndpoint(svc)),
 		decodeOrgMembershipRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/orgs/:id/memberships", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_org_memberships")(listOrgMembershipsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_org_memberships"),
+			withIdentity,
+		)(listOrgMembershipsEndpoint(svc)),
 		decodeListOrgMemberships,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Put("/orgs/:id/memberships", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_org_memberships")(updateOrgMembershipsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_org_memberships"),
+			withIdentity,
+		)(updateOrgMembershipsEndpoint(svc)),
 		decodeOrgMembershipsRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Patch("/orgs/:id/memberships", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_org_memberships")(removeOrgMembershipsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_org_memberships"),
+			withIdentity,
+		)(removeOrgMembershipsEndpoint(svc)),
 		decodeRemoveOrgMemberships,
 		encodeResponse,
 		opts...,

--- a/auth/api/http/orgs/endpoint_test.go
+++ b/auth/api/http/orgs/endpoint_test.go
@@ -112,7 +112,7 @@ func newService() auth.Service {
 
 func newServer(svc auth.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, thmocks.NewAuthService("", nil, nil), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 

--- a/auth/api/http/orgs/transport.go
+++ b/auth/api/http/orgs/transport.go
@@ -9,8 +9,10 @@ import (
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -18,54 +20,79 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc auth.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
+func MakeHandler(svc auth.Service, ac auth.Authn, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
+
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/orgs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_orgs")(createOrgsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_orgs"),
+			withIdentity,
+		)(createOrgsEndpoint(svc)),
 		decodeCreateOrgs,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/orgs/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_org")(viewOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_org"),
+			withIdentity,
+		)(viewOrgEndpoint(svc)),
 		decodeOrgRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Put("/orgs/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_org")(updateOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_org"),
+			withIdentity,
+		)(updateOrgEndpoint(svc)),
 		decodeUpdateOrg,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Delete("/orgs/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "delete_org")(deleteOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "delete_org"),
+			withIdentity,
+		)(deleteOrgEndpoint(svc)),
 		decodeOrgRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Patch("/orgs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "delete_orgs")(deleteOrgsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "delete_orgs"),
+			withIdentity,
+		)(deleteOrgsEndpoint(svc)),
 		decodeDeleteOrgs,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/orgs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_orgs")(listOrgsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_orgs"),
+			withIdentity,
+		)(listOrgsEndpoint(svc)),
 		decodeListOrgs,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/orgs/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_orgs")(listOrgsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_orgs"),
+			withIdentity,
+		)(listOrgsEndpoint(svc)),
 		decodeSearchOrgs,
 		encodeResponse,
 		opts...,

--- a/auth/api/http/transport.go
+++ b/auth/api/http/transport.go
@@ -19,13 +19,13 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc auth.Service, tracer opentracing.Tracer, logger logger.Logger) http.Handler {
+func MakeHandler(svc auth.Service, ac auth.Authn, tracer opentracing.Tracer, logger logger.Logger) http.Handler {
 	mux := bone.New()
-	mux = orgs.MakeHandler(svc, mux, tracer, logger)
-	mux = keys.MakeHandler(svc, mux, tracer, logger)
-	mux = memberships.MakeHandler(svc, mux, tracer, logger)
-	mux = invites.MakeHandler(svc, mux, tracer, logger)
-	mux = backup.MakeHandler(svc, mux, tracer, logger)
+	mux = orgs.MakeHandler(svc, ac, mux, tracer, logger)
+	mux = keys.MakeHandler(svc, ac, mux, tracer, logger)
+	mux = memberships.MakeHandler(svc, ac, mux, tracer, logger)
+	mux = invites.MakeHandler(svc, ac, mux, tracer, logger)
+	mux = backup.MakeHandler(svc, ac, mux, tracer, logger)
 
 	mux.GetFunc("/health", mainflux.Health("auth"))
 	mux.Handle("/metrics", promhttp.Handler())

--- a/certs/api/transport.go
+++ b/certs/api/transport.go
@@ -13,7 +13,10 @@ import (
 	"github.com/MainfluxLabs/mainflux/certs/pki"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -22,43 +25,61 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc certs.Service, tracer opentracing.Tracer, pkiAgent pki.Agent, logger logger.Logger) http.Handler {
+func MakeHandler(svc certs.Service, ac domain.AuthClient, tracer opentracing.Tracer, pkiAgent pki.Agent, logger logger.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
 	r := bone.New()
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	r.Post("/certs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "issue_cert")(issueCertEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "issue_cert"),
+			withIdentity,
+		)(issueCertEndpoint(svc)),
 		decodeCerts,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Post("/certs/:serial/rotate", kithttp.NewServer(
-		kitot.TraceServer(tracer, "rotate_cert")(rotateCertEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "rotate_cert"),
+			withIdentity,
+		)(rotateCertEndpoint(svc)),
 		decodeRotateCert,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Get("/certs/:serial", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_cert")(viewCertEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_cert"),
+			withIdentity,
+		)(viewCertEndpoint(svc)),
 		decodeViewCert,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Delete("/certs/:serial", kithttp.NewServer(
-		kitot.TraceServer(tracer, "revoke_cert")(revokeCertEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "revoke_cert"),
+			withIdentity,
+		)(revokeCertEndpoint(svc)),
 		decodeRevokeCerts,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Get("/things/:id/serials", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_serials")(listSerialsByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_serials"),
+			withIdentity,
+		)(listSerialsByThingEndpoint(svc)),
 		decodeListSerialsByThing,
 		encodeResponse,
 		opts...,
@@ -72,7 +93,10 @@ func MakeHandler(svc certs.Service, tracer opentracing.Tracer, pkiAgent pki.Agen
 	))
 
 	r.Put("/certs/:serial", kithttp.NewServer(
-		kitot.TraceServer(tracer, "renew_cert")(renewCertEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "renew_cert"),
+			withIdentity,
+		)(renewCertEndpoint(svc)),
 		decodeViewCert,
 		encodeResponse,
 		opts...,

--- a/cmd/alarms/main.go
+++ b/cmd/alarms/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux"
+	authapi "github.com/MainfluxLabs/mainflux/auth/api/grpc"
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/consumers/alarms"
 	"github.com/MainfluxLabs/mainflux/consumers/alarms/api"
@@ -67,6 +68,8 @@ const (
 	defServerKey         = ""
 	defThingsGRPCURL     = "localhost:8183"
 	defThingsGRPCTimeout = "1s"
+	defAuthGRPCURL       = "localhost:8181"
+	defAuthGRPCTimeout   = "1s"
 	defESURL             = "redis://localhost:6379/0"
 
 	envBrokerURL         = "MF_BROKER_URL"
@@ -88,6 +91,8 @@ const (
 	envJaegerURL         = "MF_JAEGER_URL"
 	envThingsGRPCURL     = "MF_THINGS_AUTH_GRPC_URL"
 	envThingsGRPCTimeout = "MF_THINGS_AUTH_GRPC_TIMEOUT"
+	envAuthGRPCURL       = "MF_AUTH_GRPC_URL"
+	envAuthGRPCTimeout   = "MF_AUTH_GRPC_TIMEOUT"
 	envESURL             = "MF_ALARMS_ES_URL"
 )
 
@@ -97,8 +102,10 @@ type config struct {
 	dbConfig          postgres.Config
 	httpConfig        servers.Config
 	thingsConfig      clients.Config
+	authConfig        clients.Config
 	jaegerURL         string
 	thingsGRPCTimeout time.Duration
+	authGRPCTimeout   time.Duration
 	esURL             string
 }
 
@@ -133,6 +140,14 @@ func main() {
 
 	things := thingsapi.NewClient(thingsConn, thingsTracer, cfg.thingsGRPCTimeout)
 
+	authTracer, authCloser := jaeger.Init("alarms_auth", cfg.jaegerURL, logger)
+	defer authCloser.Close()
+
+	authConn := clientsgrpc.Connect(cfg.authConfig, logger)
+	defer authConn.Close()
+
+	auth := authapi.NewClient(authConn, authTracer, cfg.authGRPCTimeout)
+
 	dbTracer, dbCloser := jaeger.Init("alarms_db", cfg.jaegerURL, logger)
 	defer dbCloser.Close()
 
@@ -143,7 +158,7 @@ func main() {
 	}
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(alarmsTracer, svc, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(alarmsTracer, svc, auth, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {
@@ -194,11 +209,23 @@ func loadConfig() config {
 		StopWaitTime: stopWaitTime,
 	}
 
+	authGRPCTimeout, err := time.ParseDuration(mainflux.Env(envAuthGRPCTimeout, defAuthGRPCTimeout))
+	if err != nil {
+		log.Fatalf("Invalid %s value: %s", envAuthGRPCTimeout, err.Error())
+	}
+
 	thingsConfig := clients.Config{
 		ClientTLS:  tls,
 		CaCerts:    mainflux.Env(envCACerts, defCACerts),
 		URL:        mainflux.Env(envThingsGRPCURL, defThingsGRPCURL),
 		ClientName: clients.Things,
+	}
+
+	authConfig := clients.Config{
+		ClientTLS:  tls,
+		CaCerts:    mainflux.Env(envCACerts, defCACerts),
+		URL:        mainflux.Env(envAuthGRPCURL, defAuthGRPCURL),
+		ClientName: clients.Auth,
 	}
 
 	return config{
@@ -207,8 +234,10 @@ func loadConfig() config {
 		dbConfig:          dbConfig,
 		httpConfig:        httpConfig,
 		thingsConfig:      thingsConfig,
+		authConfig:        authConfig,
 		jaegerURL:         mainflux.Env(envJaegerURL, defJaegerURL),
 		thingsGRPCTimeout: thingsAuthGRPCTimeout,
+		authGRPCTimeout:   authGRPCTimeout,
 		esURL:             mainflux.Env(envESURL, defESURL),
 	}
 }

--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -203,7 +203,7 @@ func main() {
 	svc := newService(db, tc, uc, dbTracer, logger, cfg, pub)
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(svc, authHttpTracer, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(svc, svc, authHttpTracer, logger), cfg.httpConfig, logger)
 	})
 	g.Go(func() error {
 		return serversgrpc.Start(ctx, authGrpcTracer, svc, cfg.grpcConfig, logger)

--- a/cmd/certs/main.go
+++ b/cmd/certs/main.go
@@ -196,7 +196,7 @@ func main() {
 	}
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, api.MakeHandler(svc, certsHttpTracer, pkiAgent, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, api.MakeHandler(svc, auth, certsHttpTracer, pkiAgent, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {

--- a/cmd/converters/main.go
+++ b/cmd/converters/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux"
+	authapi "github.com/MainfluxLabs/mainflux/auth/api/grpc"
 	adapter "github.com/MainfluxLabs/mainflux/converters"
 	"github.com/MainfluxLabs/mainflux/converters/api"
 	"github.com/MainfluxLabs/mainflux/logger"
@@ -40,6 +41,8 @@ const (
 	defBrokerURL         = "nats://localhost:4222"
 	defThingsGRPCURL     = "localhost:8183"
 	defThingsGRPCTimeout = "1s"
+	defAuthGRPCURL       = "localhost:8181"
+	defAuthGRPCTimeout   = "1s"
 
 	envLogLevel          = "MF_CONVERTERS_LOG_LEVEL"
 	envClientTLS         = "MF_CONVERTERS_CLIENT_TLS"
@@ -49,6 +52,8 @@ const (
 	envBrokerURL         = "MF_BROKER_URL"
 	envThingsGRPCURL     = "MF_THINGS_AUTH_GRPC_URL"
 	envThingsGRPCTimeout = "MF_THINGS_AUTH_GRPC_TIMEOUT"
+	envAuthGRPCURL       = "MF_AUTH_GRPC_URL"
+	envAuthGRPCTimeout   = "MF_AUTH_GRPC_TIMEOUT"
 )
 
 type config struct {
@@ -57,7 +62,9 @@ type config struct {
 	brokerURL         string
 	httpConfig        servers.Config
 	thingsConfig      clients.Config
+	authConfig        clients.Config
 	thingsGRPCTimeout time.Duration
+	authGRPCTimeout   time.Duration
 }
 
 func main() {
@@ -82,7 +89,7 @@ func main() {
 	httpTracer, closer := jaeger.Init(svcName, cfg.jaegerURL, logger)
 	defer closer.Close()
 
-	thingsTracer, thingsCloser := jaeger.Init(svcName+"_things", cfg.jaegerURL, logger)
+	thingsTracer, thingsCloser := jaeger.Init("converters_things", cfg.jaegerURL, logger)
 	defer thingsCloser.Close()
 
 	pub, err := brokers.NewPublisher(cfg.brokerURL)
@@ -93,6 +100,15 @@ func main() {
 	defer pub.Close()
 
 	tc := thingsapi.NewClient(conn, thingsTracer, cfg.thingsGRPCTimeout)
+
+	authTracer, authCloser := jaeger.Init("converters_auth", cfg.jaegerURL, logger)
+	defer authCloser.Close()
+
+	authConn := clientsgrpc.Connect(cfg.authConfig, logger)
+	defer authConn.Close()
+
+	auth := authapi.NewClient(authConn, authTracer, cfg.authGRPCTimeout)
+
 	svc := adapter.New(pub, tc)
 
 	svc = api.LoggingMiddleware(svc, logger)
@@ -113,7 +129,7 @@ func main() {
 	)
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, api.MakeHandler(svc, httpTracer, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, api.MakeHandler(svc, auth, httpTracer, logger), cfg.httpConfig, logger)
 	})
 	g.Go(func() error {
 		if sig := errors.SignalHandler(ctx); sig != nil {
@@ -146,6 +162,11 @@ func loadConfig() config {
 		StopWaitTime: stopWaitTime,
 	}
 
+	authGRPCTimeout, err := time.ParseDuration(mainflux.Env(envAuthGRPCTimeout, defAuthGRPCTimeout))
+	if err != nil {
+		log.Fatalf("Invalid %s value: %s", envAuthGRPCTimeout, err.Error())
+	}
+
 	thingsConfig := clients.Config{
 		ClientTLS:  tls,
 		CaCerts:    mainflux.Env(envCACerts, defCACerts),
@@ -153,12 +174,21 @@ func loadConfig() config {
 		ClientName: clients.Things,
 	}
 
+	authConfig := clients.Config{
+		ClientTLS:  tls,
+		CaCerts:    mainflux.Env(envCACerts, defCACerts),
+		URL:        mainflux.Env(envAuthGRPCURL, defAuthGRPCURL),
+		ClientName: clients.Auth,
+	}
+
 	return config{
 		httpConfig:        httpConfig,
 		thingsConfig:      thingsConfig,
+		authConfig:        authConfig,
 		logLevel:          mainflux.Env(envLogLevel, defLogLevel),
 		jaegerURL:         mainflux.Env(envJaegerURL, defJaegerURL),
 		brokerURL:         mainflux.Env(envBrokerURL, defBrokerURL),
 		thingsGRPCTimeout: thingsGRPCTimeout,
+		authGRPCTimeout:   authGRPCTimeout,
 	}
 }

--- a/cmd/downlinks/main.go
+++ b/cmd/downlinks/main.go
@@ -159,7 +159,7 @@ func main() {
 	})
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(downlinksTracer, svc, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(downlinksTracer, svc, auth, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {

--- a/cmd/filestore/main.go
+++ b/cmd/filestore/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux"
+	authapi "github.com/MainfluxLabs/mainflux/auth/api/grpc"
 	"github.com/MainfluxLabs/mainflux/filestore"
 	"github.com/MainfluxLabs/mainflux/filestore/api"
 	httpapi "github.com/MainfluxLabs/mainflux/filestore/api/http"
@@ -51,6 +52,8 @@ const (
 	defCACerts           = ""
 	defThingsAuthURL     = "localhost:8183"
 	defThingsAuthTimeout = "1s"
+	defAuthGRPCURL       = "localhost:8181"
+	defAuthGRPCTimeout   = "1s"
 	defClientTLS         = "false"
 	defDBHost            = "localhost"
 	defDBPort            = "5432"
@@ -81,6 +84,8 @@ const (
 	envClientTLS         = "MF_FILESTORE_TLS"
 	envThingsAuthURL     = "MF_THINGS_AUTH_GRPC_URL"
 	envThingsAuthTimeout = "MF_THINGS_AUTH_GRPC_TIMEOUT"
+	envAuthGRPCURL       = "MF_AUTH_GRPC_URL"
+	envAuthGRPCTimeout   = "MF_AUTH_GRPC_TIMEOUT"
 	envESURL             = "MF_FILESTORE_ES_URL"
 )
 
@@ -88,9 +93,11 @@ type config struct {
 	logLevel          string
 	jaegerURL         string
 	thingsAuthTimeout time.Duration
+	authGRPCTimeout   time.Duration
 	dbConfig          postgres.Config
 	httpConfig        servers.Config
 	thingsConfig      clients.Config
+	authConfig        clients.Config
 	esURL             string
 }
 
@@ -124,6 +131,14 @@ func main() {
 
 	thingsAuth := thingsapi.NewClient(thingsAuthConn, thingsTracer, cfg.thingsAuthTimeout)
 
+	authTracer, authCloser := jaeger.Init("filestore_auth", cfg.jaegerURL, logger)
+	defer authCloser.Close()
+
+	authConn := clientsgrpc.Connect(cfg.authConfig, logger)
+	defer authConn.Close()
+
+	auth := authapi.NewClient(authConn, authTracer, cfg.authGRPCTimeout)
+
 	dbTracer, dbCloser := jaeger.Init("filestore_db", cfg.jaegerURL, logger)
 	defer dbCloser.Close()
 
@@ -134,7 +149,7 @@ func main() {
 	})
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(fileStoreTracer, svc, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(fileStoreTracer, svc, auth, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {
@@ -181,6 +196,11 @@ func loadConfig() config {
 		StopWaitTime: stopWaitTime,
 	}
 
+	authGRPCTimeout, err := time.ParseDuration(mainflux.Env(envAuthGRPCTimeout, defAuthGRPCTimeout))
+	if err != nil {
+		log.Fatalf("Invalid %s value: %s", envAuthGRPCTimeout, err.Error())
+	}
+
 	thingsConfig := clients.Config{
 		ClientTLS:  tls,
 		CaCerts:    mainflux.Env(envCACerts, defCACerts),
@@ -188,13 +208,22 @@ func loadConfig() config {
 		ClientName: clients.Things,
 	}
 
+	authConfig := clients.Config{
+		ClientTLS:  tls,
+		CaCerts:    mainflux.Env(envCACerts, defCACerts),
+		URL:        mainflux.Env(envAuthGRPCURL, defAuthGRPCURL),
+		ClientName: clients.Auth,
+	}
+
 	return config{
 		logLevel:          mainflux.Env(envLogLevel, defLogLevel),
 		jaegerURL:         mainflux.Env(envJaegerURL, defJaegerURL),
 		thingsAuthTimeout: thingsAuthTimeout,
+		authGRPCTimeout:   authGRPCTimeout,
 		dbConfig:          dbConfig,
 		httpConfig:        httpConfig,
 		thingsConfig:      thingsConfig,
+		authConfig:        authConfig,
 		esURL:             mainflux.Env(envESURL, defESURL),
 	}
 }

--- a/cmd/modbus/main.go
+++ b/cmd/modbus/main.go
@@ -14,6 +14,7 @@ import (
 	_ "time/tzdata"
 
 	"github.com/MainfluxLabs/mainflux"
+	authapi "github.com/MainfluxLabs/mainflux/auth/api/grpc"
 	"github.com/MainfluxLabs/mainflux/modbus"
 	"github.com/MainfluxLabs/mainflux/modbus/api"
 	"github.com/MainfluxLabs/mainflux/modbus/events"
@@ -66,6 +67,8 @@ const (
 	defServerKey         = ""
 	defThingsGRPCURL     = "localhost:8183"
 	defThingsGRPCTimeout = "1s"
+	defAuthGRPCURL       = "localhost:8181"
+	defAuthGRPCTimeout   = "1s"
 	defESURL             = "redis://localhost:6379/0"
 
 	envLogLevel          = "MF_MODBUS_LOG_LEVEL"
@@ -87,6 +90,8 @@ const (
 	envBrokerURL         = "MF_BROKER_URL"
 	envThingsGRPCURL     = "MF_THINGS_AUTH_GRPC_URL"
 	envThingsGRPCTimeout = "MF_THINGS_AUTH_GRPC_TIMEOUT"
+	envAuthGRPCURL       = "MF_AUTH_GRPC_URL"
+	envAuthGRPCTimeout   = "MF_AUTH_GRPC_TIMEOUT"
 	envESURL             = "MF_MODBUS_ES_URL"
 )
 
@@ -95,9 +100,11 @@ type config struct {
 	dbConfig          postgres.Config
 	httpConfig        servers.Config
 	thingsConfig      clients.Config
+	authConfig        clients.Config
 	jaegerURL         string
 	brokerURL         string
 	thingsGRPCTimeout time.Duration
+	authGRPCTimeout   time.Duration
 	esURL             string
 }
 
@@ -122,6 +129,14 @@ func main() {
 
 	things := thingsapi.NewClient(thingsConn, thingsTracer, cfg.thingsGRPCTimeout)
 
+	authTracer, authCloser := jaeger.Init("modbus_auth", cfg.jaegerURL, logger)
+	defer authCloser.Close()
+
+	authConn := clientsgrpc.Connect(cfg.authConfig, logger)
+	defer authConn.Close()
+
+	auth := authapi.NewClient(authConn, authTracer, cfg.authGRPCTimeout)
+
 	dbTracer, dbCloser := jaeger.Init("modbus_db", cfg.jaegerURL, logger)
 	defer dbCloser.Close()
 
@@ -142,7 +157,7 @@ func main() {
 	})
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(modbusTracer, svc, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(modbusTracer, svc, auth, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {
@@ -193,6 +208,11 @@ func loadConfig() config {
 		StopWaitTime: stopWaitTime,
 	}
 
+	authGRPCTimeout, err := time.ParseDuration(mainflux.Env(envAuthGRPCTimeout, defAuthGRPCTimeout))
+	if err != nil {
+		log.Fatalf("Invalid %s value: %s", envAuthGRPCTimeout, err.Error())
+	}
+
 	thingsConfig := clients.Config{
 		ClientTLS:  tls,
 		CaCerts:    mainflux.Env(envCACerts, defCACerts),
@@ -200,14 +220,23 @@ func loadConfig() config {
 		ClientName: clients.Things,
 	}
 
+	authConfig := clients.Config{
+		ClientTLS:  tls,
+		CaCerts:    mainflux.Env(envCACerts, defCACerts),
+		URL:        mainflux.Env(envAuthGRPCURL, defAuthGRPCURL),
+		ClientName: clients.Auth,
+	}
+
 	return config{
 		logLevel:          mainflux.Env(envLogLevel, defLogLevel),
 		dbConfig:          dbConfig,
 		httpConfig:        httpConfig,
 		thingsConfig:      thingsConfig,
+		authConfig:        authConfig,
 		jaegerURL:         mainflux.Env(envJaegerURL, defJaegerURL),
 		brokerURL:         mainflux.Env(envBrokerURL, defBrokerURL),
 		thingsGRPCTimeout: thingsAuthGRPCTimeout,
+		authGRPCTimeout:   authGRPCTimeout,
 		esURL:             mainflux.Env(envESURL, defESURL),
 	}
 }

--- a/cmd/mqtt/main.go
+++ b/cmd/mqtt/main.go
@@ -249,7 +249,7 @@ func main() {
 	})
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, mqttapihttp.MakeHandler(mqttTracer, svc, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, mqttapihttp.MakeHandler(mqttTracer, svc, usersAuth, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {

--- a/cmd/postgres-reader/main.go
+++ b/cmd/postgres-reader/main.go
@@ -140,7 +140,7 @@ func main() {
 	svc := newService(db, dbTracer, auth, tc, logger)
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(svc, postgresHttpTracer, svcName, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(svc, auth, postgresHttpTracer, svcName, logger), cfg.httpConfig, logger)
 	})
 
 	postgresGRPCTracer, postgresGRPCCloser := jaeger.Init("postgres_grpc", cfg.jaegerURL, logger)

--- a/cmd/rules/main.go
+++ b/cmd/rules/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux"
+	authapi "github.com/MainfluxLabs/mainflux/auth/api/grpc"
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/clients"
@@ -62,6 +63,8 @@ const (
 	defThingsGRPCTimeout  = "1s"
 	defReadersGRPCURL     = "localhost:8186"
 	defReadersGRPCTimeout = "1s"
+	defAuthGRPCURL        = "localhost:8181"
+	defAuthGRPCTimeout    = "1s"
 	defESURL              = "redis://localhost:6379/0"
 	defScriptsEnabled     = "false"
 
@@ -86,6 +89,8 @@ const (
 	envThingsGRPCTimeout  = "MF_THINGS_AUTH_GRPC_TIMEOUT"
 	envReadersGRPCURL     = "MF_POSTGRES_READER_GRPC_URL"
 	envReadersGRPCTimeout = "MF_POSTGRES_READER_GRPC_TIMEOUT"
+	envAuthGRPCURL        = "MF_AUTH_GRPC_URL"
+	envAuthGRPCTimeout    = "MF_AUTH_GRPC_TIMEOUT"
 	envESURL              = "MF_RULES_ES_URL"
 	envScriptsEnabled     = "MF_RULES_SCRIPTS_ENABLED"
 )
@@ -97,9 +102,11 @@ type config struct {
 	httpConfig         servers.Config
 	thingsConfig       clients.Config
 	readersConfig      clients.Config
+	authConfig         clients.Config
 	jaegerURL          string
 	thingsGRPCTimeout  time.Duration
 	readersGRPCTimeout time.Duration
+	authGRPCTimeout    time.Duration
 	esURL              string
 	scriptsEnabled     bool
 }
@@ -145,6 +152,14 @@ func main() {
 
 	rc := readersapi.NewClient(readersConn, readersTracer, cfg.readersGRPCTimeout)
 
+	authTracer, authCloser := jaeger.Init("rules_auth", cfg.jaegerURL, logger)
+	defer authCloser.Close()
+
+	authConn := clientsgrpc.Connect(cfg.authConfig, logger)
+	defer authConn.Close()
+
+	auth := authapi.NewClient(authConn, authTracer, cfg.authGRPCTimeout)
+
 	svc := newService(dbTracer, db, tc, rc, ps, logger, cfg.scriptsEnabled)
 
 	subjects := []string{nats.SubjectMessages, nats.SubjectMessagesWithSubtopic}
@@ -153,7 +168,7 @@ func main() {
 	}
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(rulesHttpTracer, svc, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(rulesHttpTracer, svc, auth, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {
@@ -193,6 +208,11 @@ func loadConfig() config {
 		log.Fatalf("Invalid %s value: %s", envReadersGRPCTimeout, err.Error())
 	}
 
+	authGRPCTimeout, err := time.ParseDuration(mainflux.Env(envAuthGRPCTimeout, defAuthGRPCTimeout))
+	if err != nil {
+		log.Fatalf("Invalid %s value: %s", envAuthGRPCTimeout, err.Error())
+	}
+
 	dbConfig := postgres.Config{
 		Host:        mainflux.Env(envDBHost, defDBHost),
 		Port:        mainflux.Env(envDBPort, defDBPort),
@@ -227,6 +247,13 @@ func loadConfig() config {
 		ClientName: clients.Readers,
 	}
 
+	authConfig := clients.Config{
+		ClientTLS:  tls,
+		CaCerts:    mainflux.Env(envCACerts, defCACerts),
+		URL:        mainflux.Env(envAuthGRPCURL, defAuthGRPCURL),
+		ClientName: clients.Auth,
+	}
+
 	return config{
 		brokerURL:          mainflux.Env(envBrokerURL, defBrokerURL),
 		logLevel:           mainflux.Env(envLogLevel, defLogLevel),
@@ -234,9 +261,11 @@ func loadConfig() config {
 		httpConfig:         httpConfig,
 		thingsConfig:       thingsConfig,
 		readersConfig:      readersConfig,
+		authConfig:         authConfig,
 		jaegerURL:          mainflux.Env(envJaegerURL, defJaegerURL),
 		thingsGRPCTimeout:  thingsGRPCTimeout,
 		readersGRPCTimeout: readersGRPCTimeout,
+		authGRPCTimeout:    authGRPCTimeout,
 		esURL:              mainflux.Env(envESURL, defESURL),
 		scriptsEnabled:     scriptsEnabled,
 	}

--- a/cmd/smpp-notifier/main.go
+++ b/cmd/smpp-notifier/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux"
+	authapi "github.com/MainfluxLabs/mainflux/auth/api/grpc"
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/consumers/notifiers"
 	"github.com/MainfluxLabs/mainflux/consumers/notifiers/api"
@@ -65,6 +66,8 @@ const (
 	defServerKey         = ""
 	defThingsGRPCURL     = "localhost:8183"
 	defThingsGRPCTimeout = "1s"
+	defAuthGRPCURL       = "localhost:8181"
+	defAuthGRPCTimeout   = "1s"
 	defESURL             = "redis://localhost:6379/0"
 
 	defAddress    = ""
@@ -96,6 +99,8 @@ const (
 	envServerKey         = "MF_SMPP_NOTIFIER_SERVER_KEY"
 	envThingsGRPCURL     = "MF_THINGS_AUTH_GRPC_URL"
 	envThingsGRPCTimeout = "MF_THINGS_AUTH_GRPC_TIMEOUT"
+	envAuthGRPCURL       = "MF_AUTH_GRPC_URL"
+	envAuthGRPCTimeout   = "MF_AUTH_GRPC_TIMEOUT"
 	envESURL             = "MF_SMPP_NOTIFIER_ES_URL"
 
 	envAddress    = "MF_SMPP_ADDRESS"
@@ -114,10 +119,12 @@ type config struct {
 	dbConfig          postgres.Config
 	httpConfig        servers.Config
 	thingsConfig      clients.Config
+	authConfig        clients.Config
 	smppConf          mfsmpp.Config
 	from              string
 	jaegerURL         string
 	thingsGRPCTimeout time.Duration
+	authGRPCTimeout   time.Duration
 	esURL             string
 }
 
@@ -152,6 +159,14 @@ func main() {
 
 	tc := thingsapi.NewClient(thConn, thingsTracer, cfg.thingsGRPCTimeout)
 
+	authTracer, authCloser := jaeger.Init("smpp_auth", cfg.jaegerURL, logger)
+	defer authCloser.Close()
+
+	authConn := clientsgrpc.Connect(cfg.authConfig, logger)
+	defer authConn.Close()
+
+	auth := authapi.NewClient(authConn, authTracer, cfg.authGRPCTimeout)
+
 	dbTracer, dbCloser := jaeger.Init("smpp_db", cfg.jaegerURL, logger)
 	defer dbCloser.Close()
 
@@ -162,7 +177,7 @@ func main() {
 	}
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(notifiersTracer, svc, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(notifiersTracer, svc, auth, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {
@@ -242,11 +257,23 @@ func loadConfig() config {
 		StopWaitTime: stopWaitTime,
 	}
 
+	authGRPCTimeout, err := time.ParseDuration(mainflux.Env(envAuthGRPCTimeout, defAuthGRPCTimeout))
+	if err != nil {
+		log.Fatalf("Invalid %s value: %s", envAuthGRPCTimeout, err.Error())
+	}
+
 	thingsConfig := clients.Config{
 		ClientTLS:  thingsTLS,
 		CaCerts:    mainflux.Env(envThingsCACerts, defThingsCACerts),
 		URL:        mainflux.Env(envThingsGRPCURL, defThingsGRPCURL),
 		ClientName: clients.Things,
+	}
+
+	authConfig := clients.Config{
+		ClientTLS:  thingsTLS,
+		CaCerts:    mainflux.Env(envThingsCACerts, defThingsCACerts),
+		URL:        mainflux.Env(envAuthGRPCURL, defAuthGRPCURL),
+		ClientName: clients.Auth,
 	}
 
 	return config{
@@ -256,9 +283,11 @@ func loadConfig() config {
 		dbConfig:          dbConfig,
 		httpConfig:        httpConfig,
 		thingsConfig:      thingsConfig,
+		authConfig:        authConfig,
 		from:              mainflux.Env(envFrom, defFrom),
 		jaegerURL:         mainflux.Env(envJaegerURL, defJaegerURL),
 		thingsGRPCTimeout: thingsGRPCTimeout,
+		authGRPCTimeout:   authGRPCTimeout,
 		esURL:             mainflux.Env(envESURL, defESURL),
 	}
 

--- a/cmd/smtp-notifier/main.go
+++ b/cmd/smtp-notifier/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux"
+	authapi "github.com/MainfluxLabs/mainflux/auth/api/grpc"
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/consumers/notifiers"
 	"github.com/MainfluxLabs/mainflux/consumers/notifiers/api"
@@ -66,6 +67,8 @@ const (
 	defServerKey         = ""
 	defThingsGRPCURL     = "localhost:8183"
 	defThingsGRPCTimeout = "1s"
+	defAuthGRPCURL       = "localhost:8181"
+	defAuthGRPCTimeout   = "1s"
 	defESURL             = "redis://localhost:6379/0"
 
 	defEmailHost         = "localhost"
@@ -96,6 +99,8 @@ const (
 	envServerKey         = "MF_SMTP_NOTIFIER_SERVER_KEY"
 	envThingsGRPCURL     = "MF_THINGS_AUTH_GRPC_URL"
 	envThingsGRPCTimeout = "MF_THINGS_AUTH_GRPC_TIMEOUT"
+	envAuthGRPCURL       = "MF_AUTH_GRPC_URL"
+	envAuthGRPCTimeout   = "MF_AUTH_GRPC_TIMEOUT"
 	envESURL             = "MF_SMTP_NOTIFIER_ES_URL"
 
 	envEmailHost         = "MF_EMAIL_HOST"
@@ -113,10 +118,12 @@ type config struct {
 	dbConfig          postgres.Config
 	httpConfig        servers.Config
 	thingsConfig      clients.Config
+	authConfig        clients.Config
 	emailConf         email.Config
 	from              string
 	jaegerURL         string
 	thingsGRPCTimeout time.Duration
+	authGRPCTimeout   time.Duration
 	esURL             string
 }
 
@@ -151,6 +158,14 @@ func main() {
 
 	tc := thingsapi.NewClient(thConn, thingsTracer, cfg.thingsGRPCTimeout)
 
+	authTracer, authCloser := jaeger.Init("smtp_auth", cfg.jaegerURL, logger)
+	defer authCloser.Close()
+
+	authConn := clientsgrpc.Connect(cfg.authConfig, logger)
+	defer authConn.Close()
+
+	auth := authapi.NewClient(authConn, authTracer, cfg.authGRPCTimeout)
+
 	dbTracer, dbCloser := jaeger.Init("smtp_db", cfg.jaegerURL, logger)
 	defer dbCloser.Close()
 
@@ -161,7 +176,7 @@ func main() {
 	}
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(notifiersTracer, svc, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(notifiersTracer, svc, auth, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {
@@ -223,11 +238,23 @@ func loadConfig() config {
 		StopWaitTime: stopWaitTime,
 	}
 
+	authGRPCTimeout, err := time.ParseDuration(mainflux.Env(envAuthGRPCTimeout, defAuthGRPCTimeout))
+	if err != nil {
+		log.Fatalf("Invalid %s value: %s", envAuthGRPCTimeout, err.Error())
+	}
+
 	thingsConfig := clients.Config{
 		ClientTLS:  thingsTLS,
 		CaCerts:    mainflux.Env(envThingsCACerts, defThingsCACerts),
 		URL:        mainflux.Env(envThingsGRPCURL, defThingsGRPCURL),
 		ClientName: clients.Things,
+	}
+
+	authConfig := clients.Config{
+		ClientTLS:  thingsTLS,
+		CaCerts:    mainflux.Env(envThingsCACerts, defThingsCACerts),
+		URL:        mainflux.Env(envAuthGRPCURL, defAuthGRPCURL),
+		ClientName: clients.Auth,
 	}
 
 	return config{
@@ -237,9 +264,11 @@ func loadConfig() config {
 		dbConfig:          dbConfig,
 		httpConfig:        httpConfig,
 		thingsConfig:      thingsConfig,
+		authConfig:        authConfig,
 		from:              mainflux.Env(envFrom, defFrom),
 		jaegerURL:         mainflux.Env(envJaegerURL, defJaegerURL),
 		thingsGRPCTimeout: thingsGRPCTimeout,
+		authGRPCTimeout:   authGRPCTimeout,
 		esURL:             mainflux.Env(envESURL, defESURL),
 	}
 

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -217,11 +217,11 @@ func main() {
 	svc := newService(auth, users, dbTracer, cacheTracer, db, cacheClient, pub, logger, cfg)
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(svc, thingsHttpTracer, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(svc, auth, thingsHttpTracer, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(svc, thingsHttpTracer, logger), cfg.authHttpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(svc, auth, thingsHttpTracer, logger), cfg.authHttpConfig, logger)
 	})
 
 	g.Go(func() error {

--- a/cmd/timescale-reader/main.go
+++ b/cmd/timescale-reader/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/clients"
 	clientsgrpc "github.com/MainfluxLabs/mainflux/pkg/clients/grpc"
-	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	mfevents "github.com/MainfluxLabs/mainflux/pkg/events"
@@ -131,7 +130,7 @@ func main() {
 	svc := newService(db, dbTracer, auth, tc, logger)
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(svc, timescaleHttpTracer, svcName, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(svc, auth, timescaleHttpTracer, svcName, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {
@@ -243,9 +242,7 @@ func connectToDB(dbConfig timescale.Config, logger logger.Logger) *sqlx.DB {
 }
 
 func newService(db *sqlx.DB, dbTracer opentracing.Tracer, ac domain.AuthClient, tc domain.ThingsClient, logger logger.Logger) readers.Service {
-	database := dbutil.NewDatabase(db)
-
-	jsonRepo := timescale.NewJSONRepository(database)
+	jsonRepo := timescale.NewJSONRepository(db)
 	jsonRepo = tracing.JSONRepositoryMiddleware(dbTracer, jsonRepo)
 
 	senmlRepo := timescale.NewSenMLRepository(db)

--- a/cmd/uiconfigs/main.go
+++ b/cmd/uiconfigs/main.go
@@ -149,7 +149,7 @@ func main() {
 	})
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(uiTracer, svc, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(uiTracer, svc, auth, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {

--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -199,7 +199,7 @@ func main() {
 	svc := newService(db, dbTracer, auth, cfg, logger)
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(svc, usersHttpTracer, logger, cfg.passRegex), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(svc, auth, usersHttpTracer, logger, cfg.passRegex), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {

--- a/cmd/webhooks/main.go
+++ b/cmd/webhooks/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux"
+	authapi "github.com/MainfluxLabs/mainflux/auth/api/grpc"
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/clients"
@@ -67,6 +68,8 @@ const (
 	defServerKey         = ""
 	defThingsGRPCURL     = "localhost:8183"
 	defThingsGRPCTimeout = "1s"
+	defAuthGRPCURL       = "localhost:8181"
+	defAuthGRPCTimeout   = "1s"
 	defESURL             = "redis://localhost:6379/0"
 
 	envBrokerURL         = "MF_BROKER_URL"
@@ -88,6 +91,8 @@ const (
 	envJaegerURL         = "MF_JAEGER_URL"
 	envThingsGRPCURL     = "MF_THINGS_AUTH_GRPC_URL"
 	envThingsGRPCTimeout = "MF_THINGS_AUTH_GRPC_TIMEOUT"
+	envAuthGRPCURL       = "MF_AUTH_GRPC_URL"
+	envAuthGRPCTimeout   = "MF_AUTH_GRPC_TIMEOUT"
 	envESURL             = "MF_WEBHOOKS_ES_URL"
 )
 
@@ -97,8 +102,10 @@ type config struct {
 	dbConfig          postgres.Config
 	httpConfig        servers.Config
 	thingsConfig      clients.Config
+	authConfig        clients.Config
 	jaegerURL         string
 	thingsGRPCTimeout time.Duration
+	authGRPCTimeout   time.Duration
 	esURL             string
 }
 
@@ -133,6 +140,14 @@ func main() {
 
 	things := thingsapi.NewClient(thingsConn, thingsTracer, cfg.thingsGRPCTimeout)
 
+	authTracer, authCloser := jaeger.Init("webhooks_auth", cfg.jaegerURL, logger)
+	defer authCloser.Close()
+
+	authConn := clientsgrpc.Connect(cfg.authConfig, logger)
+	defer authConn.Close()
+
+	auth := authapi.NewClient(authConn, authTracer, cfg.authGRPCTimeout)
+
 	dbTracer, dbCloser := jaeger.Init("webhooks_db", cfg.jaegerURL, logger)
 	defer dbCloser.Close()
 
@@ -147,7 +162,7 @@ func main() {
 	}
 
 	g.Go(func() error {
-		return servershttp.Start(ctx, httpapi.MakeHandler(webhooksTracer, svc, logger), cfg.httpConfig, logger)
+		return servershttp.Start(ctx, httpapi.MakeHandler(webhooksTracer, svc, auth, logger), cfg.httpConfig, logger)
 	})
 
 	g.Go(func() error {
@@ -194,11 +209,23 @@ func loadConfig() config {
 		StopWaitTime: stopWaitTime,
 	}
 
+	authGRPCTimeout, err := time.ParseDuration(mainflux.Env(envAuthGRPCTimeout, defAuthGRPCTimeout))
+	if err != nil {
+		log.Fatalf("Invalid %s value: %s", envAuthGRPCTimeout, err.Error())
+	}
+
 	thingsConfig := clients.Config{
 		ClientTLS:  tls,
 		CaCerts:    mainflux.Env(envCACerts, defCACerts),
 		URL:        mainflux.Env(envThingsGRPCURL, defThingsGRPCURL),
 		ClientName: clients.Things,
+	}
+
+	authConfig := clients.Config{
+		ClientTLS:  tls,
+		CaCerts:    mainflux.Env(envCACerts, defCACerts),
+		URL:        mainflux.Env(envAuthGRPCURL, defAuthGRPCURL),
+		ClientName: clients.Auth,
 	}
 
 	return config{
@@ -207,8 +234,10 @@ func loadConfig() config {
 		dbConfig:          dbConfig,
 		httpConfig:        httpConfig,
 		thingsConfig:      thingsConfig,
+		authConfig:        authConfig,
 		jaegerURL:         mainflux.Env(envJaegerURL, defJaegerURL),
 		thingsGRPCTimeout: thingsAuthGRPCTimeout,
+		authGRPCTimeout:   authGRPCTimeout,
 		esURL:             mainflux.Env(envESURL, defESURL),
 	}
 }

--- a/consumers/alarms/api/http/endpoint_test.go
+++ b/consumers/alarms/api/http/endpoint_test.go
@@ -80,7 +80,8 @@ func newService() alarms.Service {
 
 func newHTTPServer(svc alarms.Service) *httptest.Server {
 	log := logger.NewMock()
-	mux := httpapi.MakeHandler(mocktracer.New(), svc, log)
+	ac := pkgmocks.NewAuthService("", nil, nil)
+	mux := httpapi.MakeHandler(mocktracer.New(), svc, ac, log)
 	return httptest.NewServer(mux)
 }
 

--- a/consumers/alarms/api/http/transport.go
+++ b/consumers/alarms/api/http/transport.go
@@ -10,8 +10,11 @@ import (
 	"github.com/MainfluxLabs/mainflux/consumers/alarms"
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -29,57 +32,81 @@ const (
 )
 
 // MakeHandler returns a HTTP handler for Alarm API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc alarms.Service, logger log.Logger) http.Handler {
+func MakeHandler(tracer opentracing.Tracer, svc alarms.Service, ac domain.AuthClient, logger log.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
 	r := bone.New()
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	r.Get("/things/:id/alarms", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_alarms_by_thing")(listAlarmsByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_alarms_by_thing"),
+			withIdentity,
+		)(listAlarmsByThingEndpoint(svc)),
 		decodeListAlarmsByThing,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Get("/groups/:id/alarms", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_alarms_by_group")(listAlarmsByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_alarms_by_group"),
+			withIdentity,
+		)(listAlarmsByGroupEndpoint(svc)),
 		decodeListGroupAlarms,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Get("/orgs/:id/alarms", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_alarms_by_org")(listAlarmsByOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_alarms_by_org"),
+			withIdentity,
+		)(listAlarmsByOrgEndpoint(svc)),
 		decodeListAlarmsByOrg,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Get("/alarms/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_alarm")(viewAlarmEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_alarm"),
+			withIdentity,
+		)(viewAlarmEndpoint(svc)),
 		decodeViewAlarm,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Patch("/alarms/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_alarm_status")(updateAlarmStatusEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_alarm_status"),
+			withIdentity,
+		)(updateAlarmStatusEndpoint(svc)),
 		decodeUpdateAlarmStatus,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Patch("/alarms", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_alarms")(removeAlarmsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_alarms"),
+			withIdentity,
+		)(removeAlarmsEndpoint(svc)),
 		decodeRemoveAlarms,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Get("/things/:id/alarms/export", kithttp.NewServer(
-		kitot.TraceServer(tracer, "export_alarms_by_thing")(exportAlarmsByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "export_alarms_by_thing"),
+			withIdentity,
+		)(exportAlarmsByThingEndpoint(svc)),
 		decodeExportAlarmsByThing,
 		encodeFileResponse,
 		opts...,

--- a/consumers/notifiers/api/http/endpoint_test.go
+++ b/consumers/notifiers/api/http/endpoint_test.go
@@ -64,7 +64,8 @@ var (
 
 func newHTTPServer(svc notifiers.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(mocktracer.New(), svc, logger)
+	ac := mocks.NewAuthService("", nil, nil)
+	mux := httpapi.MakeHandler(mocktracer.New(), svc, ac, logger)
 	return httptest.NewServer(mux)
 }
 

--- a/consumers/notifiers/api/http/transport.go
+++ b/consumers/notifiers/api/http/transport.go
@@ -13,8 +13,11 @@ import (
 	"github.com/MainfluxLabs/mainflux/consumers/notifiers"
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -27,47 +30,67 @@ const (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc notifiers.Service, logger log.Logger) http.Handler {
-
+func MakeHandler(tracer opentracing.Tracer, svc notifiers.Service, ac domain.AuthClient, logger log.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
 	r := bone.New()
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	r.Post("/groups/:id/notifiers", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_notifiers")(createNotifiersEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_notifiers"),
+			withIdentity,
+		)(createNotifiersEndpoint(svc)),
 		decodeCreateNotifiers,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/groups/:id/notifiers", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_notifiers_by_group")(listNotifiersByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_notifiers_by_group"),
+			withIdentity,
+		)(listNotifiersByGroupEndpoint(svc)),
 		decodeListNotifiers,
 		encodeResponse,
 		opts...,
 	))
 	r.Post("/groups/:id/notifiers/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_notifiers_by_group")(listNotifiersByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_notifiers_by_group"),
+			withIdentity,
+		)(listNotifiersByGroupEndpoint(svc)),
 		decodeSearchNotifiers,
 		encodeResponse,
 		opts...,
 	))
 
 	r.Get("/notifiers/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_notifier")(viewNotifierEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_notifier"),
+			withIdentity,
+		)(viewNotifierEndpoint(svc)),
 		decodeRequest,
 		encodeResponse,
 		opts...,
 	))
 	r.Put("/notifiers/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_notifier")(updateNotifierEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_notifier"),
+			withIdentity,
+		)(updateNotifierEndpoint(svc)),
 		decodeUpdateNotifier,
 		encodeResponse,
 		opts...,
 	))
 	r.Patch("/notifiers", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_notifiers")(removeNotifiersEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_notifiers"),
+			withIdentity,
+		)(removeNotifiersEndpoint(svc)),
 		decodeRemoveNotifiers,
 		encodeResponse,
 		opts...,

--- a/converters/api/transport.go
+++ b/converters/api/transport.go
@@ -13,6 +13,8 @@ import (
 	adapter "github.com/MainfluxLabs/mainflux/converters"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
@@ -31,9 +33,10 @@ const (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc adapter.Service, tracer opentracing.Tracer, logger logger.Logger) http.Handler {
+func MakeHandler(svc adapter.Service, ac domain.AuthClient, tracer opentracing.Tracer, logger logger.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
 	r := bone.New()

--- a/downlinks/api/http/backup/transport.go
+++ b/downlinks/api/http/backup/transport.go
@@ -13,7 +13,10 @@ import (
 	"github.com/MainfluxLabs/mainflux/downlinks"
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -21,20 +24,29 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for backup API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc downlinks.Service, mux *bone.Mux, logger log.Logger) *bone.Mux {
+func MakeHandler(tracer opentracing.Tracer, svc downlinks.Service, ac domain.AuthClient, mux *bone.Mux, logger log.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Get("/backup", kithttp.NewServer(
-		kitot.TraceServer(tracer, "backup")(backupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "backup"),
+			withIdentity,
+		)(backupEndpoint(svc)),
 		decodeBackupRequest,
 		apiutil.EncodeFileResponse,
 		opts...,
 	))
 
 	mux.Post("/restore", kithttp.NewServer(
-		kitot.TraceServer(tracer, "restore")(restoreEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "restore"),
+			withIdentity,
+		)(restoreEndpoint(svc)),
 		decodeRestoreRequest,
 		encodeResponse,
 		opts...,

--- a/downlinks/api/http/endpoint_test.go
+++ b/downlinks/api/http/endpoint_test.go
@@ -135,7 +135,8 @@ func newService() downlinks.Service {
 }
 
 func newHTTPServer(svc downlinks.Service) *httptest.Server {
-	mux := httpapi.MakeHandler(mocktracer.New(), svc, logger.NewMock())
+	ac := pkgmocks.NewAuthService(adminUser.ID, usersList, nil)
+	mux := httpapi.MakeHandler(mocktracer.New(), svc, ac, logger.NewMock())
 	return httptest.NewServer(mux)
 }
 

--- a/downlinks/api/http/transport.go
+++ b/downlinks/api/http/transport.go
@@ -14,7 +14,10 @@ import (
 	"github.com/MainfluxLabs/mainflux/downlinks/api/http/backup"
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -28,51 +31,72 @@ const (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc downlinks.Service, logger log.Logger) http.Handler {
+func MakeHandler(tracer opentracing.Tracer, svc downlinks.Service, ac domain.AuthClient, logger log.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
 	r := bone.New()
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	r.Post("/things/:id/downlinks", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_downlinks")(createDownlinksEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_downlinks"),
+			withIdentity,
+		)(createDownlinksEndpoint(svc)),
 		decodeCreateDownlinks,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/things/:id/downlinks", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_downlinks_by_thing")(listDownlinksByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_downlinks_by_thing"),
+			withIdentity,
+		)(listDownlinksByThingEndpoint(svc)),
 		decodeListThingDownlinks,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/groups/:id/downlinks", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_downlinks_by_group")(listDownlinksByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_downlinks_by_group"),
+			withIdentity,
+		)(listDownlinksByGroupEndpoint(svc)),
 		decodeListDownlinks,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/downlinks/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_downlink")(viewDownlinkEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_downlink"),
+			withIdentity,
+		)(viewDownlinkEndpoint(svc)),
 		decodeRequest,
 		encodeResponse,
 		opts...,
 	))
 	r.Put("/downlinks/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_downlink")(updateDownlinkEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_downlink"),
+			withIdentity,
+		)(updateDownlinkEndpoint(svc)),
 		decodeUpdateDownlink,
 		encodeResponse,
 		opts...,
 	))
 	r.Patch("/downlinks", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_downlinks")(removeDownlinksEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_downlinks"),
+			withIdentity,
+		)(removeDownlinksEndpoint(svc)),
 		decodeRemoveDownlinks,
 		encodeResponse,
 		opts...,
 	))
 
-	backup.MakeHandler(tracer, svc, r, logger)
+	backup.MakeHandler(tracer, svc, ac, r, logger)
 
 	r.GetFunc("/health", mainflux.Health("downlinks"))
 	r.Handle("/metrics", promhttp.Handler())

--- a/filestore/api/http/transport.go
+++ b/filestore/api/http/transport.go
@@ -15,8 +15,11 @@ import (
 	"github.com/MainfluxLabs/mainflux/filestore"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -73,12 +76,15 @@ const (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc filestore.Service, logger logger.Logger) http.Handler {
+func MakeHandler(tracer opentracing.Tracer, svc filestore.Service, ac domain.AuthClient, logger logger.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
 	r := bone.New()
+
+	withIdentity := authn.IdentityMiddleware(ac, logger)
 
 	r.Post("/files", kithttp.NewServer(
 		kitot.TraceServer(tracer, "save_file")(saveFileEndpoint(svc)),
@@ -111,25 +117,37 @@ func MakeHandler(tracer opentracing.Tracer, svc filestore.Service, logger logger
 		opts...,
 	))
 	r.Post("/groups/:id/files", kithttp.NewServer(
-		kitot.TraceServer(tracer, "save_group_file")(saveGroupFileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "save_group_file"),
+			withIdentity,
+		)(saveGroupFileEndpoint(svc)),
 		decodeSaveGroupFile,
 		encodeResponse,
 		opts...,
 	))
 	r.Put("/groups/:id/files/:name", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_group_file")(updateGroupFileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_group_file"),
+			withIdentity,
+		)(updateGroupFileEndpoint(svc)),
 		decodeUpdateGroupFile,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/groups/:id/files", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_group_files")(listGroupFilesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_group_files"),
+			withIdentity,
+		)(listGroupFilesEndpoint(svc)),
 		decodeListGroupFiles,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/groups/:id/files/:name", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_group_file")(viewGroupFileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_group_file"),
+			withIdentity,
+		)(viewGroupFileEndpoint(svc)),
 		decodeGroupFile,
 		encodeViewFileResponse,
 		opts...,
@@ -141,7 +159,10 @@ func MakeHandler(tracer opentracing.Tracer, svc filestore.Service, logger logger
 		opts...,
 	))
 	r.Delete("/groups/:id/files/:name", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_group_file")(removeGroupFileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_group_file"),
+			withIdentity,
+		)(removeGroupFileEndpoint(svc)),
 		decodeGroupFile,
 		encodeResponse,
 		opts...,

--- a/modbus/api/http/endpoint_test.go
+++ b/modbus/api/http/endpoint_test.go
@@ -141,7 +141,8 @@ func newService() modbus.Service {
 }
 
 func newHTTPServer(svc modbus.Service) *httptest.Server {
-	mux := httpapi.MakeHandler(mocktracer.New(), svc, logger.NewMock())
+	ac := pkgmocks.NewAuthService("", nil, nil)
+	mux := httpapi.MakeHandler(mocktracer.New(), svc, ac, logger.NewMock())
 	return httptest.NewServer(mux)
 }
 

--- a/modbus/api/http/transport.go
+++ b/modbus/api/http/transport.go
@@ -13,7 +13,10 @@ import (
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/modbus"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -28,45 +31,66 @@ const (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc modbus.Service, logger log.Logger) http.Handler {
+func MakeHandler(tracer opentracing.Tracer, svc modbus.Service, ac domain.AuthClient, logger log.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
 	r := bone.New()
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	r.Post("/things/:id/clients", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_clients")(createClientsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_clients"),
+			withIdentity,
+		)(createClientsEndpoint(svc)),
 		decodeCreateClients,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/things/:id/clients", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_clients_by_thing")(listClientsByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_clients_by_thing"),
+			withIdentity,
+		)(listClientsByThingEndpoint(svc)),
 		decodeListClientsByThing,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/groups/:id/clients", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_clients_by_group")(listClientsByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_clients_by_group"),
+			withIdentity,
+		)(listClientsByGroupEndpoint(svc)),
 		decodeListClientsByGroup,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/clients/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_client")(viewClientEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_client"),
+			withIdentity,
+		)(viewClientEndpoint(svc)),
 		decodeRequest,
 		encodeResponse,
 		opts...,
 	))
 	r.Put("/clients/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_client")(updateClientEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_client"),
+			withIdentity,
+		)(updateClientEndpoint(svc)),
 		decodeUpdateClient,
 		encodeResponse,
 		opts...,
 	))
 	r.Patch("/clients", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_clients")(removeClientsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_clients"),
+			withIdentity,
+		)(removeClientsEndpoint(svc)),
 		decodeRemoveClients,
 		encodeResponse,
 		opts...,

--- a/mqtt/api/http/transport.go
+++ b/mqtt/api/http/transport.go
@@ -12,6 +12,9 @@ import (
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/mqtt"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -20,15 +23,21 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc mqtt.Service, logger logger.Logger) http.Handler {
+func MakeHandler(tracer opentracing.Tracer, svc mqtt.Service, ac domain.AuthClient, logger logger.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
 	r := bone.New()
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	r.Get("/groups/:id/subscriptions", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_subscriptions")(listSubscriptionsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_subscriptions"),
+			withIdentity,
+		)(listSubscriptionsEndpoint(svc)),
 		decodeListSubscriptions,
 		encodeResponse,
 		opts...,

--- a/pkg/authn/decode.go
+++ b/pkg/authn/decode.go
@@ -4,9 +4,12 @@
 package authn
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"strings"
+
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 )
 
 // EmailFromToken extracts the email (subject) from a JWT token without
@@ -27,4 +30,17 @@ func EmailFromToken(token string) string {
 		return ""
 	}
 	return claims.Subject
+}
+
+// Used as a key under which a domain.Identity type is stored in a Context.
+type identityCtxKey struct{}
+
+// Used as a key under which an auth token string is stored in a Context.
+type tokenCtxKey struct{}
+
+// IdentityFromCtx extracts a domain.Identity associated with the passed Context, if it exists.
+func IdentityFromCtx(ctx context.Context) (domain.Identity, bool) {
+	identity, ok := ctx.Value(identityCtxKey{}).(domain.Identity)
+
+	return identity, ok
 }

--- a/pkg/authn/transport.go
+++ b/pkg/authn/transport.go
@@ -1,0 +1,43 @@
+package authn
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/MainfluxLabs/mainflux/auth"
+	"github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/go-kit/kit/endpoint"
+)
+
+// HTTPTokenToContext is a go-kit RequestFunc that extracts the authentication token from the HTTP header and returns a context derived
+// from ctx with the token value attached under the tokenKey{} key.
+func HTTPTokenToContext(ctx context.Context, req *http.Request) context.Context {
+	if token := apiutil.ExtractBearerToken(req); token != "" {
+		return context.WithValue(ctx, tokenCtxKey{}, token)
+	}
+
+	return ctx
+}
+
+// IdentityMiddleware returns a go-kit endpoint Middleware that attaches a domain.Identity associated with the authentication
+// token of the current request to the current context.
+func IdentityMiddleware(authn auth.Authn, log logger.Logger) endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request any) (any, error) {
+			token, _ := ctx.Value(tokenCtxKey{}).(string)
+			if token != "" {
+				identity, err := authn.Identify(ctx, token)
+				if err != nil {
+					log.Warn(fmt.Sprintf("error decoding token to identity: %v", err))
+					return next(ctx, request)
+				}
+
+				ctx = context.WithValue(ctx, identityCtxKey{}, identity)
+			}
+
+			return next(ctx, request)
+		}
+	}
+}

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -65,13 +65,13 @@ func newThingsService() things.Service {
 
 func newThingsServer(svc things.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, mocks.NewAuthService("", usersList, orgs), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 
 func newAuthServer(svc things.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, mocks.NewAuthService("", usersList, orgs), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -71,7 +71,7 @@ func newUserService() users.Service {
 
 func newUserServer(svc users.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger, passRegex)
+	mux := httpapi.MakeHandler(svc, mocks.NewAuthService(admin.ID, usersList, orgsList), mocktracer.New(), logger, passRegex)
 	return httptest.NewServer(mux)
 }
 

--- a/readers/api/http/backup/transport.go
+++ b/readers/api/http/backup/transport.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/readers"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -22,20 +25,29 @@ import (
 
 const octetStreamContentType = "application/octet-stream"
 
-func MakeHandler(svc readers.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
+func MakeHandler(svc readers.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Get("/backup", kithttp.NewServer(
-		kitot.TraceServer(tracer, "backup")(backupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "backup"),
+			withIdentity,
+		)(backupEndpoint(svc)),
 		decodeBackup,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/restore", kithttp.NewServer(
-		kitot.TraceServer(tracer, "restore")(restoreEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "restore"),
+			withIdentity,
+		)(restoreEndpoint(svc)),
 		decodeRestore,
 		encodeResponse,
 		opts...,

--- a/readers/api/http/messages/endpoint_test.go
+++ b/readers/api/http/messages/endpoint_test.go
@@ -65,7 +65,7 @@ func newServer(jsonMessages []mfjson.Message, senmlMessaages []senml.Message, tc
 	senmlRepo := rmocks.NewSenMLRepository("", fromSenml(senmlMessaages))
 	svc := readers.New(ac, tc, jsonRepo, senmlRepo)
 
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), svcName, logger)
+	mux := httpapi.MakeHandler(svc, ac, mocktracer.New(), svcName, logger)
 
 	id, _ := idProvider.ID()
 	user.ID = id

--- a/readers/api/http/messages/transport.go
+++ b/readers/api/http/messages/transport.go
@@ -10,9 +10,12 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/readers"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -43,76 +46,109 @@ const (
 	csvFormat              = "csv"
 )
 
-func MakeHandler(svc readers.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
+func MakeHandler(svc readers.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Get("/json", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_json_messages")(listJSONMessagesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_json_messages"),
+			withIdentity,
+		)(listJSONMessagesEndpoint(svc)),
 		decodeListJSONMessages,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/senml", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_senml_messages")(listSenMLMessagesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_senml_messages"),
+			withIdentity,
+		)(listSenMLMessagesEndpoint(svc)),
 		decodeListSenMLMessages,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/json/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_json_messages")(searchJSONMessagesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_json_messages"),
+			withIdentity,
+		)(searchJSONMessagesEndpoint(svc)),
 		decodeSearchJSONMessages,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/senml/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_senml_messages")(searchSenMLMessagesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_senml_messages"),
+			withIdentity,
+		)(searchSenMLMessagesEndpoint(svc)),
 		decodeSearchSenMLMessages,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Delete("/json", kithttp.NewServer(
-		kitot.TraceServer(tracer, "delete_all_json_messages")(deleteAllJSONMessagesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "delete_all_json_messages"),
+			withIdentity,
+		)(deleteAllJSONMessagesEndpoint(svc)),
 		decodeDeleteAllJSONMessages,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Delete("/json/:publisherID", kithttp.NewServer(
-		kitot.TraceServer(tracer, "delete_json_messages")(deleteJSONMessagesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "delete_json_messages"),
+			withIdentity,
+		)(deleteJSONMessagesEndpoint(svc)),
 		decodeDeleteJSONMessages,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Delete("/senml", kithttp.NewServer(
-		kitot.TraceServer(tracer, "delete_all_senml_messages")(deleteAllSenMLMessagesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "delete_all_senml_messages"),
+			withIdentity,
+		)(deleteAllSenMLMessagesEndpoint(svc)),
 		decodeDeleteAllSenMLMessages,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Delete("/senml/:publisherID", kithttp.NewServer(
-		kitot.TraceServer(tracer, "delete_senml_messages")(deleteSenMLMessagesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "delete_senml_messages"),
+			withIdentity,
+		)(deleteSenMLMessagesEndpoint(svc)),
 		decodeDeleteSenMLMessages,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/json/export", kithttp.NewServer(
-		kitot.TraceServer(tracer, "export_json_messages")(exportJSONMessagesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "export_json_messages"),
+			withIdentity,
+		)(exportJSONMessagesEndpoint(svc)),
 		decodeExportJSONMessages,
 		encodeFileResponse,
 		opts...,
 	))
 
 	mux.Get("/senml/export", kithttp.NewServer(
-		kitot.TraceServer(tracer, "export_senml_messages")(exportSenMLMessagesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "export_senml_messages"),
+			withIdentity,
+		)(exportSenMLMessagesEndpoint(svc)),
 		decodeExportSenMLMessages,
 		encodeFileResponse,
 		opts...,

--- a/readers/api/http/transport.go
+++ b/readers/api/http/transport.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux"
 	log "github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/readers"
 	"github.com/MainfluxLabs/mainflux/readers/api/http/backup"
 	"github.com/MainfluxLabs/mainflux/readers/api/http/messages"
@@ -18,10 +19,10 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc readers.Service, tracer opentracing.Tracer, svcName string, logger log.Logger) http.Handler {
+func MakeHandler(svc readers.Service, ac domain.AuthClient, tracer opentracing.Tracer, svcName string, logger log.Logger) http.Handler {
 	mux := bone.New()
-	mux = messages.MakeHandler(svc, mux, tracer, logger)
-	mux = backup.MakeHandler(svc, mux, tracer, logger)
+	mux = messages.MakeHandler(svc, ac, mux, tracer, logger)
+	mux = backup.MakeHandler(svc, ac, mux, tracer, logger)
 	mux.GetFunc("/health", mainflux.Health(svcName))
 	mux.Handle("/metrics", promhttp.Handler())
 	return mux

--- a/rules/api/http/rules/endpoint_test.go
+++ b/rules/api/http/rules/endpoint_test.go
@@ -94,7 +94,8 @@ func newService() rules.Service {
 
 func newHTTPServer(svc rules.Service) *httptest.Server {
 	log := logger.NewMock()
-	mux := httpapi.MakeHandler(mocktracer.New(), svc, log)
+	ac := pkgmocks.NewAuthService("", nil, nil)
+	mux := httpapi.MakeHandler(mocktracer.New(), svc, ac, log)
 	return httptest.NewServer(mux)
 }
 

--- a/rules/api/http/rules/transport.go
+++ b/rules/api/http/rules/transport.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/rules"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -21,61 +24,91 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for rule API endpoints.
-func MakeHandler(svc rules.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
+func MakeHandler(svc rules.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/groups/:id/rules", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_rules")(createRulesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_rules"),
+			withIdentity,
+		)(createRulesEndpoint(svc)),
 		decodeCreateRules,
 		encodeResponse,
 		opts...,
 	))
 	mux.Get("/rules/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_rule")(viewRuleEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_rule"),
+			withIdentity,
+		)(viewRuleEndpoint(svc)),
 		decodeRuleReq,
 		encodeResponse,
 		opts...,
 	))
 	mux.Get("/things/:id/rules", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_rules_by_thing")(listRulesByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_rules_by_thing"),
+			withIdentity,
+		)(listRulesByThingEndpoint(svc)),
 		decodeListRulesByThing,
 		encodeResponse,
 		opts...,
 	))
 	mux.Get("/groups/:id/rules", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_rules_by_group")(listRulesByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_rules_by_group"),
+			withIdentity,
+		)(listRulesByGroupEndpoint(svc)),
 		decodeListRulesByGroup,
 		encodeResponse,
 		opts...,
 	))
 	mux.Get("/rules/:id/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_thing_ids_by_rule")(listThingIDsByRuleEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_thing_ids_by_rule"),
+			withIdentity,
+		)(listThingIDsByRuleEndpoint(svc)),
 		decodeRuleReq,
 		encodeResponse,
 		opts...,
 	))
 	mux.Put("/rules/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_rule")(updateRuleEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_rule"),
+			withIdentity,
+		)(updateRuleEndpoint(svc)),
 		decodeUpdateRule,
 		encodeResponse,
 		opts...,
 	))
 	mux.Post("/rules/:id/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "assign_things")(assignThingsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "assign_things"),
+			withIdentity,
+		)(assignThingsEndpoint(svc)),
 		decodeRuleThings,
 		encodeResponse,
 		opts...,
 	))
 	mux.Patch("/rules/:id/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "unassign_things")(unassignThingsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "unassign_things"),
+			withIdentity,
+		)(unassignThingsEndpoint(svc)),
 		decodeRuleThings,
 		encodeResponse,
 		opts...,
 	))
 	mux.Patch("/rules", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_rules")(removeRulesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_rules"),
+			withIdentity,
+		)(removeRulesEndpoint(svc)),
 		decodeRemoveRules,
 		encodeResponse,
 		opts...,

--- a/rules/api/http/scripts/endpoint_test.go
+++ b/rules/api/http/scripts/endpoint_test.go
@@ -96,7 +96,8 @@ func newService() rules.Service {
 
 func newHTTPServer(svc rules.Service) *httptest.Server {
 	log := logger.NewMock()
-	mux := httpapi.MakeHandler(mocktracer.New(), svc, log)
+	ac := pkgmocks.NewAuthService("", nil, nil)
+	mux := httpapi.MakeHandler(mocktracer.New(), svc, ac, log)
 	return httptest.NewServer(mux)
 }
 

--- a/rules/api/http/scripts/transport.go
+++ b/rules/api/http/scripts/transport.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/rules"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -21,83 +24,119 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for script API endpoints.
-func MakeHandler(svc rules.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
+func MakeHandler(svc rules.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/groups/:id/scripts", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_scripts")(createScriptsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_scripts"),
+			withIdentity,
+		)(createScriptsEndpoint(svc)),
 		decodeCreateScripts,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/things/:id/scripts", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_scripts_by_thing")(listScriptsByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_scripts_by_thing"),
+			withIdentity,
+		)(listScriptsByThingEndpoint(svc)),
 		decodeListScriptsByThing,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/groups/:id/scripts", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_scripts_by_group")(listScriptsByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_scripts_by_group"),
+			withIdentity,
+		)(listScriptsByGroupEndpoint(svc)),
 		decodeListScriptsByGroup,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/scripts/:id/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_thing_ids_by_script")(listThingIDsByScriptEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_thing_ids_by_script"),
+			withIdentity,
+		)(listThingIDsByScriptEndpoint(svc)),
 		decodeScriptReq,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/scripts/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_script")(viewScriptEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_script"),
+			withIdentity,
+		)(viewScriptEndpoint(svc)),
 		decodeScriptReq,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Put("/scripts/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_script")(updateScriptEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_script"),
+			withIdentity,
+		)(updateScriptEndpoint(svc)),
 		decodeUpdateScript,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Patch("/scripts", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_scripts")(removeScriptsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_scripts"),
+			withIdentity,
+		)(removeScriptsEndpoint(svc)),
 		decodeRemoveScripts,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/things/:id/scripts", kithttp.NewServer(
-		kitot.TraceServer(tracer, "assign_scripts")(assignScriptsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "assign_scripts"),
+			withIdentity,
+		)(assignScriptsEndpoint(svc)),
 		decodeThingScripts,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Patch("/things/:id/scripts", kithttp.NewServer(
-		kitot.TraceServer(tracer, "unassign_scripts")(unassignScriptsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "unassign_scripts"),
+			withIdentity,
+		)(unassignScriptsEndpoint(svc)),
 		decodeThingScripts,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/things/:id/runs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_script_runs_by_thing")(listScriptRunsByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_script_runs_by_thing"),
+			withIdentity,
+		)(listScriptRunsByThingEndpoint(svc)),
 		decodeListScriptRunsByThing,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Patch("/runs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_script_runs")(removeScriptRunsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_script_runs"),
+			withIdentity,
+		)(removeScriptRunsEndpoint(svc)),
 		decodeRemoveScriptRuns,
 		encodeResponse,
 		opts...,

--- a/rules/api/http/transport.go
+++ b/rules/api/http/transport.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux"
 	log "github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/rules"
 	httprules "github.com/MainfluxLabs/mainflux/rules/api/http/rules"
 	httpscripts "github.com/MainfluxLabs/mainflux/rules/api/http/scripts"
@@ -17,10 +18,10 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for Rule API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc rules.Service, logger log.Logger) http.Handler {
+func MakeHandler(tracer opentracing.Tracer, svc rules.Service, ac domain.AuthClient, logger log.Logger) http.Handler {
 	mux := bone.New()
-	mux = httprules.MakeHandler(svc, mux, tracer, logger)
-	mux = httpscripts.MakeHandler(svc, mux, tracer, logger)
+	mux = httprules.MakeHandler(svc, ac, mux, tracer, logger)
+	mux = httpscripts.MakeHandler(svc, ac, mux, tracer, logger)
 
 	mux.GetFunc("/health", mainflux.Health("rules"))
 	mux.Handle("/metrics", promhttp.Handler())

--- a/things/api/http/backup/endpoint_test.go
+++ b/things/api/http/backup/endpoint_test.go
@@ -100,7 +100,7 @@ func newService() things.Service {
 
 func newServer(svc things.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, mocks.NewAuthService(admin.ID, usersList, orgsList), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 

--- a/things/api/http/backup/transport.go
+++ b/things/api/http/backup/transport.go
@@ -11,10 +11,13 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -22,20 +25,29 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc things.Service, mux *bone.Mux, tracer opentracing.Tracer, logger log.Logger) *bone.Mux {
+func MakeHandler(svc things.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger log.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Get("/backup", kithttp.NewServer(
-		kitot.TraceServer(tracer, "backup")(backupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "backup"),
+			withIdentity,
+		)(backupEndpoint(svc)),
 		decodeBackup,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/restore", kithttp.NewServer(
-		kitot.TraceServer(tracer, "restore")(restoreEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "restore"),
+			withIdentity,
+		)(restoreEndpoint(svc)),
 		decodeRestore,
 		encodeResponse,
 		opts...,

--- a/things/api/http/groups/endpoint_test.go
+++ b/things/api/http/groups/endpoint_test.go
@@ -111,7 +111,7 @@ func newService() things.Service {
 
 func newServer(svc things.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, mocks.NewAuthService(admin.ID, usersList, orgsList), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 

--- a/things/api/http/groups/transport.go
+++ b/things/api/http/groups/transport.go
@@ -11,10 +11,13 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -22,83 +25,119 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc things.Service, mux *bone.Mux, tracer opentracing.Tracer, logger log.Logger) *bone.Mux {
+func MakeHandler(svc things.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger log.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/orgs/:id/groups", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_groups")(createGroupsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_groups"),
+			withIdentity,
+		)(createGroupsEndpoint(svc)),
 		decodeCreateGroups,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/groups/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_group")(viewGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_group"),
+			withIdentity,
+		)(viewGroupEndpoint(svc)),
 		decodeRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/things/:id/groups", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_group_by_thing")(viewGroupByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_group_by_thing"),
+			withIdentity,
+		)(viewGroupByThingEndpoint(svc)),
 		decodeViewByThing,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/profiles/:id/groups", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_group_by_profile")(viewGroupByProfileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_group_by_profile"),
+			withIdentity,
+		)(viewGroupByProfileEndpoint(svc)),
 		decodeViewByProfile,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/groups", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_groups")(listGroupsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_groups"),
+			withIdentity,
+		)(listGroupsEndpoint(svc)),
 		decodeList,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/orgs/:id/groups", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_groups_by_org")(listGroupsByOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_groups_by_org"),
+			withIdentity,
+		)(listGroupsByOrgEndpoint(svc)),
 		decodeListByOrg,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/groups/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_groups")(listGroupsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_groups"),
+			withIdentity,
+		)(listGroupsEndpoint(svc)),
 		decodeSearch,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/orgs/:id/groups/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_groups_by_org")(listGroupsByOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_groups_by_org"),
+			withIdentity,
+		)(listGroupsByOrgEndpoint(svc)),
 		decodeSearchByOrg,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Put("/groups/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_group")(updateGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_group"),
+			withIdentity,
+		)(updateGroupEndpoint(svc)),
 		decodeUpdateGroup,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Delete("/groups/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_group")(removeGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_group"),
+			withIdentity,
+		)(removeGroupEndpoint(svc)),
 		decodeRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Patch("/groups", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_groups")(removeGroupsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_groups"),
+			withIdentity,
+		)(removeGroupsEndpoint(svc)),
 		decodeRemoveGroups,
 		encodeResponse,
 		opts...,

--- a/things/api/http/memberships/endpoint_test.go
+++ b/things/api/http/memberships/endpoint_test.go
@@ -115,7 +115,7 @@ func newService() things.Service {
 
 func newServer(svc things.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, mocks.NewAuthService(admin.ID, usersList, orgsList), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 

--- a/things/api/http/memberships/transport.go
+++ b/things/api/http/memberships/transport.go
@@ -11,9 +11,12 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -25,34 +28,49 @@ const (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc things.Service, mux *bone.Mux, tracer opentracing.Tracer, logger log.Logger) *bone.Mux {
+func MakeHandler(svc things.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger log.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/groups/:id/memberships", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_group_memberships")(createGroupMembershipsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_group_memberships"),
+			withIdentity,
+		)(createGroupMembershipsEndpoint(svc)),
 		decodeCreateGroupMemberships,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/groups/:id/memberships", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_group_memberships")(listGroupMembershipsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_group_memberships"),
+			withIdentity,
+		)(listGroupMembershipsEndpoint(svc)),
 		decodeListGroupMemberships,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Put("/groups/:id/memberships", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_group_memberships")(updateGroupMembershipsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_group_memberships"),
+			withIdentity,
+		)(updateGroupMembershipsEndpoint(svc)),
 		decodeUpdateGroupMemberships,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Patch("/groups/:id/memberships", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_group_memberships")(removeGroupMembershipsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_group_memberships"),
+			withIdentity,
+		)(removeGroupMembershipsEndpoint(svc)),
 		decodeRemoveGroupMemberships,
 		encodeResponse,
 		opts...,

--- a/things/api/http/profiles/endpoint_test.go
+++ b/things/api/http/profiles/endpoint_test.go
@@ -128,7 +128,7 @@ func newService() things.Service {
 
 func newServer(svc things.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, mocks.NewAuthService(admin.ID, usersList, orgsList), mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 

--- a/things/api/http/profiles/transport.go
+++ b/things/api/http/profiles/transport.go
@@ -11,10 +11,13 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -22,90 +25,118 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc things.Service, mux *bone.Mux, tracer opentracing.Tracer, logger log.Logger) *bone.Mux {
+func MakeHandler(svc things.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger log.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/groups/:id/profiles", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_profiles")(createProfilesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_profiles"),
+			withIdentity,
+		)(createProfilesEndpoint(svc)),
 		decodeCreateProfiles,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Get("/profiles/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_profile")(viewProfileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_profile"),
+			withIdentity,
+		)(viewProfileEndpoint(svc)),
 		decodeRequest,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Get("/things/:id/profiles", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_profile_by_thing")(viewProfileByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_profile_by_thing"),
+			withIdentity,
+		)(viewProfileByThingEndpoint(svc)),
 		decodeViewByThing,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Get("/profiles", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_profiles")(listProfilesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_profiles"),
+			withIdentity,
+		)(listProfilesEndpoint(svc)),
 		decodeList,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Get("/groups/:id/profiles", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_profiles_by_group")(listProfilesByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_profiles_by_group"),
+			withIdentity,
+		)(listProfilesByGroupEndpoint(svc)),
 		decodeListByGroup,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Get("/orgs/:id/profiles", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_profiles_by_org")(listProfilesByOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_profiles_by_org"),
+			withIdentity,
+		)(listProfilesByOrgEndpoint(svc)),
 		decodeListByOrg,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Post("/profiles/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_profiles")(listProfilesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_profiles"),
+			withIdentity,
+		)(listProfilesEndpoint(svc)),
 		decodeSearch,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Post("/groups/:id/profiles/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_profiles_by_group")(listProfilesByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_profiles_by_group"),
+			withIdentity,
+		)(listProfilesByGroupEndpoint(svc)),
 		decodeSearchByGroup,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Post("/orgs/:id/profiles/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_profiles_by_org")(listProfilesByOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_profiles_by_org"),
+			withIdentity,
+		)(listProfilesByOrgEndpoint(svc)),
 		decodeSearchByOrg,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Put("/profiles/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_profile")(updateProfileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_profile"),
+			withIdentity,
+		)(updateProfileEndpoint(svc)),
 		decodeUpdateProfile,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Delete("/profiles/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_profile")(removeProfileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_profile"),
+			withIdentity,
+		)(removeProfileEndpoint(svc)),
 		decodeRequest,
 		encodeResponse,
 		opts...,
 	))
-
 	mux.Patch("/profiles", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_profiles")(removeProfilesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_profiles"),
+			withIdentity,
+		)(removeProfilesEndpoint(svc)),
 		decodeRemoveProfiles,
 		encodeResponse,
 		opts...,

--- a/things/api/http/things/endpoint_test.go
+++ b/things/api/http/things/endpoint_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/MainfluxLabs/mainflux/auth"
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
@@ -122,9 +123,9 @@ func newService() things.Service {
 	return things.New(auth, nil, thingsRepo, profilesRepo, groupsRepo, groupMembershipsRepo, profileCache, thingCache, groupCache, idProvider, emailerMock)
 }
 
-func newServer(svc things.Service) *httptest.Server {
+func newServer(svc things.Service, auth domain.AuthClient) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger)
+	mux := httpapi.MakeHandler(svc, auth, mocktracer.New(), logger)
 	return httptest.NewServer(mux)
 }
 
@@ -135,7 +136,7 @@ func toJSON(data any) string {
 
 func TestCreateThings(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -260,7 +261,7 @@ func TestCreateThings(t *testing.T) {
 
 func TestUpdateThing(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group, group)
@@ -409,7 +410,7 @@ func TestUpdateThing(t *testing.T) {
 
 func TestUpdateThingGroupAndProfile(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group, group)
@@ -543,7 +544,7 @@ func TestUpdateThingGroupAndProfile(t *testing.T) {
 
 func TestViewThing(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -629,7 +630,7 @@ func TestViewThing(t *testing.T) {
 
 func TestViewMetadataByKey(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 	idProvider := uuid.New()
 
@@ -703,7 +704,7 @@ func TestViewMetadataByKey(t *testing.T) {
 
 func TestListThings(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -895,7 +896,7 @@ func TestListThings(t *testing.T) {
 
 func TestSearchThings(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -1073,7 +1074,7 @@ func TestSearchThings(t *testing.T) {
 
 func TestSearchThingsByProfile(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -1223,7 +1224,7 @@ func TestSearchThingsByProfile(t *testing.T) {
 
 func TestSearchThingsByGroup(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -1374,7 +1375,7 @@ func TestSearchThingsByGroup(t *testing.T) {
 
 func TestSearchThingsByOrg(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -1524,7 +1525,7 @@ func TestSearchThingsByOrg(t *testing.T) {
 
 func TestListThingsByProfile(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -1711,7 +1712,7 @@ func TestListThingsByProfile(t *testing.T) {
 
 func TestListThingsByOrg(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), adminToken, orgID, group)
@@ -1931,7 +1932,7 @@ func TestListThingsByOrg(t *testing.T) {
 
 func TestUpdateExternalKey(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	createdGroups, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -2038,7 +2039,7 @@ func TestUpdateExternalKey(t *testing.T) {
 
 func TestRemoveExternalKey(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	createdGroups, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -2095,7 +2096,7 @@ func TestRemoveExternalKey(t *testing.T) {
 
 func TestRemoveThing(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -2157,7 +2158,7 @@ func TestRemoveThing(t *testing.T) {
 
 func TestRemoveThings(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)
@@ -2258,7 +2259,7 @@ func TestRemoveThings(t *testing.T) {
 }
 func TestIdentify(t *testing.T) {
 	svc := newService()
-	ts := newServer(svc)
+	ts := newServer(svc, mocks.NewAuthService(admin.ID, usersList, orgsList))
 	defer ts.Close()
 
 	grs, err := svc.CreateGroups(context.Background(), token, orgID, group)

--- a/things/api/http/things/transport.go
+++ b/things/api/http/things/transport.go
@@ -12,10 +12,13 @@ import (
 	"github.com/MainfluxLabs/mainflux"
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/things"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -24,20 +27,29 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc things.Service, mux *bone.Mux, tracer opentracing.Tracer, logger log.Logger) *bone.Mux {
+func MakeHandler(svc things.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger log.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/profiles/:id/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_things")(createThingsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_things"),
+			withIdentity,
+		)(createThingsEndpoint(svc)),
 		decodeCreateThings,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/things/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_thing")(viewThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_thing"),
+			withIdentity,
+		)(viewThingEndpoint(svc)),
 		decodeRequest,
 		encodeResponse,
 		opts...,
@@ -51,105 +63,150 @@ func MakeHandler(svc things.Service, mux *bone.Mux, tracer opentracing.Tracer, l
 	))
 
 	mux.Get("/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_things")(listThingsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_things"),
+			withIdentity,
+		)(listThingsEndpoint(svc)),
 		decodeList,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/profiles/:id/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_things_by_profile")(listThingsByProfileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_things_by_profile"),
+			withIdentity,
+		)(listThingsByProfileEndpoint(svc)),
 		decodeListByProfile,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/groups/:id/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_things_by_group")(listThingsByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_things_by_group"),
+			withIdentity,
+		)(listThingsByGroupEndpoint(svc)),
 		decodeListByGroup,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/orgs/:id/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_things_by_org")(listThingsByOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_things_by_org"),
+			withIdentity,
+		)(listThingsByOrgEndpoint(svc)),
 		decodeListByOrg,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/things/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_things")(listThingsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_things"),
+			withIdentity,
+		)(listThingsEndpoint(svc)),
 		decodeSearch,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/profiles/:id/things/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_things_by_profile")(listThingsByProfileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_things_by_profile"),
+			withIdentity,
+		)(listThingsByProfileEndpoint(svc)),
 		decodeSearchByProfile,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/groups/:id/things/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_things_by_group")(listThingsByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_things_by_group"),
+			withIdentity,
+		)(listThingsByGroupEndpoint(svc)),
 		decodeSearchByGroup,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/orgs/:id/things/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_things_by_org")(listThingsByOrgEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_things_by_org"),
+			withIdentity,
+		)(listThingsByOrgEndpoint(svc)),
 		decodeSearchByOrg,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Put("/things/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_thing")(updateThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_thing"),
+			withIdentity,
+		)(updateThingEndpoint(svc)),
 		decodeUpdateThing,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Patch("/things/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_thing_group_and_profile")(updateThingGroupAndProfileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_thing_group_and_profile"),
+			withIdentity,
+		)(updateThingGroupAndProfileEndpoint(svc)),
 		decodeUpdateThingGroupAndProfile,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Put("/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_things_metadata")(updateThingsMetadataEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_things_metadata"),
+			withIdentity,
+		)(updateThingsMetadataEndpoint(svc)),
 		decodeUpdateThingsMetadata,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Delete("/things/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_thing")(removeThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_thing"),
+			withIdentity,
+		)(removeThingEndpoint(svc)),
 		decodeRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Patch("/things", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_things")(removeThingsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_things"),
+			withIdentity,
+		)(removeThingsEndpoint(svc)),
 		decodeRemoveThings,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Patch("/things/:id/external-key", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_external_key")(updateExternalKeyEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_external_key"),
+			withIdentity,
+		)(updateExternalKeyEndpoint(svc)),
 		decodeUpdateExternalKey,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Delete("/things/:id/external-key", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_external_key")(removeExternalKeyEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_external_key"),
+			withIdentity,
+		)(removeExternalKeyEndpoint(svc)),
 		decodeRemoveExternalKey,
 		encodeResponse,
 		opts...,

--- a/things/api/http/transport.go
+++ b/things/api/http/transport.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux"
 	log "github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	svcthings "github.com/MainfluxLabs/mainflux/things"
 	"github.com/MainfluxLabs/mainflux/things/api/http/backup"
 	"github.com/MainfluxLabs/mainflux/things/api/http/groups"
@@ -21,13 +22,13 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc svcthings.Service, tracer opentracing.Tracer, logger log.Logger) http.Handler {
+func MakeHandler(svc svcthings.Service, ac domain.AuthClient, tracer opentracing.Tracer, logger log.Logger) http.Handler {
 	mux := bone.New()
-	mux = things.MakeHandler(svc, mux, tracer, logger)
-	mux = profiles.MakeHandler(svc, mux, tracer, logger)
-	mux = groups.MakeHandler(svc, mux, tracer, logger)
-	mux = memberships.MakeHandler(svc, mux, tracer, logger)
-	mux = backup.MakeHandler(svc, mux, tracer, logger)
+	mux = things.MakeHandler(svc, ac, mux, tracer, logger)
+	mux = profiles.MakeHandler(svc, ac, mux, tracer, logger)
+	mux = groups.MakeHandler(svc, ac, mux, tracer, logger)
+	mux = memberships.MakeHandler(svc, ac, mux, tracer, logger)
+	mux = backup.MakeHandler(svc, ac, mux, tracer, logger)
 	mux.GetFunc("/health", mainflux.Health("things"))
 	mux.Handle("/metrics", promhttp.Handler())
 	return mux

--- a/uiconfigs/api/http/backup/transport.go
+++ b/uiconfigs/api/http/backup/transport.go
@@ -12,9 +12,12 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/uiconfigs"
 	"github.com/MainfluxLabs/mainflux/uiconfigs/api/http/things"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -22,20 +25,29 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc uiconfigs.Service, mux *bone.Mux, logger log.Logger) *bone.Mux {
+func MakeHandler(tracer opentracing.Tracer, svc uiconfigs.Service, ac domain.AuthClient, mux *bone.Mux, logger log.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Get("/backup", kithttp.NewServer(
-		kitot.TraceServer(tracer, "backup")(backupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "backup"),
+			withIdentity,
+		)(backupEndpoint(svc)),
 		decodeBackupConfigs,
 		apiutil.EncodeFileResponse,
 		opts...,
 	))
 
 	mux.Post("/restore", kithttp.NewServer(
-		kitot.TraceServer(tracer, "restore")(restoreEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "restore"),
+			withIdentity,
+		)(restoreEndpoint(svc)),
 		decodeRestoreConfigs,
 		encodeResponse,
 		opts...,

--- a/uiconfigs/api/http/orgs/transport.go
+++ b/uiconfigs/api/http/orgs/transport.go
@@ -11,9 +11,12 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/uiconfigs"
 	"github.com/MainfluxLabs/mainflux/uiconfigs/api/http/things"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -21,27 +24,39 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc uiconfigs.Service, mux *bone.Mux, logger log.Logger) *bone.Mux {
+func MakeHandler(tracer opentracing.Tracer, svc uiconfigs.Service, ac domain.AuthClient, mux *bone.Mux, logger log.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Get("/orgs/:id/configs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_org_config")(viewOrgConfigEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_org_config"),
+			withIdentity,
+		)(viewOrgConfigEndpoint(svc)),
 		decodeViewOrgConfig,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/orgs/configs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_all_orgs_configs")(listOrgsConfigsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_all_orgs_configs"),
+			withIdentity,
+		)(listOrgsConfigsEndpoint(svc)),
 		decodeListOrgsConfigs,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Put("/orgs/:id/configs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_org_config")(updateOrgConfigEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_org_config"),
+			withIdentity,
+		)(updateOrgConfigEndpoint(svc)),
 		decodeUpdateOrgConfig,
 		encodeResponse,
 		opts...,

--- a/uiconfigs/api/http/things/transport.go
+++ b/uiconfigs/api/http/things/transport.go
@@ -11,8 +11,11 @@ import (
 
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/uiconfigs"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -20,27 +23,39 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc uiconfigs.Service, mux *bone.Mux, logger log.Logger) *bone.Mux {
+func MakeHandler(tracer opentracing.Tracer, svc uiconfigs.Service, ac domain.AuthClient, mux *bone.Mux, logger log.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Get("/things/:id/configs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_thing_config")(viewThingConfigEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_thing_config"),
+			withIdentity,
+		)(viewThingConfigEndpoint(svc)),
 		decodeViewThingConfig,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/things/configs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_all_things_configs")(listThingsConfigsEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_all_things_configs"),
+			withIdentity,
+		)(listThingsConfigsEndpoint(svc)),
 		decodeListThingsConfigs,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Put("/things/:id/configs", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_thing_config")(updateThingConfigEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_thing_config"),
+			withIdentity,
+		)(updateThingConfigEndpoint(svc)),
 		decodeUpdateThingConfig,
 		encodeResponse,
 		opts...,

--- a/uiconfigs/api/http/transport.go
+++ b/uiconfigs/api/http/transport.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux"
 	log "github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/uiconfigs"
 	"github.com/MainfluxLabs/mainflux/uiconfigs/api/http/backup"
 	"github.com/MainfluxLabs/mainflux/uiconfigs/api/http/orgs"
@@ -19,11 +20,11 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc uiconfigs.Service, logger log.Logger) http.Handler {
+func MakeHandler(tracer opentracing.Tracer, svc uiconfigs.Service, ac domain.AuthClient, logger log.Logger) http.Handler {
 	mux := bone.New()
-	mux = orgs.MakeHandler(tracer, svc, mux, logger)
-	mux = things.MakeHandler(tracer, svc, mux, logger)
-	mux = backup.MakeHandler(tracer, svc, mux, logger)
+	mux = orgs.MakeHandler(tracer, svc, ac, mux, logger)
+	mux = things.MakeHandler(tracer, svc, ac, mux, logger)
+	mux = backup.MakeHandler(tracer, svc, ac, mux, logger)
 	mux.GetFunc("/health", mainflux.Health("uiconfigs"))
 	mux.Handle("/metrics", promhttp.Handler())
 	return mux

--- a/users/api/http/backup/transport.go
+++ b/users/api/http/backup/transport.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/users"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -21,20 +24,29 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc users.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
+func MakeHandler(svc users.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger) *bone.Mux {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Get("/backup", kithttp.NewServer(
-		kitot.TraceServer(tracer, "backup")(backupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "backup"),
+			withIdentity,
+		)(backupEndpoint(svc)),
 		decodeBackup,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/restore", kithttp.NewServer(
-		kitot.TraceServer(tracer, "restore")(restoreEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "restore"),
+			withIdentity,
+		)(restoreEndpoint(svc)),
 		decodeRestore,
 		encodeResponse,
 		opts...,

--- a/users/api/http/invites/endpoint_test.go
+++ b/users/api/http/invites/endpoint_test.go
@@ -122,7 +122,8 @@ func newService() users.Service {
 }
 
 func newServer(svc users.Service) *httptest.Server {
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger.NewMock(), passRegex)
+	ac := mocks.NewAuthService(admin.ID, usersList, nil)
+	mux := httpapi.MakeHandler(svc, ac, mocktracer.New(), logger.NewMock(), passRegex)
 	return httptest.NewServer(mux)
 }
 

--- a/users/api/http/invites/transport.go
+++ b/users/api/http/invites/transport.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/users"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -23,12 +26,15 @@ import (
 const stateKey = "state"
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc users.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger, passwordRegex *regexp.Regexp) *bone.Mux {
+func MakeHandler(svc users.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger, passwordRegex *regexp.Regexp) *bone.Mux {
 	userPasswordRegex = passwordRegex
 
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
+
+	withIdentity := authn.IdentityMiddleware(ac, logger)
 
 	mux.Post("/register/invite/:id", kithttp.NewServer(
 		kitot.TraceServer(tracer, "register_by_invite")(inviteRegistrationEndpoint(svc)),
@@ -38,14 +44,20 @@ func MakeHandler(svc users.Service, mux *bone.Mux, tracer opentracing.Tracer, lo
 	))
 
 	mux.Post("/invites", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_platform_invite")(createPlatformInviteEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_platform_invite"),
+			withIdentity,
+		)(createPlatformInviteEndpoint(svc)),
 		decodeCreatePlatformInviteRequest,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/invites", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_platform_invites")(listPlatformInvitesEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_platform_invites"),
+			withIdentity,
+		)(listPlatformInvitesEndpoint(svc)),
 		decodeListPlatformInvitesRequest,
 		encodeResponse,
 		opts...,
@@ -59,7 +71,10 @@ func MakeHandler(svc users.Service, mux *bone.Mux, tracer opentracing.Tracer, lo
 	))
 
 	mux.Delete("/invites/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "revoke_platform_invite")(revokePlatformInviteEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "revoke_platform_invite"),
+			withIdentity,
+		)(revokePlatformInviteEndpoint(svc)),
 		decodeInviteRequest,
 		encodeResponse,
 		opts...,

--- a/users/api/http/transport.go
+++ b/users/api/http/transport.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux"
 	log "github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	svcusers "github.com/MainfluxLabs/mainflux/users"
 	"github.com/MainfluxLabs/mainflux/users/api/http/backup"
 	"github.com/MainfluxLabs/mainflux/users/api/http/invites"
@@ -20,11 +21,11 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc svcusers.Service, tracer opentracing.Tracer, logger log.Logger, passwordRegex *regexp.Regexp) http.Handler {
+func MakeHandler(svc svcusers.Service, ac domain.AuthClient, tracer opentracing.Tracer, logger log.Logger, passwordRegex *regexp.Regexp) http.Handler {
 	mux := bone.New()
-	mux = users.MakeHandler(svc, mux, tracer, logger, passwordRegex)
-	mux = invites.MakeHandler(svc, mux, tracer, logger, passwordRegex)
-	mux = backup.MakeHandler(svc, mux, tracer, logger)
+	mux = users.MakeHandler(svc, ac, mux, tracer, logger, passwordRegex)
+	mux = invites.MakeHandler(svc, ac, mux, tracer, logger, passwordRegex)
+	mux = backup.MakeHandler(svc, ac, mux, tracer, logger)
 	mux.GetFunc("/health", mainflux.Health("users"))
 	mux.Handle("/metrics", promhttp.Handler())
 	return mux

--- a/users/api/http/users/endpoint_test.go
+++ b/users/api/http/users/endpoint_test.go
@@ -165,7 +165,8 @@ func newService() users.Service {
 }
 
 func newServer(svc users.Service) *httptest.Server {
-	mux := httpapi.MakeHandler(svc, mocktracer.New(), logger.NewMock(), passRegex)
+	ac := mocks.NewAuthService(admin.ID, usersList, nil)
+	mux := httpapi.MakeHandler(svc, ac, mocktracer.New(), logger.NewMock(), passRegex)
 	return httptest.NewServer(mux)
 }
 

--- a/users/api/http/users/transport.go
+++ b/users/api/http/users/transport.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/users"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -34,17 +37,23 @@ const (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(svc users.Service, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger, passwordRegex *regexp.Regexp) *bone.Mux {
+func MakeHandler(svc users.Service, ac domain.AuthClient, mux *bone.Mux, tracer opentracing.Tracer, logger logger.Logger, passwordRegex *regexp.Regexp) *bone.Mux {
 	userPasswordRegex = passwordRegex
 
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 	callbackOpts := append([]kithttp.ServerOption{}, opts...)
 	callbackOpts = append(callbackOpts, kithttp.ServerErrorEncoder(encodeOAuthCallbackError))
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	mux.Post("/users", kithttp.NewServer(
-		kitot.TraceServer(tracer, "register")(registrationEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "register"),
+			withIdentity,
+		)(registrationEndpoint(svc)),
 		decodeRegisterUser,
 		encodeResponse,
 		opts...,
@@ -65,35 +74,50 @@ func MakeHandler(svc users.Service, mux *bone.Mux, tracer opentracing.Tracer, lo
 	))
 
 	mux.Get("/users/profile", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_profile")(viewProfileEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_profile"),
+			withIdentity,
+		)(viewProfileEndpoint(svc)),
 		decodeViewProfile,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/users/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_user")(viewUserEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_user"),
+			withIdentity,
+		)(viewUserEndpoint(svc)),
 		decodeViewUser,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Get("/users", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_users")(listUsersEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_users"),
+			withIdentity,
+		)(listUsersEndpoint(svc)),
 		decodeListUsers,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/users/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_users")(listUsersEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_users"),
+			withIdentity,
+		)(listUsersEndpoint(svc)),
 		decodeSearchUsers,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Put("/users", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_user")(updateUserEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_user"),
+			withIdentity,
+		)(updateUserEndpoint(svc)),
 		decodeUpdateUser,
 		encodeResponse,
 		opts...,
@@ -114,7 +138,10 @@ func MakeHandler(svc users.Service, mux *bone.Mux, tracer opentracing.Tracer, lo
 	))
 
 	mux.Patch("/password", kithttp.NewServer(
-		kitot.TraceServer(tracer, "reset")(passwordChangeEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "reset"),
+			withIdentity,
+		)(passwordChangeEndpoint(svc)),
 		decodePasswordChange,
 		encodeResponse,
 		opts...,
@@ -142,14 +169,20 @@ func MakeHandler(svc users.Service, mux *bone.Mux, tracer opentracing.Tracer, lo
 	))
 
 	mux.Post("/users/:id/enable", kithttp.NewServer(
-		kitot.TraceServer(tracer, "enable_user")(enableUserEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "enable_user"),
+			withIdentity,
+		)(enableUserEndpoint(svc)),
 		decodeChangeUserStatus,
 		encodeResponse,
 		opts...,
 	))
 
 	mux.Post("/users/:id/disable", kithttp.NewServer(
-		kitot.TraceServer(tracer, "disable_user")(disableUserEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "disable_user"),
+			withIdentity,
+		)(disableUserEndpoint(svc)),
 		decodeChangeUserStatus,
 		encodeResponse,
 		opts...,

--- a/webhooks/api/http/endpoint_test.go
+++ b/webhooks/api/http/endpoint_test.go
@@ -61,7 +61,8 @@ var (
 
 func newHTTPServer(svc webhooks.Service) *httptest.Server {
 	logger := logger.NewMock()
-	mux := httpapi.MakeHandler(mocktracer.New(), svc, logger)
+	ac := mocks.NewAuthService("", nil, nil)
+	mux := httpapi.MakeHandler(mocktracer.New(), svc, ac, logger)
 	return httptest.NewServer(mux)
 }
 

--- a/webhooks/api/http/transport.go
+++ b/webhooks/api/http/transport.go
@@ -12,9 +12,12 @@ import (
 	"github.com/MainfluxLabs/mainflux"
 	log "github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"github.com/MainfluxLabs/mainflux/webhooks"
+	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
@@ -23,57 +26,84 @@ import (
 )
 
 // MakeHandler returns a HTTP handler for API endpoints.
-func MakeHandler(tracer opentracing.Tracer, svc webhooks.Service, logger log.Logger) http.Handler {
+func MakeHandler(tracer opentracing.Tracer, svc webhooks.Service, ac domain.AuthClient, logger log.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
 	}
 
 	r := bone.New()
 
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
 	r.Post("/things/:id/webhooks", kithttp.NewServer(
-		kitot.TraceServer(tracer, "create_webhooks")(createWebhooksEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "create_webhooks"),
+			withIdentity,
+		)(createWebhooksEndpoint(svc)),
 		decodeCreateWebhooks,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/things/:id/webhooks", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_webhooks_by_thing")(listWebhooksByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_webhooks_by_thing"),
+			withIdentity,
+		)(listWebhooksByThingEndpoint(svc)),
 		decodeListThingWebhooks,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/groups/:id/webhooks", kithttp.NewServer(
-		kitot.TraceServer(tracer, "list_webhooks_by_group")(listWebhooksByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_webhooks_by_group"),
+			withIdentity,
+		)(listWebhooksByGroupEndpoint(svc)),
 		decodeListGroupWebhooks,
 		encodeResponse,
 		opts...,
 	))
 	r.Post("/things/:id/webhooks/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_webhooks_by_thing")(listWebhooksByThingEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_webhooks_by_thing"),
+			withIdentity,
+		)(listWebhooksByThingEndpoint(svc)),
 		decodeSearchThingWebhooks,
 		encodeResponse,
 		opts...,
 	))
 	r.Post("/groups/:id/webhooks/search", kithttp.NewServer(
-		kitot.TraceServer(tracer, "search_webhooks_by_group")(listWebhooksByGroupEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "search_webhooks_by_group"),
+			withIdentity,
+		)(listWebhooksByGroupEndpoint(svc)),
 		decodeSearchGroupWebhooks,
 		encodeResponse,
 		opts...,
 	))
 	r.Get("/webhooks/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_webhook")(viewWebhookEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_webhook"),
+			withIdentity,
+		)(viewWebhookEndpoint(svc)),
 		decodeRequest,
 		encodeResponse,
 		opts...,
 	))
 	r.Put("/webhooks/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "update_webhook")(updateWebhookEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_webhook"),
+			withIdentity,
+		)(updateWebhookEndpoint(svc)),
 		decodeUpdateWebhook,
 		encodeResponse,
 		opts...,
 	))
 	r.Patch("/webhooks", kithttp.NewServer(
-		kitot.TraceServer(tracer, "remove_webhooks")(removeWebhooksEndpoint(svc)),
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "remove_webhooks"),
+			withIdentity,
+		)(removeWebhooksEndpoint(svc)),
 		decodeRemoveWebhooks,
 		encodeResponse,
 		opts...,


### PR DESCRIPTION
### Background

As a prerequisite to introducing the audit log service, it's necessary that platform events be accompanied by an identity of their _actor_, i.e. the user who initiated the event. For example, if a "thing removed" event is emitted by the `things` service, we want to know _who_ removed the thing.

### JWT token identification

To attach actor identity (represented by the `domain.Identity{Email string, ID string}` type) to an event before it is dispatched, it's necessary to decode the authentication JWT associated with the HTTP request that led to the creation of the event. This is usually done by the `auth` service `Identify` method, which takes a JWT and returns back the said `domain.Identity` representing the exact user identified by the token.

When thinking about _where_ to perform JWT identification in the event publishing pipeline, I initially gravitated towards the event publisher `.Publish()` method : make it accept a token and call out to `auth.Identify`, then attach the identity to the event before emitting it.

The key issue with that approach is that _most_ service methods that accept an auth token as an argument __already decode it (i.e. pass it to `auth.Identify`) at some point during their execution__, most commonly to perform authorization/permission checks. As such, performing identification at the event publisher level would introduce an additional, potentially unneeded cross-service gRPC call.

I thus needed to find a way to decode the auth token into a `domain.Identity` only _once per endpoint_ and make it subsequently available to the service method itself as well as the event publishing middleware. 

The natural solution for this, partially implemented by this PR, is a __`go-kit` middleware__ - see [`pkg/authn.IdentityMiddleware`](https://github.com/bool3max/mainflux/blob/a52788eba0cc3e357e6948e1f1501fd8fef7bd65/pkg/authn/transport.go#L26): it extracts the auth token from the context, passes it to `auth.Identify()`, and then attaches the returned `domain.Identity` back to the context - making it accessible to all downstream code, including the event publisher, which can make use of it without needing to re-identify the token.

Note however, that in its current state, this PR does not solve the duplicate token identification calls. It merely lays the groundwork for a proper refactor at a later time, which would entail rewriting all service method definitions to access the token from the context as opposed to an argument, and rewriting all authorization/permission checks to accept/work with a `domain.Identity` as opposed to a raw token.

Currently, __only the event publisher makes use of the `domain.Identity` value from the context__. The rest of the code still follows the existing pattern where the token is extracted by a `go-kit` `DecodeRequestFunc` and then forwarded to the service methods (as an argument), after which they eventually perform `auth.Identify` calls themselves. As such, the `IdentityMiddleware` does not abort the request on error (e.g. missing auth token or a failure during `auth.Identify`), it simply logs the error. This is something that would be changed in the future.

---

> After inspecting the codebase for calls to `auth.Identify` I discovered some _existing_ code-paths that make duplicate calls to `auth.Identify`. For example, the `canUserAccessGroup` helper in `things`:
> https://github.com/MainfluxLabs/mainflux/blob/6cddb5d118f6a6b859f1508e8a2907c08cb89e5d/things/groups.go#L317-L336
> ... it first makes a call to `auth.Identify` to obtain the User ID, but then later potentially a call to `isAdmin` - which calls `auth.Authorize`, which internally calls `Identify()` again, because the `AuthzReq` includes a `token` opposed to a `domain.Identity`.
> So perhaps this is something that could be improved as well. My initial hunch is that all authz-related code should accept an _identity_ as opposed to a token.


Depends on #1235 