### PR TITLE
MF-1161 - Introduce Input Config with subtopic filtering for rules

### DIFF
--- a/api/openapi/rules.yml
+++ b/api/openapi/rules.yml
@@ -455,6 +455,12 @@ components:
             type: string
             format: uuid
           example: ["123e4567-e89b-12d3-a456-426614174000"]
+        config:
+          type: object
+          description: Optional input-type-specific configuration.
+          additionalProperties: true
+          example:
+            subtopic: "sensors.room1"
       required: [type]
     UpdateRuleInput:
       type: object
@@ -464,6 +470,12 @@ components:
           type: string
           enum: [message, alarm, command]
           example: "message"
+        config:
+          type: object
+          description: Optional input-type-specific configuration.
+          additionalProperties: true
+          example:
+            subtopic: "sensors.room1"
       required: [type]
     Condition:
       type: object

--- a/rules/README.md
+++ b/rules/README.md
@@ -33,10 +33,19 @@ A rule evaluates a set of conditions against an incoming payload. When condition
 
 The `input` field defines what triggers rule evaluation.
 
-| Field       | Description                                    |
-| ----------- | ---------------------------------------------- |
-| `type`      | Trigger type: `message`, `alarm`, or `command` |
-| `thing_ids` | IDs of things to which this rule applies.      |
+| Field       | Description                                       |
+| ----------- | ------------------------------------------------- |
+| `type`      | Trigger type: `message`, `alarm`, or `command`    |
+| `thing_ids` | IDs of things to which this rule applies          |
+| `config`    | Optional input-type-specific settings (see below) |
+
+### Input Config
+
+The `config` field holds optional, input-type-specific settings.
+
+| Field      | Description                                                                                  |
+| ---------- | -------------------------------------------------------------------------------------------- |
+| `subtopic` | Filters messages by subtopic (e.g. `sensors.room1`). If omitted, all messages are evaluated. |
 
 ### Conditions
 

--- a/rules/api/http/rules/endpoint.go
+++ b/rules/api/http/rules/endpoint.go
@@ -119,7 +119,7 @@ func updateRuleEndpoint(svc rules.Service) endpoint.Endpoint {
 			ID:          req.id,
 			Name:        req.Name,
 			Description: req.Description,
-			Input:       rules.Input{Type: req.Input.Type},
+			Input:       rules.Input{Type: req.Input.Type, Config: req.Input.Config},
 			Conditions:  req.Conditions,
 			Operator:    req.Operator,
 			Actions:     req.Actions,

--- a/rules/api/http/rules/requests.go
+++ b/rules/api/http/rules/requests.go
@@ -131,7 +131,8 @@ func (req listRulesByGroupReq) validate() error {
 }
 
 type updateRuleInput struct {
-	Type string `json:"type"`
+	Type   string            `json:"type"`
+	Config rules.InputConfig `json:"config,omitempty"`
 }
 
 type updateRuleReq struct {

--- a/rules/postgres/init.go
+++ b/rules/postgres/init.go
@@ -138,6 +138,15 @@ func migrateDB(db *sqlx.DB) error {
 					`ALTER TABLE rules DROP COLUMN IF EXISTS input_type`,
 				},
 			},
+			{
+				Id: "rules_7",
+				Up: []string{
+					`ALTER TABLE rules ADD COLUMN IF NOT EXISTS input_config JSONB NOT NULL DEFAULT '{}'`,
+				},
+				Down: []string{
+					`ALTER TABLE rules DROP COLUMN IF EXISTS input_config`,
+				},
+			},
 		},
 	}
 	_, err := migrate.Exec(db.DB, "postgres", migrations, migrate.Up)

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -36,8 +36,8 @@ func (rr ruleRepository) Save(ctx context.Context, rls ...rules.Rule) ([]rules.R
 	}
 	defer tx.Rollback()
 
-	rq := `INSERT INTO rules (id, group_id, name, description, input_type, conditions, operator, actions)
-		VALUES (:id, :group_id, :name, :description, :input_type, :conditions, :operator, :actions);`
+	rq := `INSERT INTO rules (id, group_id, name, description, input_type, input_config, conditions, operator, actions)
+		VALUES (:id, :group_id, :name, :description, :input_type, :input_config, :conditions, :operator, :actions);`
 
 	for _, rule := range rls {
 		dbr, err := toDBRule(rule)
@@ -88,7 +88,7 @@ func (rr ruleRepository) RetrieveByGroup(ctx context.Context, groupID string, pm
 	}
 	whereClause := dbutil.BuildWhereClause(gq, nq, itq)
 
-	q := fmt.Sprintf(`SELECT id, group_id, name, description, input_type, conditions, operator, actions
+	q := fmt.Sprintf(`SELECT id, group_id, name, description, input_type, input_config, conditions, operator, actions
 		FROM rules %s
 		ORDER BY %s %s %s;`, whereClause, oq, dq, olq)
 
@@ -126,7 +126,7 @@ func (rr ruleRepository) RetrieveByThing(ctx context.Context, thingID string, pm
 	countClause := dbutil.BuildWhereClause(tq, itq)
 
 	q := fmt.Sprintf(`SELECT r.id, r.group_id, r.name, r.description,
-		r.input_type, r.conditions, r.operator, r.actions
+		r.input_type, r.input_config, r.conditions, r.operator, r.actions
 		FROM rules r %s %s
 		ORDER BY r.%s %s %s;`, joinClause, whereClause, oq, dq, olq)
 
@@ -144,7 +144,7 @@ func (rr ruleRepository) RetrieveByThing(ctx context.Context, thingID string, pm
 }
 
 func (rr ruleRepository) RetrieveByID(ctx context.Context, id string) (rules.Rule, error) {
-	q := `SELECT id, group_id, name, description, input_type, conditions, operator, actions
+	q := `SELECT id, group_id, name, description, input_type, input_config, conditions, operator, actions
 		FROM rules
 		WHERE id = $1;`
 
@@ -166,9 +166,9 @@ func (rr ruleRepository) RetrieveByID(ctx context.Context, id string) (rules.Rul
 }
 
 func (rr ruleRepository) Update(ctx context.Context, r rules.Rule) error {
-	uq := `UPDATE rules 
+	uq := `UPDATE rules
 		SET name = :name, description = :description, input_type = :input_type,
-		conditions = :conditions, operator = :operator, actions = :actions
+		input_config = :input_config, conditions = :conditions, operator = :operator, actions = :actions
 		WHERE id = :id;`
 
 	dbr, err := toDBRule(r)
@@ -363,12 +363,22 @@ type dbRule struct {
 	Name        string `db:"name"`
 	Description string `db:"description"`
 	InputType   string `db:"input_type"`
+	InputConfig []byte `db:"input_config"`
 	Conditions  []byte `db:"conditions"`
 	Operator    string `db:"operator"`
 	Actions     []byte `db:"actions"`
 }
 
 func toDBRule(r rules.Rule) (dbRule, error) {
+	inputConfig := []byte("{}")
+	if len(r.Input.Config) > 0 {
+		b, err := json.Marshal(r.Input.Config)
+		if err != nil {
+			return dbRule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
+		}
+		inputConfig = b
+	}
+
 	conditions, err := json.Marshal(r.Conditions)
 	if err != nil {
 		return dbRule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
@@ -385,6 +395,7 @@ func toDBRule(r rules.Rule) (dbRule, error) {
 		Name:        r.Name,
 		Description: r.Description,
 		InputType:   r.Input.Type,
+		InputConfig: inputConfig,
 		Conditions:  conditions,
 		Operator:    r.Operator,
 		Actions:     actions,
@@ -402,12 +413,17 @@ func toRule(dbr dbRule, thingIDs []string) (rules.Rule, error) {
 		return rules.Rule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
 	}
 
+	var inputConfig rules.InputConfig
+	if err := json.Unmarshal(dbr.InputConfig, &inputConfig); err != nil {
+		return rules.Rule{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
+	}
+
 	return rules.Rule{
 		ID:          dbr.ID,
 		GroupID:     dbr.GroupID,
 		Name:        dbr.Name,
 		Description: dbr.Description,
-		Input:       rules.Input{Type: dbr.InputType, ThingIDs: thingIDs},
+		Input:       rules.Input{Type: dbr.InputType, ThingIDs: thingIDs, Config: inputConfig},
 		Conditions:  conditions,
 		Operator:    dbr.Operator,
 		Actions:     actions,

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -13,14 +13,25 @@ import (
 )
 
 const (
-	InputTypeMessage  = "message"
-	InputTypeAlarm    = "alarm"
-	InputTypeCommand  = "command"
+	InputTypeMessage = "message"
+	InputTypeAlarm   = "alarm"
+	InputTypeCommand = "command"
 )
 
+type InputConfig map[string]any
+
+func (c InputConfig) Subtopic() string {
+	if c == nil {
+		return ""
+	}
+	s, _ := c["subtopic"].(string)
+	return s
+}
+
 type Input struct {
-	Type     string   `json:"type"`
-	ThingIDs []string `json:"thing_ids"`
+	Type     string      `json:"type"`
+	ThingIDs []string    `json:"thing_ids"`
+	Config   InputConfig `json:"config,omitempty"`
 }
 
 type Rule struct {

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -21,9 +21,6 @@ const (
 type InputConfig map[string]any
 
 func (c InputConfig) Subtopic() string {
-	if c == nil {
-		return ""
-	}
 	s, _ := c["subtopic"].(string)
 	return s
 }

--- a/rules/service.go
+++ b/rules/service.go
@@ -148,7 +148,7 @@ const (
 	// subjectAlarms represents subject used to publish messages that trigger an alarm.
 	subjectAlarms = "alarms"
 	// subjectSMTP represents subject used to publish messages that trigger an SMTP notification.
-	subjectSMTP     = "smtp"
+	subjectSMTP = "smtp"
 	// subjectWebhooks represents subject used to publish messages that trigger webhook forwarding.
 	subjectWebhooks = "webhooks"
 )
@@ -498,6 +498,9 @@ func (rs *rulesService) ConsumeMessage(_ string, msg protomfx.Message) error {
 	}
 
 	for _, rule := range page.Rules {
+		if sub := rule.Input.Config.Subtopic(); sub != "" && sub != msg.Subtopic {
+			continue
+		}
 		if err := rs.processRule(&msg, payload, rule); err != nil {
 			rs.logger.Error(fmt.Sprintf("processing rule with id %s failed with error: %v", rule.ID, err))
 		}


### PR DESCRIPTION
Resolves #1161

Adds a per-input-type config field (`input_config JSONB`) to rules, introducing `subtopic` as the first config option, used to filter message-type rules by subtopic.

Each input type (#1161 message, #1163 command, #1164 alarm) has its own set of config fields. Rather than adding a new flat column per type per issue, we introduce a single `input_config JSONB` column that stores type-specific config as a map. This keeps the schema stable, so future input type config fields are just new keys in the blob, no migration needed.

Regarding the `Subtopic` field in `Input.Config`, subtopic validation is omitted intentionally; the UI form will guide users on the correct **`dot-separated format`**.