### PR TITLE
MF-1232 - attach acting user identity to redis events

### DIFF
--- a/certs/events/handler.go
+++ b/certs/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc certs.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.ThingRemoved:
 		return h.svc.RemoveCertsByThing(ctx, e.ID)
 	case events.GroupRemoved:

--- a/consumers/alarms/events/handler.go
+++ b/consumers/alarms/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc alarms.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.ThingRemoved:
 		return h.svc.RemoveAlarmsByThing(ctx, e.ID)
 	case events.GroupRemoved:

--- a/consumers/notifiers/events/handler.go
+++ b/consumers/notifiers/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc notifiers.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.GroupRemoved:
 		return h.svc.RemoveNotifiersByGroup(ctx, e.ID)
 	}

--- a/downlinks/events/handler.go
+++ b/downlinks/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc downlinks.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.ThingRemoved:
 		return h.svc.RemoveDownlinksByThing(ctx, e.ID)
 	case events.ProfileUpdated:

--- a/filestore/events/handler.go
+++ b/filestore/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc filestore.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.ThingRemoved:
 		return h.svc.RemoveFiles(ctx, e.ID)
 	case events.GroupRemoved:

--- a/modbus/events/handler.go
+++ b/modbus/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc modbus.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.ThingRemoved:
 		return h.svc.RemoveClientsByThing(ctx, e.ID)
 	case events.ProfileUpdated:

--- a/mqtt/redis/events/handler.go
+++ b/mqtt/redis/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc mqtt.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.ThingRemoved:
 		return h.svc.RemoveSubscriptionsByThing(ctx, e.ID)
 	case events.GroupRemoved:

--- a/pkg/events/publisher.go
+++ b/pkg/events/publisher.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
 	"github.com/go-redis/redis/v8"
 )
 
@@ -44,7 +45,7 @@ type Publisher interface {
 	// channel. It's asynchronous, meaning that it doesn't block the caller
 	// and as such returns no errors. If the underlying event buffer is full,
 	// the oldest queued event is dropped to make space.
-	Publish(ctx context.Context, e Event)
+	Publish(ctx context.Context, e EventAction)
 
 	// Close stops the event drainer goroutine, attempts a final drain,
 	// and closes the underlying Redis client.
@@ -89,7 +90,7 @@ type publisher struct {
 	drainBackoff  time.Duration
 	shutdownDrain time.Duration
 
-	bufferCh chan RedisEvent
+	bufferCh chan redisEvent
 	logger   logger.Logger
 
 	stopCh    chan struct{}
@@ -138,7 +139,7 @@ func NewPublisher(cfg PublisherConfig, log logger.Logger) (Publisher, error) {
 		drainInterval: cfg.DrainInitialInterval,
 		drainBackoff:  cfg.DrainMaxBackoff,
 		shutdownDrain: cfg.ShutdownDrainTimeout,
-		bufferCh:      make(chan RedisEvent, cfg.BufferSize),
+		bufferCh:      make(chan redisEvent, cfg.BufferSize),
 		logger:        log,
 		stopCh:        make(chan struct{}),
 		doneCh:        make(chan struct{}),
@@ -148,8 +149,16 @@ func NewPublisher(cfg PublisherConfig, log logger.Logger) (Publisher, error) {
 	return p, nil
 }
 
-func (p *publisher) Publish(_ context.Context, e Event) {
-	re := e.Encode()
+func (p *publisher) Publish(ctx context.Context, e EventAction) {
+	event := Event{
+		Action: e,
+	}
+
+	if actorIdentity, ok := authn.IdentityFromCtx(ctx); ok {
+		event.ActorIdentity = actorIdentity
+	}
+
+	re := event.Encode()
 
 	// Attempt to enqueue the encoded event onto the buffer channel. If we succeed, simply return.
 	select {
@@ -179,7 +188,7 @@ func (p *publisher) Publish(_ context.Context, e Event) {
 		// buffer. Simply drop the incoming event and log.
 		p.logger.Warn(fmt.Sprintf(
 			"event publisher buffer full for stream %q; dropping incoming %s event",
-			p.stream, re.Operation(),
+			p.stream, re.operation(),
 		))
 	}
 }
@@ -219,7 +228,7 @@ func (p *publisher) runDrainer() {
 // finalDrain is the last pass that attempts to emit all remaining queued events in the buffer (including the passed pendingEvent)
 // after the Publisher has been signalled to stop from the outside, all the while respecting the maximum p.shutdownDrain time.
 // Events that aren't emitted in time are dropped and lost.
-func (p *publisher) finalDrain(pendingEvent *RedisEvent) {
+func (p *publisher) finalDrain(pendingEvent *redisEvent) {
 	stop := make(chan struct{})
 	timer := time.AfterFunc(p.shutdownDrain, func() { close(stop) })
 	defer timer.Stop()
@@ -250,7 +259,7 @@ func (p *publisher) finalDrain(pendingEvent *RedisEvent) {
 // emit attempts to XADD a specific event repeatedly until success or
 // until signalled to stop via the passed stop channel.
 // returns true on successful delivery, and false if signalled to stop in the midst of a retry attempt.
-func (p *publisher) emit(ev RedisEvent, stop <-chan struct{}) bool {
+func (p *publisher) emit(ev redisEvent, stop <-chan struct{}) bool {
 	backoff := p.drainInterval
 
 	for {
@@ -268,7 +277,7 @@ func (p *publisher) emit(ev RedisEvent, stop <-chan struct{}) bool {
 
 		p.logger.Warn(fmt.Sprintf(
 			"failed to publish %s event to stream %q: %s",
-			ev.Operation(), p.stream, err,
+			ev.operation(), p.stream, err,
 		))
 
 		// We failed to emit the event to Redis - retry after sleeping for the backoff time,

--- a/pkg/events/publisher.go
+++ b/pkg/events/publisher.go
@@ -154,8 +154,8 @@ func (p *publisher) Publish(ctx context.Context, e EventAction) {
 		Action: e,
 	}
 
-	if actorIdentity, ok := authn.IdentityFromCtx(ctx); ok {
-		event.ActorIdentity = actorIdentity
+	if jwtUserIdentity, ok := authn.IdentityFromCtx(ctx); ok {
+		event.JWTUserIdentity = jwtUserIdentity
 	}
 
 	re := event.Encode()

--- a/pkg/events/redis.go
+++ b/pkg/events/redis.go
@@ -31,8 +31,8 @@ const (
 	OrgCreate = orgPrefix + "create"
 	OrgRemove = orgPrefix + "remove"
 
-	actorIdentityUserID = "_actor_user_id"
-	actorIdentityEmail  = "_actor_user_email"
+	jwtIdentityUserID    = "jwt_identity_user_id"
+	jwtIdentityUserEmail = "jwt_identity_user_email"
 
 	ThingsStream = mainfluxPrefix + "things"
 	AuthStream   = mainfluxPrefix + "auth"
@@ -46,16 +46,16 @@ func (e redisEvent) operation() string {
 	return e.field("operation", "")
 }
 
-// actorIdentity returns the identity of the actor that initiated the event.
-func (e redisEvent) actorIdentity() domain.Identity {
+// jwtUserIdentity returns the identity of the user that initiated the event.
+func (e redisEvent) jwtUserIdentity() domain.Identity {
 	var identity domain.Identity
 
-	if actorUserID, ok := e[actorIdentityUserID]; ok {
-		identity.ID, _ = actorUserID.(string)
+	if jwtUserID, ok := e[jwtIdentityUserID]; ok {
+		identity.ID, _ = jwtUserID.(string)
 	}
 
-	if actorUserEmail, ok := e[actorIdentityEmail]; ok {
-		identity.Email, _ = actorUserEmail.(string)
+	if jwtUserEmail, ok := e[jwtIdentityUserEmail]; ok {
+		identity.Email, _ = jwtUserEmail.(string)
 	}
 
 	return identity

--- a/pkg/events/redis.go
+++ b/pkg/events/redis.go
@@ -6,6 +6,8 @@ package events
 import (
 	"context"
 	"fmt"
+
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 )
 
 const (
@@ -29,21 +31,38 @@ const (
 	OrgCreate = orgPrefix + "create"
 	OrgRemove = orgPrefix + "remove"
 
+	actorIdentityUserID = "_actor_user_id"
+	actorIdentityEmail  = "_actor_user_email"
+
 	ThingsStream = mainfluxPrefix + "things"
 	AuthStream   = mainfluxPrefix + "auth"
 )
 
-// RedisEvent is the raw payload delivered on a Redis stream.
-type RedisEvent map[string]any
+// redisEvent is the raw payload delivered on a Redis stream.
+type redisEvent map[string]any
 
-// Operation returns the event's operation name, or an empty string if missing.
-func (e RedisEvent) Operation() string {
-	s, _ := e["operation"].(string)
-	return s
+// operation returns the event's operation name, or an empty string if missing.
+func (e redisEvent) operation() string {
+	return e.field("operation", "")
 }
 
-// Field returns the string value stored under key, or def if missing.
-func (e RedisEvent) Field(key, def string) string {
+// actorIdentity returns the identity of the actor that initiated the event.
+func (e redisEvent) actorIdentity() domain.Identity {
+	var identity domain.Identity
+
+	if actorUserID, ok := e[actorIdentityUserID]; ok {
+		identity.ID, _ = actorUserID.(string)
+	}
+
+	if actorUserEmail, ok := e[actorIdentityEmail]; ok {
+		identity.Email, _ = actorUserEmail.(string)
+	}
+
+	return identity
+}
+
+// field returns the string value stored under key, or def if missing.
+func (e redisEvent) field(key, def string) string {
 	s, ok := e[key].(string)
 	if !ok {
 		return def

--- a/pkg/events/redis.go
+++ b/pkg/events/redis.go
@@ -50,13 +50,8 @@ func (e redisEvent) operation() string {
 func (e redisEvent) jwtUserIdentity() domain.Identity {
 	var identity domain.Identity
 
-	if jwtUserID, ok := e[jwtIdentityUserID]; ok {
-		identity.ID, _ = jwtUserID.(string)
-	}
-
-	if jwtUserEmail, ok := e[jwtIdentityUserEmail]; ok {
-		identity.Email, _ = jwtUserEmail.(string)
-	}
+	identity.ID, _ = e[jwtIdentityUserID].(string)
+	identity.Email, _ = e[jwtIdentityUserEmail].(string)
 
 	return identity
 }

--- a/pkg/events/schema.go
+++ b/pkg/events/schema.go
@@ -5,44 +5,75 @@ package events
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 )
 
-// Event is implemented by concrete typed events that can be encoded
-// to a type that can be transmitted by a Redis client.
-type Event interface {
-	Encode() RedisEvent
+// EventAction represents an action occurring on the platform.
+type EventAction interface {
+	// Encode returns a map representation of the event action.
+	Encode() map[string]any
+
+	// Operation returns the string representation of the event action operation.
+	Operation() string
 }
 
-// decodeEvent turns a raw RedisEvent into its typed Event equivalent based
-// on the operation field, or returns nil when the operation is unknown.
-func decodeEvent(re RedisEvent) Event {
-	switch re.Operation() {
-	case ThingCreate:
-		return DecodeThingCreated(re)
-	case ThingUpdate:
-		return DecodeThingUpdated(re)
-	case ThingUpdateGroupAndProfile:
-		return DecodeThingGroupAndProfileUpdated(re)
-	case ThingRemove:
-		return DecodeThingRemoved(re)
-	case ProfileCreate:
-		return DecodeProfileCreated(re)
-	case ProfileUpdate:
-		return DecodeProfileUpdated(re)
-	case ProfileRemove:
-		return DecodeProfileRemoved(re)
-	case GroupRemove:
-		return DecodeGroupRemoved(re)
-	case OrgCreate:
-		return DecodeOrgCreated(re)
-	case OrgRemove:
-		return DecodeOrgRemoved(re)
+// Event is the type representing a platform event, composed of an action and the actor's identity.
+type Event struct {
+	Action        EventAction
+	ActorIdentity domain.Identity
+}
+
+// Encode turns an Event into a redisEvent
+func (e Event) Encode() redisEvent {
+	re := redisEvent(e.Action.Encode())
+	re["operation"] = e.Action.Operation()
+
+	if e.ActorIdentity.ID != "" {
+		re[actorIdentityUserID] = e.ActorIdentity.ID
+		re[actorIdentityEmail] = e.ActorIdentity.Email
 	}
 
-	return nil
+	return re
+}
+
+// decodeEvent turns a raw RedisEvent into an Event.
+func decodeEvent(re redisEvent) (Event, error) {
+	var action EventAction
+
+	op := re.operation()
+
+	switch op {
+	case ThingCreate:
+		action = decodeThingCreated(re)
+	case ThingUpdate:
+		action = decodeThingUpdated(re)
+	case ThingUpdateGroupAndProfile:
+		action = decodeThingGroupAndProfileUpdated(re)
+	case ThingRemove:
+		action = decodeThingRemoved(re)
+	case ProfileCreate:
+		action = decodeProfileCreated(re)
+	case ProfileUpdate:
+		action = decodeProfileUpdated(re)
+	case ProfileRemove:
+		action = decodeProfileRemoved(re)
+	case GroupRemove:
+		action = decodeGroupRemoved(re)
+	case OrgCreate:
+		action = decodeOrgCreated(re)
+	case OrgRemove:
+		action = decodeOrgRemoved(re)
+	default:
+		return Event{}, fmt.Errorf("unknown event operation %s", op)
+	}
+
+	return Event{
+		Action:        action,
+		ActorIdentity: re.actorIdentity(),
+	}, nil
 }
 
 // ThingCreated signals the creation of a thing.
@@ -54,9 +85,8 @@ type ThingCreated struct {
 	Metadata  map[string]any
 }
 
-func (e ThingCreated) Encode() RedisEvent {
-	m := RedisEvent{
-		"operation":  ThingCreate,
+func (e ThingCreated) Encode() map[string]any {
+	m := map[string]any{
 		"id":         e.ID,
 		"group_id":   e.GroupID,
 		"profile_id": e.ProfileID,
@@ -72,14 +102,18 @@ func (e ThingCreated) Encode() RedisEvent {
 	return m
 }
 
-func DecodeThingCreated(e RedisEvent) ThingCreated {
+func (e ThingCreated) Operation() string {
+	return ThingCreate
+}
+
+func decodeThingCreated(e redisEvent) ThingCreated {
 	t := ThingCreated{
-		ID:        e.Field("id", ""),
-		GroupID:   e.Field("group_id", ""),
-		ProfileID: e.Field("profile_id", ""),
-		Name:      e.Field("name", ""),
+		ID:        e.field("id", ""),
+		GroupID:   e.field("group_id", ""),
+		ProfileID: e.field("profile_id", ""),
+		Name:      e.field("name", ""),
 	}
-	if raw := e.Field("metadata", ""); raw != "" {
+	if raw := e.field("metadata", ""); raw != "" {
 		_ = json.Unmarshal([]byte(raw), &t.Metadata)
 	}
 	return t
@@ -93,9 +127,12 @@ type ThingUpdated struct {
 	Metadata  map[string]any
 }
 
-func (e ThingUpdated) Encode() RedisEvent {
-	m := RedisEvent{
-		"operation":  ThingUpdate,
+func (e ThingUpdated) Operation() string {
+	return ThingUpdate
+}
+
+func (e ThingUpdated) Encode() map[string]any {
+	m := map[string]any{
 		"id":         e.ID,
 		"profile_id": e.ProfileID,
 	}
@@ -110,13 +147,13 @@ func (e ThingUpdated) Encode() RedisEvent {
 	return m
 }
 
-func DecodeThingUpdated(e RedisEvent) ThingUpdated {
+func decodeThingUpdated(e redisEvent) ThingUpdated {
 	t := ThingUpdated{
-		ID:        e.Field("id", ""),
-		ProfileID: e.Field("profile_id", ""),
-		Name:      e.Field("name", ""),
+		ID:        e.field("id", ""),
+		ProfileID: e.field("profile_id", ""),
+		Name:      e.field("name", ""),
 	}
-	if raw := e.Field("metadata", ""); raw != "" {
+	if raw := e.field("metadata", ""); raw != "" {
 		_ = json.Unmarshal([]byte(raw), &t.Metadata)
 	}
 	return t
@@ -129,9 +166,12 @@ type ThingGroupAndProfileUpdated struct {
 	GroupID   string
 }
 
-func (e ThingGroupAndProfileUpdated) Encode() RedisEvent {
-	m := RedisEvent{
-		"operation":  ThingUpdateGroupAndProfile,
+func (e ThingGroupAndProfileUpdated) Operation() string {
+	return ThingUpdateGroupAndProfile
+}
+
+func (e ThingGroupAndProfileUpdated) Encode() map[string]any {
+	m := map[string]any{
 		"id":         e.ID,
 		"profile_id": e.ProfileID,
 	}
@@ -141,11 +181,11 @@ func (e ThingGroupAndProfileUpdated) Encode() RedisEvent {
 	return m
 }
 
-func DecodeThingGroupAndProfileUpdated(e RedisEvent) ThingGroupAndProfileUpdated {
+func decodeThingGroupAndProfileUpdated(e redisEvent) ThingGroupAndProfileUpdated {
 	return ThingGroupAndProfileUpdated{
-		ID:        e.Field("id", ""),
-		ProfileID: e.Field("profile_id", ""),
-		GroupID:   e.Field("group_id", ""),
+		ID:        e.field("id", ""),
+		ProfileID: e.field("profile_id", ""),
+		GroupID:   e.field("group_id", ""),
 	}
 }
 
@@ -154,15 +194,18 @@ type ThingRemoved struct {
 	ID string
 }
 
-func (e ThingRemoved) Encode() RedisEvent {
-	return RedisEvent{
-		"operation": ThingRemove,
-		"id":        e.ID,
+func (e ThingRemoved) Operation() string {
+	return ThingRemove
+}
+
+func (e ThingRemoved) Encode() map[string]any {
+	return redisEvent{
+		"id": e.ID,
 	}
 }
 
-func DecodeThingRemoved(e RedisEvent) ThingRemoved {
-	return ThingRemoved{ID: e.Field("id", "")}
+func decodeThingRemoved(e redisEvent) ThingRemoved {
+	return ThingRemoved{ID: e.field("id", "")}
 }
 
 // ProfileCreated signals the creation of a profile.
@@ -173,11 +216,14 @@ type ProfileCreated struct {
 	Metadata map[string]any
 }
 
-func (e ProfileCreated) Encode() RedisEvent {
-	m := RedisEvent{
-		"operation": ProfileCreate,
-		"id":        e.ID,
-		"group_id":  e.GroupID,
+func (e ProfileCreated) Operation() string {
+	return ProfileCreate
+}
+
+func (e ProfileCreated) Encode() map[string]any {
+	m := redisEvent{
+		"id":       e.ID,
+		"group_id": e.GroupID,
 	}
 	if e.Name != "" {
 		m["name"] = e.Name
@@ -190,13 +236,13 @@ func (e ProfileCreated) Encode() RedisEvent {
 	return m
 }
 
-func DecodeProfileCreated(e RedisEvent) ProfileCreated {
+func decodeProfileCreated(e redisEvent) ProfileCreated {
 	p := ProfileCreated{
-		ID:      e.Field("id", ""),
-		GroupID: e.Field("group_id", ""),
-		Name:    e.Field("name", ""),
+		ID:      e.field("id", ""),
+		GroupID: e.field("group_id", ""),
+		Name:    e.field("name", ""),
 	}
-	if raw := e.Field("metadata", ""); raw != "" {
+	if raw := e.field("metadata", ""); raw != "" {
 		_ = json.Unmarshal([]byte(raw), &p.Metadata)
 	}
 	return p
@@ -210,10 +256,13 @@ type ProfileUpdated struct {
 	Metadata map[string]any
 }
 
-func (e ProfileUpdated) Encode() RedisEvent {
-	m := RedisEvent{
-		"operation": ProfileUpdate,
-		"id":        e.ID,
+func (e ProfileUpdated) Operation() string {
+	return ProfileUpdate
+}
+
+func (e ProfileUpdated) Encode() map[string]any {
+	m := redisEvent{
+		"id": e.ID,
 	}
 	if e.Name != "" {
 		m["name"] = e.Name
@@ -231,19 +280,18 @@ func (e ProfileUpdated) Encode() RedisEvent {
 	return m
 }
 
-
-func DecodeProfileUpdated(e RedisEvent) ProfileUpdated {
+func decodeProfileUpdated(e redisEvent) ProfileUpdated {
 	p := ProfileUpdated{
-		ID:   e.Field("id", ""),
-		Name: e.Field("name", ""),
+		ID:   e.field("id", ""),
+		Name: e.field("name", ""),
 	}
-	if raw := e.Field("config", ""); raw != "" {
+	if raw := e.field("config", ""); raw != "" {
 		var cfg domain.ProfileConfig
 		if err := json.Unmarshal([]byte(raw), &cfg); err == nil {
 			p.Config = &cfg
 		}
 	}
-	if raw := e.Field("metadata", ""); raw != "" {
+	if raw := e.field("metadata", ""); raw != "" {
 		_ = json.Unmarshal([]byte(raw), &p.Metadata)
 	}
 	return p
@@ -254,15 +302,18 @@ type ProfileRemoved struct {
 	ID string
 }
 
-func (e ProfileRemoved) Encode() RedisEvent {
-	return RedisEvent{
-		"operation": ProfileRemove,
-		"id":        e.ID,
+func (e ProfileRemoved) Operation() string {
+	return ProfileRemove
+}
+
+func (e ProfileRemoved) Encode() map[string]any {
+	return redisEvent{
+		"id": e.ID,
 	}
 }
 
-func DecodeProfileRemoved(e RedisEvent) ProfileRemoved {
-	return ProfileRemoved{ID: e.Field("id", "")}
+func decodeProfileRemoved(e redisEvent) ProfileRemoved {
+	return ProfileRemoved{ID: e.field("id", "")}
 }
 
 // GroupRemoved signals that a group has been removed.
@@ -271,10 +322,13 @@ type GroupRemoved struct {
 	ThingIDs []string
 }
 
-func (e GroupRemoved) Encode() RedisEvent {
-	m := RedisEvent{
-		"operation": GroupRemove,
-		"id":        e.ID,
+func (e GroupRemoved) Operation() string {
+	return GroupRemove
+}
+
+func (e GroupRemoved) Encode() map[string]any {
+	m := redisEvent{
+		"id": e.ID,
 	}
 	if len(e.ThingIDs) > 0 {
 		m["thing_ids"] = strings.Join(e.ThingIDs, ",")
@@ -282,9 +336,9 @@ func (e GroupRemoved) Encode() RedisEvent {
 	return m
 }
 
-func DecodeGroupRemoved(e RedisEvent) GroupRemoved {
-	g := GroupRemoved{ID: e.Field("id", "")}
-	if raw := e.Field("thing_ids", ""); raw != "" {
+func decodeGroupRemoved(e redisEvent) GroupRemoved {
+	g := GroupRemoved{ID: e.field("id", "")}
+	if raw := e.field("thing_ids", ""); raw != "" {
 		g.ThingIDs = strings.Split(raw, ",")
 	}
 	return g
@@ -295,15 +349,18 @@ type OrgCreated struct {
 	ID string
 }
 
-func (e OrgCreated) Encode() RedisEvent {
-	return RedisEvent{
-		"operation": OrgCreate,
-		"id":        e.ID,
+func (e OrgCreated) Operation() string {
+	return OrgCreate
+}
+
+func (e OrgCreated) Encode() map[string]any {
+	return redisEvent{
+		"id": e.ID,
 	}
 }
 
-func DecodeOrgCreated(e RedisEvent) OrgCreated {
-	return OrgCreated{ID: e.Field("id", "")}
+func decodeOrgCreated(e redisEvent) OrgCreated {
+	return OrgCreated{ID: e.field("id", "")}
 }
 
 // OrgRemoved signals that an organization has been removed.
@@ -311,13 +368,16 @@ type OrgRemoved struct {
 	ID string
 }
 
-func (e OrgRemoved) Encode() RedisEvent {
-	return RedisEvent{
-		"operation": OrgRemove,
-		"id":        e.ID,
+func (e OrgRemoved) Operation() string {
+	return OrgRemove
+}
+
+func (e OrgRemoved) Encode() map[string]any {
+	return redisEvent{
+		"id": e.ID,
 	}
 }
 
-func DecodeOrgRemoved(e RedisEvent) OrgRemoved {
-	return OrgRemoved{ID: e.Field("id", "")}
+func decodeOrgRemoved(e redisEvent) OrgRemoved {
+	return OrgRemoved{ID: e.field("id", "")}
 }

--- a/pkg/events/schema.go
+++ b/pkg/events/schema.go
@@ -20,10 +20,11 @@ type EventAction interface {
 	Operation() string
 }
 
-// Event is the type representing a platform event, composed of an action and the actor's identity.
+// Event is the type representing a platform event, composed of an action and the identity
+// of the user who initiated the event.
 type Event struct {
-	Action        EventAction
-	ActorIdentity domain.Identity
+	Action          EventAction
+	JWTUserIdentity domain.Identity
 }
 
 // Encode turns an Event into a redisEvent
@@ -31,9 +32,9 @@ func (e Event) Encode() redisEvent {
 	re := redisEvent(e.Action.Encode())
 	re["operation"] = e.Action.Operation()
 
-	if e.ActorIdentity.ID != "" {
-		re[actorIdentityUserID] = e.ActorIdentity.ID
-		re[actorIdentityEmail] = e.ActorIdentity.Email
+	if e.JWTUserIdentity.ID != "" {
+		re[jwtIdentityUserID] = e.JWTUserIdentity.ID
+		re[jwtIdentityUserEmail] = e.JWTUserIdentity.Email
 	}
 
 	return re
@@ -71,8 +72,8 @@ func decodeEvent(re redisEvent) (Event, error) {
 	}
 
 	return Event{
-		Action:        action,
-		ActorIdentity: re.actorIdentity(),
+		Action:          action,
+		JWTUserIdentity: re.jwtUserIdentity(),
 	}, nil
 }
 

--- a/pkg/events/subscriber.go
+++ b/pkg/events/subscriber.go
@@ -158,13 +158,10 @@ func (es *subEventStore) handleBatch(ctx context.Context, msgs []redis.XMessage,
 			return lastID
 		}
 
-		re := RedisEvent(msg.Values)
-		event := decodeEvent(re)
-		if event == nil {
-			es.logger.Warn(fmt.Sprintf(
-				"unknown operation %q in stream %q (id=%s); skipping",
-				re.Operation(), es.stream, msg.ID,
-			))
+		re := redisEvent(msg.Values)
+		event, err := decodeEvent(re)
+		if err != nil {
+			es.logger.Warn(fmt.Sprintf("error prcessing event (id=%s) in stream %q: %s", msg.ID, es.stream, err.Error()))
 			lastID = msg.ID
 			continue
 		}
@@ -172,7 +169,7 @@ func (es *subEventStore) handleBatch(ctx context.Context, msgs []redis.XMessage,
 		if err := es.dispatch(ctx, h, event); err != nil {
 			es.logger.Warn(fmt.Sprintf(
 				"giving up on event %s (operation=%s) after retries: %s",
-				msg.ID, re.Operation(), err,
+				msg.ID, re.operation(), err,
 			))
 		}
 		lastID = msg.ID

--- a/pkg/events/subscriber_test.go
+++ b/pkg/events/subscriber_test.go
@@ -75,7 +75,7 @@ func publishThingRemoved(t *testing.T, stream, id string) {
 	t.Helper()
 	err := redisClient.XAdd(context.Background(), &r.XAddArgs{
 		Stream: stream,
-		Values: map[string]any(events.ThingRemoved{ID: id}.Encode()),
+		Values: map[string]any(events.Event{Action: events.ThingRemoved{ID: id}}.Encode()),
 	}).Err()
 	require.NoError(t, err, "publishing event")
 }
@@ -142,7 +142,7 @@ func TestFirstBootSkipsHistory(t *testing.T) {
 
 	// Pre-boot events must not have been replayed.
 	assert.Equal(t, 1, h.count())
-	got := h.received[0].(events.ThingRemoved)
+	got := h.received[0].Action.(events.ThingRemoved)
 	assert.Equal(t, "post-boot-1", got.ID)
 }
 
@@ -178,7 +178,7 @@ func TestCursorPersistsAcrossRestart(t *testing.T) {
 	}()
 
 	require.True(t, waitForCount(t, h2, 1, 2000), "expected event published while subscriber was down to be delivered on restart")
-	assert.Equal(t, "b", h2.received[0].(events.ThingRemoved).ID)
+	assert.Equal(t, "b", h2.received[0].Action.(events.ThingRemoved).ID)
 }
 
 func TestUnknownOperationIsSkipped(t *testing.T) {
@@ -206,7 +206,7 @@ func TestUnknownOperationIsSkipped(t *testing.T) {
 	// advanced past the bogus entry.
 	publishThingRemoved(t, events.ThingsStream, "after-bogus")
 	require.True(t, waitForCount(t, h, 1, 2000))
-	assert.Equal(t, "after-bogus", h.received[0].(events.ThingRemoved).ID)
+	assert.Equal(t, "after-bogus", h.received[0].Action.(events.ThingRemoved).ID)
 }
 
 func TestHandlerErrorRetriesThenSkips(t *testing.T) {
@@ -233,7 +233,7 @@ func TestHandlerErrorRetriesThenSkips(t *testing.T) {
 	// Cursor must have advanced so the next event is delivered immediately.
 	publishThingRemoved(t, events.ThingsStream, "after-fail")
 	require.True(t, waitForCount(t, h, 3, 2000), "expected subsequent event to be delivered after skip")
-	assert.Equal(t, "after-fail", h.received[2].(events.ThingRemoved).ID)
+	assert.Equal(t, "after-fail", h.received[2].Action.(events.ThingRemoved).ID)
 }
 
 func TestCursorMatchesLastDeliveredID(t *testing.T) {

--- a/readers/events/handler.go
+++ b/readers/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc readers.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.ThingRemoved:
 		return h.svc.RemoveMessagesByThing(ctx, e.ID)
 	case events.GroupRemoved:

--- a/rules/events/handler.go
+++ b/rules/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc rules.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.ThingRemoved:
 		if err := h.svc.UnassignRulesFromThing(ctx, e.ID); err != nil {
 			return err

--- a/things/redis/events/handler.go
+++ b/things/redis/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc things.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.OrgRemoved:
 		if _, err := h.svc.RemoveGroupsByOrg(ctx, e.ID); err != nil {
 			return err

--- a/uiconfigs/events/handler.go
+++ b/uiconfigs/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc uiconfigs.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.ThingRemoved:
 		return h.svc.RemoveThingConfig(ctx, e.ID)
 	case events.OrgRemoved:

--- a/webhooks/events/handler.go
+++ b/webhooks/events/handler.go
@@ -20,7 +20,7 @@ func NewEventHandler(svc webhooks.Service) events.EventHandler {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
-	switch e := event.(type) {
+	switch e := event.Action.(type) {
 	case events.ThingRemoved:
 		return h.svc.RemoveWebhooksByThing(ctx, e.ID)
 	case events.GroupRemoved:


### PR DESCRIPTION
- Un-exported `pkg/events.RedisEvent` and its methods
- Made slight improvements to the structure of event-related types
    - `EventAction` types now define the operation string in a separate `Operation()` method, meaning that they no longer have to encode in manually in `Encode()`. 
    - The base `Event` type is now a concrete `struct` and features an `.Encode()` method which takes care of encoding all of its parameters into the final `redisEvent`
    - The base `Event` type now additionally contains a `domain.Identity` field containing the identity of the user who initiated the event. The identity is attached in the event publisher's `.Publish()` method, which extracts it from the passed `context`, and attaches it to the event

Depends on #1236. Resolves #1232.