### PR TITLE
MF-1250 - Add JSON converter endpoints, consolidate routes to ?to= query param, and extend SenML to support reader exports

### DIFF
--- a/api/openapi/converters.yml
+++ b/api/openapi/converters.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.1
 info:
   title: Mainflux converters service
-  description: HTTP API for converting CSV files into SenML or JSON messages and publishing them to the platform.
-  version: 1.0.0
+  description: HTTP API for converting CSV or JSON files into SenML or JSON messages and publishing them to the platform.
+  version: 1.1.0
 
 paths:
   /csv/senml:
@@ -63,6 +63,68 @@ paths:
         '500':
           $ref: "#/components/responses/ServiceError"
 
+  /json/senml:
+    post:
+      summary: Convert JSON to SenML messages
+      description: |
+        Parses the uploaded JSON file and publishes its records as SenML entries.
+
+        **JSON format:**
+        - A JSON array of objects.
+        - Each object must contain a `t` key with a Unix timestamp as a floating-point number.
+        - All other keys are treated as measurement names; their values must be floating-point numbers.
+
+        Each object produces one SenML record per measurement key with fields `n` (name), `v` (value), and `t` (timestamp).
+
+        Large files are processed in batches of 50,000 records with a 30-second pause between batches.
+      tags:
+        - converters
+      requestBody:
+        $ref: "#/components/requestBodies/ConvertJSONReq"
+      responses:
+        '202':
+          description: JSON accepted and messages published.
+        '400':
+          description: Failed due to malformed JSON or missing/invalid `t` field.
+        '401':
+          description: Missing or invalid Thing key provided.
+        '403':
+          description: Failed to perform authorization over the entity.
+        '415':
+          description: Missing or invalid content type. Must be multipart/form-data.
+        '500':
+          $ref: "#/components/responses/ServiceError"
+
+  /json/json:
+    post:
+      summary: Convert JSON to JSON messages
+      description: |
+        Parses the uploaded JSON file and publishes its records as JSON messages.
+
+        **JSON format:**
+        - A JSON array of objects.
+        - The key configured as the time field in the thing's profile transformer is parsed as a Unix timestamp (float) and stored as `Created` in the payload.
+        - All other keys are included as-is; numeric values remain numbers, strings remain strings.
+
+        Large files are processed in batches of 50,000 records with a 30-second pause between batches.
+      tags:
+        - converters
+      requestBody:
+        $ref: "#/components/requestBodies/ConvertJSONReq"
+      responses:
+        '202':
+          description: JSON accepted and messages published.
+        '400':
+          description: Failed due to malformed JSON or invalid time field value.
+        '401':
+          description: Missing or invalid Thing key provided.
+        '403':
+          description: Failed to perform authorization over the entity.
+        '415':
+          description: Missing or invalid content type. Must be multipart/form-data.
+        '500':
+          $ref: "#/components/responses/ServiceError"
+
 components:
   requestBodies:
     ConvertCSVReq:
@@ -77,6 +139,21 @@ components:
                 type: string
                 format: binary
                 description: CSV file to be converted.
+            required:
+              - file
+
+    ConvertJSONReq:
+      description: JSON file to convert and publish.
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              file:
+                type: string
+                format: binary
+                description: JSON file to be converted.
             required:
               - file
 

--- a/api/openapi/converters.yml
+++ b/api/openapi/converters.yml
@@ -5,26 +5,36 @@ info:
   version: 1.0.0
 
 paths:
-  /csv/senml:
+  /csv/convert:
     post:
-      summary: Convert CSV to SenML messages
+      summary: Convert CSV file to SenML or JSON messages
       description: |
-        Parses the uploaded CSV file and publishes its rows as SenML records.
+        Parses the uploaded CSV file and publishes its rows as SenML or JSON records, depending on the `to` query parameter.
 
-        **CSV format:**
-        - Row 1 (header): first column is ignored (timestamp column), remaining columns are measurement names.
-        - Row 2+ (data): first column is a Unix timestamp as a floating-point number, remaining columns are floating-point measurement values.
+        **CSV → SenML (`?to=senml`):**
+        - Row 1 (header): `name`, `time`, `value`, `string_value`, `bool_value`, `data_value`, `unit`, `sum` columns (reader-export format). Envelope columns (`subtopic`, `publisher`, `protocol`, `update_time`) are ignored.
+        - Each data row produces one SenML record. The `time` column is treated as nanoseconds and converted to seconds.
 
-        Large files are processed in batches of 50,000 records with a 30-second pause between batches.
+        **CSV → JSON (`?to=json`):**
+        - Row 1 (header): column names. The column matching the thing's profile transformer `time_field` is parsed as a timestamp. Envelope columns are skipped.
+        - Each data row produces one JSON object keyed by column name.
       tags:
         - converters
+      parameters:
+        - name: to
+          in: query
+          required: true
+          description: Output format — `senml` or `json`.
+          schema:
+            type: string
+            enum: [senml, json]
       requestBody:
         $ref: "#/components/requestBodies/ConvertCSVReq"
       responses:
         '202':
-          description: CSV accepted and messages published.
+          description: CSV accepted and messages are being published.
         '400':
-          description: Failed due to malformed CSV (fewer than 2 columns, or invalid timestamp value).
+          description: Failed due to malformed CSV, invalid timestamp, or missing/invalid `to` parameter.
         '401':
           description: Missing or invalid Thing key provided.
         '403':
@@ -34,88 +44,35 @@ paths:
         '500':
           $ref: "#/components/responses/ServiceError"
 
-  /csv/json:
+  /json/convert:
     post:
-      summary: Convert CSV to JSON messages
+      summary: Convert JSON file to SenML or JSON messages
       description: |
-        Parses the uploaded CSV file and publishes its rows as JSON records.
+        Parses the uploaded JSON file (array of objects) and publishes its records as SenML or JSON messages, depending on the `to` query parameter.
 
-        **CSV format:**
-        - Row 1 (header): must include a `created` column; remaining columns are field names.
-        - Row 2+ (data): values are automatically parsed as floating-point numbers where possible, otherwise kept as strings.
+        **JSON → SenML (`?to=senml`):**
+        - Each object must have a `t` (seconds) or `time` (nanoseconds) key and either a `name`/`n` key for named measurements or multiple numeric fields for multi-measurement records.
 
-        Large files are processed in batches of 50,000 records with a 30-second pause between batches.
+        **JSON → JSON (`?to=json`):**
+        - Reader-exported Format A objects (`{"payload": {...}, "created": ..., ...}`) are automatically unwrapped — the inner `payload` object becomes the record.
+        - The key configured as `time_field` in the profile transformer is stored as `Created`. Envelope fields are stripped.
       tags:
         - converters
-      requestBody:
-        $ref: "#/components/requestBodies/ConvertCSVReq"
-      responses:
-        '202':
-          description: CSV accepted and messages published.
-        '400':
-          description: Failed due to malformed CSV (fewer than 2 columns, or missing "created" column).
-        '401':
-          description: Missing or invalid Thing key provided.
-        '403':
-          description: Failed to perform authorization over the entity.
-        '415':
-          description: Missing or invalid content type. Must be multipart/form-data.
-        '500':
-          $ref: "#/components/responses/ServiceError"
-
-  /json/senml:
-    post:
-      summary: Convert JSON to SenML messages
-      description: |
-        Parses the uploaded JSON file and publishes its records as SenML entries.
-
-        **JSON format:**
-        - A JSON array of objects.
-        - Each object must contain a `t` key with a Unix timestamp as a floating-point number.
-        - All other keys are treated as measurement names; their values must be floating-point numbers.
-
-        Each object produces one SenML record per measurement key with fields `n` (name), `v` (value), and `t` (timestamp).
-
-        Large files are processed in batches of 50,000 records with a 30-second pause between batches.
-      tags:
-        - converters
+      parameters:
+        - name: to
+          in: query
+          required: true
+          description: Output format — `senml` or `json`.
+          schema:
+            type: string
+            enum: [senml, json]
       requestBody:
         $ref: "#/components/requestBodies/ConvertJSONReq"
       responses:
         '202':
-          description: JSON accepted and messages published.
+          description: JSON accepted and messages are being published.
         '400':
-          description: Failed due to malformed JSON or missing/invalid `t` field.
-        '401':
-          description: Missing or invalid Thing key provided.
-        '403':
-          description: Failed to perform authorization over the entity.
-        '415':
-          description: Missing or invalid content type. Must be multipart/form-data.
-        '500':
-          $ref: "#/components/responses/ServiceError"
-
-  /json/json:
-    post:
-      summary: Convert JSON to JSON messages
-      description: |
-        Parses the uploaded JSON file and publishes its records as JSON messages.
-
-        **JSON format:**
-        - A JSON array of objects.
-        - The key configured as the time field in the thing's profile transformer is parsed as a Unix timestamp (float) and stored as `Created` in the payload.
-        - All other keys are included as-is; numeric values remain numbers, strings remain strings.
-
-        Large files are processed in batches of 50,000 records with a 30-second pause between batches.
-      tags:
-        - converters
-      requestBody:
-        $ref: "#/components/requestBodies/ConvertJSONReq"
-      responses:
-        '202':
-          description: JSON accepted and messages published.
-        '400':
-          description: Failed due to malformed JSON or invalid time field value.
+          description: Failed due to malformed JSON, invalid time field, or missing/invalid `to` parameter.
         '401':
           description: Missing or invalid Thing key provided.
         '403':

--- a/api/openapi/converters.yml
+++ b/api/openapi/converters.yml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Mainflux converters service
   description: HTTP API for converting CSV or JSON files into SenML or JSON messages and publishing them to the platform.
-  version: 1.1.0
+  version: 1.0.0
 
 paths:
   /csv/senml:

--- a/api/openapi/converters.yml
+++ b/api/openapi/converters.yml
@@ -5,7 +5,7 @@ info:
   version: 1.0.0
 
 paths:
-  /csv/convert:
+  /csv:
     post:
       summary: Convert CSV file to SenML or JSON messages
       description: |
@@ -44,7 +44,7 @@ paths:
         '500':
           $ref: "#/components/responses/ServiceError"
 
-  /json/convert:
+  /json:
     post:
       summary: Convert JSON file to SenML or JSON messages
       description: |

--- a/converters/README.md
+++ b/converters/README.md
@@ -1,6 +1,6 @@
 # Converters Service
 
-The Converters service accepts CSV and JSON file uploads and publishes the parsed records as SenML or JSON messages to the platform on behalf of a thing. It is designed for bulk historical data ingestion —  common in migration scenarios or periodic batch uploads from data-logging devices.
+The Converters service accepts CSV and JSON file uploads and publishes the parsed records as SenML or JSON messages to the platform on behalf of a thing. It is designed for bulk historical data ingestion — common in migration scenarios or periodic batch uploads from data-logging devices.
 
 The service authenticates the request using the thing's internal key and publishes messages to NATS using the same subject scheme as live messages, so the data flows through the normal consumer pipeline.
 

--- a/converters/README.md
+++ b/converters/README.md
@@ -8,7 +8,7 @@ Large files are processed in batches of 50,000 records. A 30-second pause is ins
 
 ## CSV Formats
 
-### SenML (`POST /csv/senml`)
+### SenML (`POST /csv/convert?to=senml`)
 
 | Row       | First column                                   | Remaining columns                 |
 |-----------|------------------------------------------------|-----------------------------------|
@@ -17,7 +17,7 @@ Large files are processed in batches of 50,000 records. A 30-second pause is ins
 
 Each data row produces one SenML record per measurement column with fields `n` (name), `v` (value), and `t` (timestamp).
 
-### JSON (`POST /csv/json`)
+### JSON (`POST /csv/convert?to=json`)
 
 | Row       | Content                                                                                                                                |
 |-----------|----------------------------------------------------------------------------------------------------------------------------------------|
@@ -28,7 +28,7 @@ Each data row produces one JSON object keyed by column name.
 
 ## JSON Formats
 
-### SenML (`POST /json/senml`)
+### SenML (`POST /json/convert?to=senml`)
 
 Input is a JSON array of objects. Each object must contain a `t` key (Unix timestamp as a floating-point number) and one or more measurement keys with numeric values.
 
@@ -48,7 +48,7 @@ Example file (`readings.json`):
 ]
 ```
 
-### JSON (`POST /json/json`)
+### JSON (`POST /json/convert?to=json`)
 
 Input is a JSON array of objects. The key configured as the time field in the thing's profile transformer is parsed as a numeric Unix timestamp and stored as `Created` in the payload. All other keys are included as-is.
 
@@ -119,22 +119,22 @@ Requests must use `Content-Type: multipart/form-data`. The maximum accepted file
 
 ```bash
 # Convert and publish a CSV file as SenML messages
-curl -X POST http://localhost/converters/csv/senml \
+curl -X POST "http://localhost/converters/csv/convert?to=senml" \
   -H "Authorization: Thing <thing_key>" \
   -F "file=@/path/to/data.csv"
 
 # Convert and publish a CSV file as JSON messages
-curl -X POST http://localhost/converters/csv/json \
+curl -X POST "http://localhost/converters/csv/convert?to=json" \
   -H "Authorization: Thing <thing_key>" \
   -F "file=@/path/to/data.csv"
 
 # Convert and publish a JSON file as SenML messages
-curl -X POST http://localhost/converters/json/senml \
+curl -X POST "http://localhost/converters/json/convert?to=senml" \
   -H "Authorization: Thing <thing_key>" \
   -F "file=@/path/to/data.json"
 
 # Convert and publish a JSON file as JSON messages
-curl -X POST http://localhost/converters/json/json \
+curl -X POST "http://localhost/converters/json/convert?to=json" \
   -H "Authorization: Thing <thing_key>" \
   -F "file=@/path/to/data.json"
 ```

--- a/converters/README.md
+++ b/converters/README.md
@@ -1,6 +1,6 @@
 # Converters Service
 
-The Converters service accepts CSV file uploads and publishes the parsed rows as SenML or JSON messages to the platform on behalf of a thing. It is designed for bulk historical data ingestion — common in migration scenarios or periodic batch uploads from data-logging devices.
+The Converters service accepts CSV and JSON file uploads and publishes the parsed records as SenML or JSON messages to the platform on behalf of a thing. It is designed for bulk historical data ingestion —  common in migration scenarios or periodic batch uploads from data-logging devices.
 
 The service authenticates the request using the thing's internal key and publishes messages to NATS using the same subject scheme as live messages, so the data flows through the normal consumer pipeline.
 
@@ -25,6 +25,46 @@ Each data row produces one SenML record per measurement column with fields `n` (
 | Data rows | Values are parsed as floating-point numbers where possible; otherwise kept as strings.                                                 |
 
 Each data row produces one JSON object keyed by column name.
+
+## JSON Formats
+
+### SenML (`POST /json/senml`)
+
+Input is a JSON array of objects. Each object must contain a `t` key (Unix timestamp as a floating-point number) and one or more measurement keys with numeric values.
+
+| Key | Type    | Description                             |
+|-----|---------|-----------------------------------------|
+| `t` | float64 | Unix timestamp                          |
+| `*` | float64 | Measurement name → floating-point value |
+
+Each object produces one SenML record per measurement key with fields `n` (name), `v` (value), and `t` (timestamp).
+
+Example file (`readings.json`):
+
+```json
+[
+  {"t": 1709635200.0, "voltage": 120.1, "current": 1.2},
+  {"t": 1709635260.0, "voltage": 119.8, "current": 1.3}
+]
+```
+
+### JSON (`POST /json/json`)
+
+Input is a JSON array of objects. The key configured as the time field in the thing's profile transformer is parsed as a numeric Unix timestamp and stored as `Created` in the payload. All other keys are included as-is.
+
+| Key             | Type   | Description                                           |
+|-----------------|--------|-------------------------------------------------------|
+| `<time_field>`  | float64 | Becomes `Created` in the published payload           |
+| `*`             | any    | Other fields passed through unchanged                 |
+
+Example file (`events.json`), assuming `time_field` is set to `time` in the profile transformer config:
+
+```json
+[
+  {"time": 1709635200.0, "temperature": 21.5, "humidity": 60, "status": "ok"},
+  {"time": 1709635260.0, "temperature": 22.1, "humidity": 58, "status": "ok"}
+]
+```
 
 ## Configuration
 
@@ -87,6 +127,16 @@ curl -X POST http://localhost/converters/csv/senml \
 curl -X POST http://localhost/converters/csv/json \
   -H "Authorization: Thing <thing_key>" \
   -F "file=@/path/to/data.csv"
+
+# Convert and publish a JSON file as SenML messages
+curl -X POST http://localhost/converters/json/senml \
+  -H "Authorization: Thing <thing_key>" \
+  -F "file=@/path/to/data.json"
+
+# Convert and publish a JSON file as JSON messages
+curl -X POST http://localhost/converters/json/json \
+  -H "Authorization: Thing <thing_key>" \
+  -F "file=@/path/to/data.json"
 ```
 
 For the full HTTP API reference, see the [OpenAPI specification](https://mainfluxlabs.github.io/docs/swagger/).

--- a/converters/README.md
+++ b/converters/README.md
@@ -8,7 +8,7 @@ Large files are processed in batches of 50,000 records. A 30-second pause is ins
 
 ## CSV Formats
 
-### SenML (`POST /csv/convert?to=senml`)
+### SenML (`POST /csv?to=senml`)
 
 | Row       | First column                                   | Remaining columns                 |
 |-----------|------------------------------------------------|-----------------------------------|
@@ -17,7 +17,7 @@ Large files are processed in batches of 50,000 records. A 30-second pause is ins
 
 Each data row produces one SenML record per measurement column with fields `n` (name), `v` (value), and `t` (timestamp).
 
-### JSON (`POST /csv/convert?to=json`)
+### JSON (`POST /csv?to=json`)
 
 | Row       | Content                                                                                                                                |
 |-----------|----------------------------------------------------------------------------------------------------------------------------------------|
@@ -28,7 +28,7 @@ Each data row produces one JSON object keyed by column name.
 
 ## JSON Formats
 
-### SenML (`POST /json/convert?to=senml`)
+### SenML (`POST /json?to=senml`)
 
 Input is a JSON array of objects. Each object must contain a `t` key (Unix timestamp as a floating-point number) and one or more measurement keys with numeric values.
 
@@ -48,7 +48,7 @@ Example file (`readings.json`):
 ]
 ```
 
-### JSON (`POST /json/convert?to=json`)
+### JSON (`POST /json?to=json`)
 
 Input is a JSON array of objects. The key configured as the time field in the thing's profile transformer is parsed as a numeric Unix timestamp and stored as `Created` in the payload. All other keys are included as-is.
 
@@ -119,22 +119,22 @@ Requests must use `Content-Type: multipart/form-data`. The maximum accepted file
 
 ```bash
 # Convert and publish a CSV file as SenML messages
-curl -X POST "http://localhost/converters/csv/convert?to=senml" \
+curl -X POST "http://localhost/converters/csv?to=senml" \
   -H "Authorization: Thing <thing_key>" \
   -F "file=@/path/to/data.csv"
 
 # Convert and publish a CSV file as JSON messages
-curl -X POST "http://localhost/converters/csv/convert?to=json" \
+curl -X POST "http://localhost/converters/csv?to=json" \
   -H "Authorization: Thing <thing_key>" \
   -F "file=@/path/to/data.csv"
 
 # Convert and publish a JSON file as SenML messages
-curl -X POST "http://localhost/converters/json/convert?to=senml" \
+curl -X POST "http://localhost/converters/json?to=senml" \
   -H "Authorization: Thing <thing_key>" \
   -F "file=@/path/to/data.json"
 
 # Convert and publish a JSON file as JSON messages
-curl -X POST "http://localhost/converters/json/convert?to=json" \
+curl -X POST "http://localhost/converters/json?to=json" \
   -H "Authorization: Thing <thing_key>" \
   -F "file=@/path/to/data.json"
 ```

--- a/converters/api/endpoint.go
+++ b/converters/api/endpoint.go
@@ -19,9 +19,8 @@ func convertCSVEndpoint(svc converters.Service) endpoint.Endpoint {
 
 		switch req.to {
 		case toSenML:
-			// Publish async to avoid blocking past the gateway timeout on large files.
 			go func() { _ = svc.PublishSenMLMessagesFromCSV(context.Background(), req.key.Value, req.csvLines) }()
-		default:
+		case toJSON:
 			go func() { _ = svc.PublishJSONMessagesFromCSV(context.Background(), req.key.Value, req.csvLines) }()
 		}
 
@@ -38,9 +37,8 @@ func convertJSONEndpoint(svc converters.Service) endpoint.Endpoint {
 
 		switch req.to {
 		case toSenML:
-			// Publish async to avoid blocking past the gateway timeout on large files.
 			go func() { _ = svc.PublishSenMLMessagesFromJSON(context.Background(), req.key.Value, req.records) }()
-		default:
+		case toJSON:
 			go func() { _ = svc.PublishJSONMessagesFromJSON(context.Background(), req.key.Value, req.records) }()
 		}
 

--- a/converters/api/endpoint.go
+++ b/converters/api/endpoint.go
@@ -18,7 +18,7 @@ func convertCSVEndpoint(svc converters.Service) endpoint.Endpoint {
 		}
 
 		switch req.to {
-		case "senml":
+		case toSenML:
 			// Publish async to avoid blocking past the gateway timeout on large files.
 			go func() { _ = svc.PublishSenMLMessagesFromCSV(context.Background(), req.key.Value, req.csvLines) }()
 		default:
@@ -37,7 +37,7 @@ func convertJSONEndpoint(svc converters.Service) endpoint.Endpoint {
 		}
 
 		switch req.to {
-		case "senml":
+		case toSenML:
 			// Publish async to avoid blocking past the gateway timeout on large files.
 			go func() { _ = svc.PublishSenMLMessagesFromJSON(context.Background(), req.key.Value, req.records) }()
 		default:

--- a/converters/api/endpoint.go
+++ b/converters/api/endpoint.go
@@ -19,6 +19,7 @@ func convertCSVToJSONEndpoint(svc converters.Service) endpoint.Endpoint {
 
 		// Publish async to avoid blocking past the gateway timeout on large files.
 		go func() { _ = svc.PublishJSONMessagesFromCSV(context.Background(), req.key.Value, req.csvLines) }()
+
 		return nil, nil
 	}
 }

--- a/converters/api/endpoint.go
+++ b/converters/api/endpoint.go
@@ -10,57 +10,39 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
-func convertCSVToJSONEndpoint(svc converters.Service) endpoint.Endpoint {
+func convertCSVEndpoint(svc converters.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request any) (any, error) {
 		req := request.(convertCSVReq)
 		if err := req.validate(); err != nil {
 			return nil, err
 		}
 
-		// Publish async to avoid blocking past the gateway timeout on large files.
-		go func() { _ = svc.PublishJSONMessagesFromCSV(context.Background(), req.key.Value, req.csvLines) }()
-
-		return nil, nil
-	}
-}
-
-func convertCSVToSenMLEndpoint(svc converters.Service) endpoint.Endpoint {
-	return func(ctx context.Context, request any) (any, error) {
-		req := request.(convertCSVReq)
-		if err := req.validate(); err != nil {
-			return nil, err
+		switch req.to {
+		case "senml":
+			// Publish async to avoid blocking past the gateway timeout on large files.
+			go func() { _ = svc.PublishSenMLMessagesFromCSV(context.Background(), req.key.Value, req.csvLines) }()
+		default:
+			go func() { _ = svc.PublishJSONMessagesFromCSV(context.Background(), req.key.Value, req.csvLines) }()
 		}
 
-		// Publish async to avoid blocking past the gateway timeout on large files.
-		go func() { _ = svc.PublishSenMLMessagesFromCSV(context.Background(), req.key.Value, req.csvLines) }()
-
 		return nil, nil
 	}
 }
 
-func convertJSONToJSONEndpoint(svc converters.Service) endpoint.Endpoint {
+func convertJSONEndpoint(svc converters.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request any) (any, error) {
 		req := request.(convertJSONReq)
 		if err := req.validate(); err != nil {
 			return nil, err
 		}
 
-		// Publish async to avoid blocking past the gateway timeout on large files.
-		go func() { _ = svc.PublishJSONMessagesFromJSON(context.Background(), req.key.Value, req.records) }()
-
-		return nil, nil
-	}
-}
-
-func convertJSONToSenMLEndpoint(svc converters.Service) endpoint.Endpoint {
-	return func(ctx context.Context, request any) (any, error) {
-		req := request.(convertJSONReq)
-		if err := req.validate(); err != nil {
-			return nil, err
+		switch req.to {
+		case "senml":
+			// Publish async to avoid blocking past the gateway timeout on large files.
+			go func() { _ = svc.PublishSenMLMessagesFromJSON(context.Background(), req.key.Value, req.records) }()
+		default:
+			go func() { _ = svc.PublishJSONMessagesFromJSON(context.Background(), req.key.Value, req.records) }()
 		}
-
-		// Publish async to avoid blocking past the gateway timeout on large files.
-		go func() { _ = svc.PublishSenMLMessagesFromJSON(context.Background(), req.key.Value, req.records) }()
 
 		return nil, nil
 	}

--- a/converters/api/endpoint.go
+++ b/converters/api/endpoint.go
@@ -17,7 +17,37 @@ func convertCSVToJSONEndpoint(svc converters.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		if err := svc.PublishJSONMessages(ctx, req.key.Value, req.csvLines); err != nil {
+		if err := svc.PublishJSONMessagesFromCSV(ctx, req.key.Value, req.csvLines); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+}
+
+func convertJSONToSenMLEndpoint(svc converters.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request any) (any, error) {
+		req := request.(convertJSONReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		if err := svc.PublishSenMLMessagesFromJSON(ctx, req.key.Value, req.records); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+}
+
+func convertJSONToJSONEndpoint(svc converters.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request any) (any, error) {
+		req := request.(convertJSONReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		if err := svc.PublishJSONMessagesFromJSON(ctx, req.key.Value, req.records); err != nil {
 			return nil, err
 		}
 
@@ -32,7 +62,7 @@ func convertCSVToSenMLEndpoint(svc converters.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		if err := svc.PublishSenMLMessages(ctx, req.key.Value, req.csvLines); err != nil {
+		if err := svc.PublishSenMLMessagesFromCSV(ctx, req.key.Value, req.csvLines); err != nil {
 			return nil, err
 		}
 

--- a/converters/api/logging.go
+++ b/converters/api/logging.go
@@ -27,10 +27,10 @@ func LoggingMiddleware(svc converters.Service, logger log.Logger) converters.Ser
 	return &loggingMiddleware{logger, svc}
 }
 
-func (lm *loggingMiddleware) PublishJSONMessages(ctx context.Context, token string, csvLines [][]string) (err error) {
+func (lm *loggingMiddleware) PublishSenMLMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
 	defer func(begin time.Time) {
 		email := authn.EmailFromToken(token)
-		message := fmt.Sprintf("Method publish_json_messages by user %s took %s to complete", email, time.Since(begin))
+		message := fmt.Sprintf("Method publish_senml_messages_from_json by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -38,13 +38,13 @@ func (lm *loggingMiddleware) PublishJSONMessages(ctx context.Context, token stri
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.PublishJSONMessages(ctx, token, csvLines)
+	return lm.svc.PublishSenMLMessagesFromJSON(ctx, token, records)
 }
 
-func (lm *loggingMiddleware) PublishSenMLMessages(ctx context.Context, token string, csvLines [][]string) (err error) {
+func (lm *loggingMiddleware) PublishJSONMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
 	defer func(begin time.Time) {
 		email := authn.EmailFromToken(token)
-		message := fmt.Sprintf("Method publish_senml_messages by user %s took %s to complete", email, time.Since(begin))
+		message := fmt.Sprintf("Method publish_json_messages_from_json by user %s took %s to complete", email, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -52,5 +52,33 @@ func (lm *loggingMiddleware) PublishSenMLMessages(ctx context.Context, token str
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.PublishSenMLMessages(ctx, token, csvLines)
+	return lm.svc.PublishJSONMessagesFromJSON(ctx, token, records)
+}
+
+func (lm *loggingMiddleware) PublishJSONMessagesFromCSV(ctx context.Context, token string, csvLines [][]string) (err error) {
+	defer func(begin time.Time) {
+		email := authn.EmailFromToken(token)
+		message := fmt.Sprintf("Method publish_json_messages_from_csv by user %s took %s to complete", email, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.PublishJSONMessagesFromCSV(ctx, token, csvLines)
+}
+
+func (lm *loggingMiddleware) PublishSenMLMessagesFromCSV(ctx context.Context, token string, csvLines [][]string) (err error) {
+	defer func(begin time.Time) {
+		email := authn.EmailFromToken(token)
+		message := fmt.Sprintf("Method publish_senml_messages_from_csv by user %s took %s to complete", email, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.PublishSenMLMessagesFromCSV(ctx, token, csvLines)
 }

--- a/converters/api/logging.go
+++ b/converters/api/logging.go
@@ -27,34 +27,6 @@ func LoggingMiddleware(svc converters.Service, logger log.Logger) converters.Ser
 	return &loggingMiddleware{logger, svc}
 }
 
-func (lm *loggingMiddleware) PublishSenMLMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
-	defer func(begin time.Time) {
-		email := authn.EmailFromToken(token)
-		message := fmt.Sprintf("Method publish_senml_messages_from_json by user %s took %s to complete", email, time.Since(begin))
-		if err != nil {
-			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
-			return
-		}
-		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
-	}(time.Now())
-
-	return lm.svc.PublishSenMLMessagesFromJSON(ctx, token, records)
-}
-
-func (lm *loggingMiddleware) PublishJSONMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
-	defer func(begin time.Time) {
-		email := authn.EmailFromToken(token)
-		message := fmt.Sprintf("Method publish_json_messages_from_json by user %s took %s to complete", email, time.Since(begin))
-		if err != nil {
-			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
-			return
-		}
-		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
-	}(time.Now())
-
-	return lm.svc.PublishJSONMessagesFromJSON(ctx, token, records)
-}
-
 func (lm *loggingMiddleware) PublishJSONMessagesFromCSV(ctx context.Context, token string, csvLines [][]string) (err error) {
 	defer func(begin time.Time) {
 		email := authn.EmailFromToken(token)
@@ -81,4 +53,32 @@ func (lm *loggingMiddleware) PublishSenMLMessagesFromCSV(ctx context.Context, to
 	}(time.Now())
 
 	return lm.svc.PublishSenMLMessagesFromCSV(ctx, token, csvLines)
+}
+
+func (lm *loggingMiddleware) PublishJSONMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
+	defer func(begin time.Time) {
+		email := authn.EmailFromToken(token)
+		message := fmt.Sprintf("Method publish_json_messages_from_json by user %s took %s to complete", email, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.PublishJSONMessagesFromJSON(ctx, token, records)
+}
+
+func (lm *loggingMiddleware) PublishSenMLMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
+	defer func(begin time.Time) {
+		email := authn.EmailFromToken(token)
+		message := fmt.Sprintf("Method publish_senml_messages_from_json by user %s took %s to complete", email, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.PublishSenMLMessagesFromJSON(ctx, token, records)
 }

--- a/converters/api/metrics.go
+++ b/converters/api/metrics.go
@@ -30,24 +30,6 @@ func MetricsMiddleware(svc converters.Service, counter metrics.Counter, latency 
 	}
 }
 
-func (mm *metricsMiddleware) PublishSenMLMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
-	defer func(begin time.Time) {
-		mm.counter.With("method", "publish_senml_messages_from_json").Add(1)
-		mm.latency.With("method", "publish_senml_messages_from_json").Observe(time.Since(begin).Seconds())
-	}(time.Now())
-
-	return mm.svc.PublishSenMLMessagesFromJSON(ctx, token, records)
-}
-
-func (mm *metricsMiddleware) PublishJSONMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
-	defer func(begin time.Time) {
-		mm.counter.With("method", "publish_json_messages_from_json").Add(1)
-		mm.latency.With("method", "publish_json_messages_from_json").Observe(time.Since(begin).Seconds())
-	}(time.Now())
-
-	return mm.svc.PublishJSONMessagesFromJSON(ctx, token, records)
-}
-
 func (mm *metricsMiddleware) PublishJSONMessagesFromCSV(ctx context.Context, token string, csvLines [][]string) (err error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "publish_json_messages_from_csv").Add(1)
@@ -64,4 +46,22 @@ func (mm *metricsMiddleware) PublishSenMLMessagesFromCSV(ctx context.Context, to
 	}(time.Now())
 
 	return mm.svc.PublishSenMLMessagesFromCSV(ctx, token, csvLines)
+}
+
+func (mm *metricsMiddleware) PublishJSONMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "publish_json_messages_from_json").Add(1)
+		mm.latency.With("method", "publish_json_messages_from_json").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.PublishJSONMessagesFromJSON(ctx, token, records)
+}
+
+func (mm *metricsMiddleware) PublishSenMLMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "publish_senml_messages_from_json").Add(1)
+		mm.latency.With("method", "publish_senml_messages_from_json").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.PublishSenMLMessagesFromJSON(ctx, token, records)
 }

--- a/converters/api/metrics.go
+++ b/converters/api/metrics.go
@@ -30,20 +30,38 @@ func MetricsMiddleware(svc converters.Service, counter metrics.Counter, latency 
 	}
 }
 
-func (mm *metricsMiddleware) PublishJSONMessages(ctx context.Context, token string, csvLines [][]string) (err error) {
+func (mm *metricsMiddleware) PublishSenMLMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
 	defer func(begin time.Time) {
-		mm.counter.With("method", "publish_json_messages").Add(1)
-		mm.latency.With("method", "publish_json_messages").Observe(time.Since(begin).Seconds())
+		mm.counter.With("method", "publish_senml_messages_from_json").Add(1)
+		mm.latency.With("method", "publish_senml_messages_from_json").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.PublishJSONMessages(ctx, token, csvLines)
+	return mm.svc.PublishSenMLMessagesFromJSON(ctx, token, records)
 }
 
-func (mm *metricsMiddleware) PublishSenMLMessages(ctx context.Context, token string, csvLines [][]string) (err error) {
+func (mm *metricsMiddleware) PublishJSONMessagesFromJSON(ctx context.Context, token string, records []map[string]any) (err error) {
 	defer func(begin time.Time) {
-		mm.counter.With("method", "publish_senml_messages").Add(1)
-		mm.latency.With("method", "publish_senml_messages").Observe(time.Since(begin).Seconds())
+		mm.counter.With("method", "publish_json_messages_from_json").Add(1)
+		mm.latency.With("method", "publish_json_messages_from_json").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.PublishSenMLMessages(ctx, token, csvLines)
+	return mm.svc.PublishJSONMessagesFromJSON(ctx, token, records)
+}
+
+func (mm *metricsMiddleware) PublishJSONMessagesFromCSV(ctx context.Context, token string, csvLines [][]string) (err error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "publish_json_messages_from_csv").Add(1)
+		mm.latency.With("method", "publish_json_messages_from_csv").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.PublishJSONMessagesFromCSV(ctx, token, csvLines)
+}
+
+func (mm *metricsMiddleware) PublishSenMLMessagesFromCSV(ctx context.Context, token string, csvLines [][]string) (err error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "publish_senml_messages_from_csv").Add(1)
+		mm.latency.With("method", "publish_senml_messages_from_csv").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.PublishSenMLMessagesFromCSV(ctx, token, csvLines)
 }

--- a/converters/api/requests.go
+++ b/converters/api/requests.go
@@ -8,10 +8,15 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 )
 
+const (
+	toSenML = "senml"
+	toJSON  = "json"
+)
+
 type convertCSVReq struct {
 	csvLines [][]string
 	key      domain.ThingKey
-	to       string // "senml" or "json"
+	to       string
 }
 
 func (req convertCSVReq) validate() error {
@@ -23,7 +28,7 @@ func (req convertCSVReq) validate() error {
 		return apiutil.ErrEmptyList
 	}
 
-	if req.to != "senml" && req.to != "json" {
+	if req.to != toSenML && req.to != toJSON {
 		return apiutil.ErrInvalidQueryParams
 	}
 
@@ -33,7 +38,7 @@ func (req convertCSVReq) validate() error {
 type convertJSONReq struct {
 	records []map[string]any
 	key     domain.ThingKey
-	to      string // "senml" or "json"
+	to      string
 }
 
 func (req convertJSONReq) validate() error {
@@ -45,7 +50,7 @@ func (req convertJSONReq) validate() error {
 		return apiutil.ErrEmptyList
 	}
 
-	if req.to != "senml" && req.to != "json" {
+	if req.to != toSenML && req.to != toJSON {
 		return apiutil.ErrInvalidQueryParams
 	}
 

--- a/converters/api/requests.go
+++ b/converters/api/requests.go
@@ -24,3 +24,20 @@ func (req convertCSVReq) validate() error {
 
 	return nil
 }
+
+type convertJSONReq struct {
+	records []map[string]any
+	key     domain.ThingKey
+}
+
+func (req convertJSONReq) validate() error {
+	if req.key.Value == "" {
+		return apiutil.ErrBearerKey
+	}
+
+	if len(req.records) == 0 {
+		return apiutil.ErrEmptyList
+	}
+
+	return nil
+}

--- a/converters/api/requests.go
+++ b/converters/api/requests.go
@@ -11,6 +11,7 @@ import (
 type convertCSVReq struct {
 	csvLines [][]string
 	key      domain.ThingKey
+	to       string // "senml" or "json"
 }
 
 func (req convertCSVReq) validate() error {
@@ -22,12 +23,17 @@ func (req convertCSVReq) validate() error {
 		return apiutil.ErrEmptyList
 	}
 
+	if req.to != "senml" && req.to != "json" {
+		return apiutil.ErrInvalidQueryParams
+	}
+
 	return nil
 }
 
 type convertJSONReq struct {
 	records []map[string]any
 	key     domain.ThingKey
+	to      string // "senml" or "json"
 }
 
 func (req convertJSONReq) validate() error {
@@ -37,6 +43,10 @@ func (req convertJSONReq) validate() error {
 
 	if len(req.records) == 0 {
 		return apiutil.ErrEmptyList
+	}
+
+	if req.to != "senml" && req.to != "json" {
+		return apiutil.ErrInvalidQueryParams
 	}
 
 	return nil

--- a/converters/api/transport.go
+++ b/converters/api/transport.go
@@ -61,12 +61,6 @@ func MakeHandler(svc adapter.Service, ac domain.AuthClient, tracer opentracing.T
 	return r
 }
 
-type SenmlRec struct {
-	Name  string `json:"n"`
-	Time  string `json:"t"`
-	Value string `json:"v"`
-}
-
 func decodeConvertCSVFile(_ context.Context, r *http.Request) (any, error) {
 	if !strings.Contains(r.Header.Get("Content-Type"), multiPartContentType) {
 		return nil, apiutil.ErrUnsupportedContentType
@@ -81,6 +75,7 @@ func decodeConvertCSVFile(_ context.Context, r *http.Request) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 
 	csvLines, readErr := csv.NewReader(file).ReadAll()
 	if readErr != nil {
@@ -110,6 +105,7 @@ func decodeConvertJSONFile(_ context.Context, r *http.Request) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 
 	data, err := io.ReadAll(file)
 	if err != nil {

--- a/converters/api/transport.go
+++ b/converters/api/transport.go
@@ -6,6 +6,8 @@ package api
 import (
 	"context"
 	"encoding/csv"
+	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 
@@ -53,6 +55,20 @@ func MakeHandler(svc adapter.Service, ac domain.AuthClient, tracer opentracing.T
 		opts...,
 	))
 
+	r.Post("/json/senml", kithttp.NewServer(
+		kitot.TraceServer(tracer, "convert_json_to_senml")(convertJSONToSenMLEndpoint(svc)),
+		decodeConvertJSONFile,
+		encodeResponse,
+		opts...,
+	))
+
+	r.Post("/json/json", kithttp.NewServer(
+		kitot.TraceServer(tracer, "convert_json_to_json")(convertJSONToJSONEndpoint(svc)),
+		decodeConvertJSONFile,
+		encodeResponse,
+		opts...,
+	))
+
 	r.GetFunc("/health", mainflux.Health("converters"))
 	r.Handle("/metrics", promhttp.Handler())
 
@@ -88,6 +104,39 @@ func decodeConvertCSVFile(_ context.Context, r *http.Request) (any, error) {
 	req := convertCSVReq{
 		key:      apiutil.ExtractThingKey(r),
 		csvLines: csvLines,
+	}
+
+	return req, nil
+}
+
+func decodeConvertJSONFile(_ context.Context, r *http.Request) (any, error) {
+	if !strings.Contains(r.Header.Get("Content-Type"), multiPartContentType) {
+		return nil, apiutil.ErrUnsupportedContentType
+	}
+
+	err := r.ParseMultipartForm(maxMemory)
+	if err != nil {
+		return nil, err
+	}
+
+	file, _, err := r.FormFile(fileKey)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	var records []map[string]any
+	if err := json.Unmarshal(data, &records); err != nil {
+		return nil, err
+	}
+
+	req := convertJSONReq{
+		key:     apiutil.ExtractThingKey(r),
+		records: records,
 	}
 
 	return req, nil

--- a/converters/api/transport.go
+++ b/converters/api/transport.go
@@ -41,14 +41,14 @@ func MakeHandler(svc adapter.Service, ac domain.AuthClient, tracer opentracing.T
 
 	r := bone.New()
 
-	r.Post("/csv/convert", kithttp.NewServer(
+	r.Post("/csv", kithttp.NewServer(
 		kitot.TraceServer(tracer, "convert_csv")(convertCSVEndpoint(svc)),
 		decodeConvertCSVFile,
 		encodeResponse,
 		opts...,
 	))
 
-	r.Post("/json/convert", kithttp.NewServer(
+	r.Post("/json", kithttp.NewServer(
 		kitot.TraceServer(tracer, "convert_json")(convertJSONEndpoint(svc)),
 		decodeConvertJSONFile,
 		encodeResponse,

--- a/converters/api/transport.go
+++ b/converters/api/transport.go
@@ -41,29 +41,15 @@ func MakeHandler(svc adapter.Service, ac domain.AuthClient, tracer opentracing.T
 
 	r := bone.New()
 
-	r.Post("/csv/senml", kithttp.NewServer(
-		kitot.TraceServer(tracer, "convert_csv_to_senml")(convertCSVToSenMLEndpoint(svc)),
+	r.Post("/csv/convert", kithttp.NewServer(
+		kitot.TraceServer(tracer, "convert_csv")(convertCSVEndpoint(svc)),
 		decodeConvertCSVFile,
 		encodeResponse,
 		opts...,
 	))
 
-	r.Post("/csv/json", kithttp.NewServer(
-		kitot.TraceServer(tracer, "convert_csv_to_json")(convertCSVToJSONEndpoint(svc)),
-		decodeConvertCSVFile,
-		encodeResponse,
-		opts...,
-	))
-
-	r.Post("/json/senml", kithttp.NewServer(
-		kitot.TraceServer(tracer, "convert_json_to_senml")(convertJSONToSenMLEndpoint(svc)),
-		decodeConvertJSONFile,
-		encodeResponse,
-		opts...,
-	))
-
-	r.Post("/json/json", kithttp.NewServer(
-		kitot.TraceServer(tracer, "convert_json_to_json")(convertJSONToJSONEndpoint(svc)),
+	r.Post("/json/convert", kithttp.NewServer(
+		kitot.TraceServer(tracer, "convert_json")(convertJSONEndpoint(svc)),
 		decodeConvertJSONFile,
 		encodeResponse,
 		opts...,
@@ -104,6 +90,7 @@ func decodeConvertCSVFile(_ context.Context, r *http.Request) (any, error) {
 	req := convertCSVReq{
 		key:      apiutil.ExtractThingKey(r),
 		csvLines: csvLines,
+		to:       r.URL.Query().Get("to"),
 	}
 
 	return req, nil
@@ -137,6 +124,7 @@ func decodeConvertJSONFile(_ context.Context, r *http.Request) (any, error) {
 	req := convertJSONReq{
 		key:     apiutil.ExtractThingKey(r),
 		records: records,
+		to:      r.URL.Query().Get("to"),
 	}
 
 	return req, nil

--- a/converters/service.go
+++ b/converters/service.go
@@ -58,12 +58,6 @@ func New(pub messaging.Publisher, things domain.ThingsClient) Service {
 }
 
 func (as *adapterService) PublishSenMLMessagesFromCSV(ctx context.Context, key string, csvLines [][]string) error {
-	thKey := domain.ThingKey{Value: key, Type: domain.KeyTypeInternal}
-	pc, err := as.things.GetPubConfigByKey(ctx, thKey)
-	if err != nil {
-		return err
-	}
-
 	msg := protomfx.Message{
 		Protocol: protocol,
 		Created:  time.Now().UnixNano(),
@@ -81,7 +75,7 @@ func (as *adapterService) PublishSenMLMessagesFromCSV(ctx context.Context, key s
 			return err
 		}
 		msg.Payload = data
-		if err := as.publish(msg, pc); err != nil {
+		if _, err = as.publish(ctx, key, msg); err != nil {
 			return err
 		}
 		msgs = []map[string]any{}
@@ -199,7 +193,7 @@ func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key st
 				return err
 			}
 			msg.Payload = data
-			if err := as.publish(msg, pc); err != nil {
+			if _, err = as.publish(ctx, key, msg); err != nil {
 				return err
 			}
 			msgs = []map[string]any{}
@@ -213,7 +207,7 @@ func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key st
 			return err
 		}
 		msg.Payload = data
-		if err := as.publish(msg, pc); err != nil {
+		if _, err := as.publish(ctx, key, msg); err != nil {
 			return err
 		}
 	}
@@ -221,12 +215,6 @@ func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key st
 }
 
 func (as *adapterService) PublishSenMLMessagesFromJSON(ctx context.Context, key string, records []map[string]any) error {
-	thKey := domain.ThingKey{Value: key, Type: domain.KeyTypeInternal}
-	pc, err := as.things.GetPubConfigByKey(ctx, thKey)
-	if err != nil {
-		return err
-	}
-
 	msg := protomfx.Message{
 		Protocol: protocol,
 		Created:  time.Now().UnixNano(),
@@ -243,7 +231,7 @@ func (as *adapterService) PublishSenMLMessagesFromJSON(ctx context.Context, key 
 			return err
 		}
 		msg.Payload = data
-		if err := as.publish(msg, pc); err != nil {
+		if _, err = as.publish(ctx, key, msg); err != nil {
 			return err
 		}
 		msgs = []map[string]any{}
@@ -430,7 +418,8 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 				return err
 			}
 			msg.Payload = data
-			if err := as.publish(msg, pc); err != nil {
+			_, err = as.publish(ctx, key, msg)
+			if err != nil {
 				return err
 			}
 			counter = 0
@@ -443,16 +432,23 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 	return nil
 }
 
-func (as *adapterService) publish(msg protomfx.Message, pc domain.PubConfigInfo) error {
+func (as *adapterService) publish(ctx context.Context, key string, msg protomfx.Message) (m protomfx.Message, err error) {
+	pcr := domain.ThingKey{Type: domain.KeyTypeInternal, Value: key}
+
+	pc, err := as.things.GetPubConfigByKey(ctx, pcr)
+	if err != nil {
+		return protomfx.Message{}, err
+	}
+
 	if err := messaging.FormatMessage(pc, &msg); err != nil {
-		return err
+		return protomfx.Message{}, err
 	}
 
 	for _, subject := range nats.GetPublishSubjects(msg.Publisher, msg.Subtopic, pc.ProfileConfig) {
 		if err := as.publisher.Publish(subject, msg); err != nil {
-			return err
+			return protomfx.Message{}, err
 		}
 	}
 
-	return nil
+	return m, nil
 }

--- a/converters/service.go
+++ b/converters/service.go
@@ -23,10 +23,21 @@ const (
 // ErrInvalidTimeField represents an invalid timestamp.
 var ErrInvalidTimeField = errors.New("invalid time field")
 
+// reservedFields are message keys that must not appear inside the payload.
+var reservedFields = map[string]bool{
+	"protocol":  true,
+	"publisher": true,
+	"subtopic":  true,
+	"created":   true,
+	"Created":   true,
+}
+
 // Service specifies coap service API.
 type Service interface {
-	PublishSenMLMessages(ctx context.Context, key string, csvLines [][]string) error
-	PublishJSONMessages(ctx context.Context, key string, csvLines [][]string) error
+	PublishSenMLMessagesFromCSV(ctx context.Context, key string, csvLines [][]string) error
+	PublishJSONMessagesFromCSV(ctx context.Context, key string, csvLines [][]string) error
+	PublishSenMLMessagesFromJSON(ctx context.Context, key string, records []map[string]any) error
+	PublishJSONMessagesFromJSON(ctx context.Context, key string, records []map[string]any) error
 }
 
 var _ Service = (*adapterService)(nil)
@@ -44,7 +55,7 @@ func New(pub messaging.Publisher, things domain.ThingsClient) Service {
 	}
 }
 
-func (as *adapterService) PublishSenMLMessages(ctx context.Context, key string, csvLines [][]string) error {
+func (as *adapterService) PublishSenMLMessagesFromCSV(ctx context.Context, key string, csvLines [][]string) error {
 	msg := protomfx.Message{
 		Protocol: protocol,
 		Created:  time.Now().UnixNano(),
@@ -92,7 +103,7 @@ func (as *adapterService) PublishSenMLMessages(ctx context.Context, key string, 
 	return nil
 }
 
-func (as *adapterService) PublishJSONMessages(ctx context.Context, key string, csvLines [][]string) error {
+func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key string, csvLines [][]string) error {
 	thKey := domain.ThingKey{
 		Value: key,
 		Type:  domain.KeyTypeInternal,
@@ -123,6 +134,9 @@ func (as *adapterService) PublishJSONMessages(ctx context.Context, key string, c
 			record["Created"] = t
 		}
 		for j, columnName := range keys {
+			if reservedFields[columnName] {
+				continue
+			}
 			if f, err := strconv.ParseFloat(csvLines[i][j+1], 64); err == nil {
 				record[columnName] = f
 			} else {
@@ -144,6 +158,132 @@ func (as *adapterService) PublishJSONMessages(ctx context.Context, key string, c
 			counter = 0
 			msgs = []map[string]any{}
 			if i != len(csvLines)-1 {
+				time.Sleep(30 * time.Second)
+			}
+		}
+	}
+	return nil
+}
+
+func (as *adapterService) PublishSenMLMessagesFromJSON(ctx context.Context, key string, records []map[string]any) error {
+	msg := protomfx.Message{
+		Protocol: protocol,
+		Created:  time.Now().UnixNano(),
+	}
+	counter := 0
+	msgs := []map[string]any{}
+	for i, record := range records {
+		tVal, ok := record["t"]
+		if !ok {
+			return ErrInvalidTimeField
+		}
+		t, ok := tVal.(float64)
+		if !ok {
+			return ErrInvalidTimeField
+		}
+		for n, val := range record {
+			if n == "t" {
+				continue
+			}
+			v, ok := val.(float64)
+			if !ok {
+				return ErrInvalidTimeField
+			}
+			msgs = append(msgs, map[string]any{"n": n, "v": v, "t": t})
+			counter++
+			if counter >= 50000 {
+				data, err := json.Marshal(msgs)
+				if err != nil {
+					return err
+				}
+				msg.Payload = data
+				if _, err = as.publish(ctx, key, msg); err != nil {
+					return err
+				}
+				counter = 0
+				msgs = []map[string]any{}
+				time.Sleep(30 * time.Second)
+			}
+		}
+		if i == len(records)-1 && len(msgs) > 0 {
+			data, err := json.Marshal(msgs)
+			if err != nil {
+				return err
+			}
+			msg.Payload = data
+			if _, err = as.publish(ctx, key, msg); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key string, records []map[string]any) error {
+	thKey := domain.ThingKey{
+		Value: key,
+		Type:  domain.KeyTypeInternal,
+	}
+
+	pc, err := as.things.GetPubConfigByKey(ctx, thKey)
+	if err != nil {
+		return err
+	}
+
+	timeField := pc.ProfileConfig.Transformer.TimeField
+
+	msg := protomfx.Message{
+		Protocol: protocol,
+		Created:  time.Now().UnixNano(),
+	}
+	counter := 0
+	msgs := []map[string]any{}
+	for i, inputRecord := range records {
+		// Auto-unwrap reader-exported Format A: {"payload":{...},"created":...,...}
+		source := inputRecord
+		var outerTimestamp float64
+		if pld, ok := inputRecord["payload"].(map[string]any); ok {
+			source = pld
+			// Prefer the outer timeField value (numeric); fall back to outer "created".
+			if timeField != "" {
+				outerTimestamp, _ = inputRecord[timeField].(float64)
+			}
+			if outerTimestamp == 0 {
+				outerTimestamp, _ = inputRecord["created"].(float64)
+			}
+		}
+
+		record := map[string]any{}
+		if outerTimestamp != 0 {
+			record["Created"] = outerTimestamp
+		}
+
+		for k, v := range source {
+			if reservedFields[k] {
+				continue
+			}
+			if timeField != "" && k == timeField {
+				if t, ok := v.(float64); ok {
+					record["Created"] = t
+				}
+			}
+			record[k] = v
+		}
+		msgs = append(msgs, record)
+		counter++
+		if counter == 50000 || i == len(records)-1 {
+			data, err := json.Marshal(msgs)
+			if err != nil {
+				return err
+			}
+			msg.Payload = data
+			_, err = as.publish(ctx, key, msg)
+			if err != nil {
+				return err
+			}
+			counter = 0
+			msgs = []map[string]any{}
+			if i != len(records)-1 {
 				time.Sleep(30 * time.Second)
 			}
 		}

--- a/converters/service.go
+++ b/converters/service.go
@@ -301,9 +301,14 @@ func toSenMLEntries(record map[string]any) ([]map[string]any, error) {
 		return nil, ErrInvalidTimeField
 	}
 
-	n, _ := record["n"].(string)
+	n := ""
+	if s, ok := record["n"].(string); ok {
+		n = s
+	}
 	if n == "" {
-		n, _ = record["name"].(string)
+		if s, ok := record["name"].(string); ok {
+			n = s
+		}
 	}
 
 	if n != "" {

--- a/converters/service.go
+++ b/converters/service.go
@@ -32,7 +32,6 @@ var reservedFields = map[string]bool{
 	"publisher": true,
 	"subtopic":  true,
 	"created":   true,
-	"Created":   true,
 }
 
 // Service specifies coap service API.
@@ -103,6 +102,12 @@ func (as *adapterService) PublishSenMLMessagesFromCSV(ctx context.Context, key s
 				}
 			case "n", "name", "vs", "string_value", "vd", "data_value", "u", "unit":
 				record[col] = val
+			case "protocol":
+				if val != "" {
+					msg.Protocol = val
+				}
+			case "subtopic":
+				msg.Subtopic = val
 			}
 		}
 		entries, err := toSenMLEntries(record)
@@ -160,6 +165,14 @@ func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key st
 		}
 		for j, columnName := range keys {
 			if reservedFields[columnName] {
+				switch columnName {
+				case "protocol":
+					if val := csvLines[i][j+1]; val != "" {
+						msg.Protocol = val
+					}
+				case "subtopic":
+					msg.Subtopic = csvLines[i][j+1]
+				}
 				continue
 			}
 			if f, err := strconv.ParseFloat(csvLines[i][j+1], 64); err == nil {
@@ -227,6 +240,12 @@ func (as *adapterService) PublishSenMLMessagesFromJSON(ctx context.Context, key 
 	}
 
 	for _, record := range records {
+		if s, ok := record["protocol"].(string); ok && s != "" {
+			msg.Protocol = s
+		}
+		if s, ok := record["subtopic"].(string); ok {
+			msg.Subtopic = s
+		}
 		entries, err := toSenMLEntries(record)
 		if err != nil {
 			return err
@@ -349,6 +368,13 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 			if outerTimestamp == 0 {
 				outerTimestamp, _ = inputRecord["created"].(float64)
 			}
+			// Preserve envelope fields from the outer record into the message.
+			if s, ok := inputRecord["protocol"].(string); ok && s != "" {
+				msg.Protocol = s
+			}
+			if s, ok := inputRecord["subtopic"].(string); ok {
+				msg.Subtopic = s
+			}
 		}
 
 		record := map[string]any{}
@@ -357,9 +383,24 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 		}
 
 		for k, v := range source {
-			// For flat records strip envelope fields; for unwrapped Format A the
-			// outer envelope is already excluded - inner fields are sensor data.
+			// For flat records, envelope fields are lifted into the message rather
+			// than stored in the payload. For unwrapped Format A the outer envelope
+			// is already handled above; inner fields are sensor data.
 			if !unwrapped && reservedFields[k] {
+				switch k {
+				case "protocol":
+					if s, ok := v.(string); ok && s != "" {
+						msg.Protocol = s
+					}
+				case "subtopic":
+					if s, ok := v.(string); ok {
+						msg.Subtopic = s
+					}
+				case "created":
+					if t, ok := v.(float64); ok && t != 0 {
+						record["Created"] = t
+					}
+				}
 				continue
 			}
 			if timeField != "" && k == timeField {

--- a/converters/service.go
+++ b/converters/service.go
@@ -58,6 +58,12 @@ func New(pub messaging.Publisher, things domain.ThingsClient) Service {
 }
 
 func (as *adapterService) PublishSenMLMessagesFromCSV(ctx context.Context, key string, csvLines [][]string) error {
+	thKey := domain.ThingKey{Value: key, Type: domain.KeyTypeInternal}
+	pc, err := as.things.GetPubConfigByKey(ctx, thKey)
+	if err != nil {
+		return err
+	}
+
 	msg := protomfx.Message{
 		Protocol: protocol,
 		Created:  time.Now().UnixNano(),
@@ -75,7 +81,7 @@ func (as *adapterService) PublishSenMLMessagesFromCSV(ctx context.Context, key s
 			return err
 		}
 		msg.Payload = data
-		if _, err = as.publish(ctx, key, msg); err != nil {
+		if err := as.publish(msg, pc); err != nil {
 			return err
 		}
 		msgs = []map[string]any{}
@@ -193,7 +199,7 @@ func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key st
 				return err
 			}
 			msg.Payload = data
-			if _, err = as.publish(ctx, key, msg); err != nil {
+			if err := as.publish(msg, pc); err != nil {
 				return err
 			}
 			msgs = []map[string]any{}
@@ -207,7 +213,7 @@ func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key st
 			return err
 		}
 		msg.Payload = data
-		if _, err := as.publish(ctx, key, msg); err != nil {
+		if err := as.publish(msg, pc); err != nil {
 			return err
 		}
 	}
@@ -215,6 +221,12 @@ func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key st
 }
 
 func (as *adapterService) PublishSenMLMessagesFromJSON(ctx context.Context, key string, records []map[string]any) error {
+	thKey := domain.ThingKey{Value: key, Type: domain.KeyTypeInternal}
+	pc, err := as.things.GetPubConfigByKey(ctx, thKey)
+	if err != nil {
+		return err
+	}
+
 	msg := protomfx.Message{
 		Protocol: protocol,
 		Created:  time.Now().UnixNano(),
@@ -231,7 +243,7 @@ func (as *adapterService) PublishSenMLMessagesFromJSON(ctx context.Context, key 
 			return err
 		}
 		msg.Payload = data
-		if _, err = as.publish(ctx, key, msg); err != nil {
+		if err := as.publish(msg, pc); err != nil {
 			return err
 		}
 		msgs = []map[string]any{}
@@ -418,8 +430,7 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 				return err
 			}
 			msg.Payload = data
-			_, err = as.publish(ctx, key, msg)
-			if err != nil {
+			if err := as.publish(msg, pc); err != nil {
 				return err
 			}
 			counter = 0
@@ -432,23 +443,16 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 	return nil
 }
 
-func (as *adapterService) publish(ctx context.Context, key string, msg protomfx.Message) (m protomfx.Message, err error) {
-	pcr := domain.ThingKey{Type: domain.KeyTypeInternal, Value: key}
-
-	pc, err := as.things.GetPubConfigByKey(ctx, pcr)
-	if err != nil {
-		return protomfx.Message{}, err
-	}
-
+func (as *adapterService) publish(msg protomfx.Message, pc domain.PubConfigInfo) error {
 	if err := messaging.FormatMessage(pc, &msg); err != nil {
-		return protomfx.Message{}, err
+		return err
 	}
 
 	for _, subject := range nats.GetPublishSubjects(msg.Publisher, msg.Subtopic, pc.ProfileConfig) {
 		if err := as.publisher.Publish(subject, msg); err != nil {
-			return protomfx.Message{}, err
+			return err
 		}
 	}
 
-	return m, nil
+	return nil
 }

--- a/converters/service.go
+++ b/converters/service.go
@@ -351,9 +351,9 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 		Protocol: protocol,
 		Created:  time.Now().UnixNano(),
 	}
-	counter := 0
 	msgs := []map[string]any{}
-	for i, inputRecord := range records {
+	size := 0
+	for _, inputRecord := range records {
 		// Auto-unwrap reader-exported Format A: {"payload":{...},"created":...,...}
 		source := inputRecord
 		unwrapped := false
@@ -410,23 +410,34 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 			}
 			record[k] = v
 		}
+		recData, err := json.Marshal(record)
+		if err != nil {
+			return err
+		}
 		msgs = append(msgs, record)
-		counter++
-		if counter == 50000 || i == len(records)-1 {
+		size += len(recData)
+		if size >= maxBatchBytes {
 			data, err := json.Marshal(msgs)
 			if err != nil {
 				return err
 			}
 			msg.Payload = data
-			_, err = as.publish(ctx, key, msg)
-			if err != nil {
+			if _, err = as.publish(ctx, key, msg); err != nil {
 				return err
 			}
-			counter = 0
 			msgs = []map[string]any{}
-			if i != len(records)-1 {
-				time.Sleep(30 * time.Second)
-			}
+			size = 0
+			time.Sleep(batchDelay)
+		}
+	}
+	if len(msgs) > 0 {
+		data, err := json.Marshal(msgs)
+		if err != nil {
+			return err
+		}
+		msg.Payload = data
+		if _, err := as.publish(ctx, key, msg); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/converters/service.go
+++ b/converters/service.go
@@ -258,10 +258,13 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 	counter := 0
 	msgs := []map[string]any{}
 	for i, inputRecord := range records {
+		// Auto-unwrap reader-exported Format A: {"payload":{...},"created":...,...}
 		source := inputRecord
+		unwrapped := false
 		var outerTimestamp float64
 		if pld, ok := inputRecord["payload"].(map[string]any); ok {
 			source = pld
+			unwrapped = true
 			// Prefer the outer timeField value (numeric); fall back to outer "created".
 			if timeField != "" {
 				outerTimestamp, _ = inputRecord[timeField].(float64)
@@ -277,7 +280,9 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 		}
 
 		for k, v := range source {
-			if reservedFields[k] {
+			// For flat records strip envelope fields; for unwrapped Format A the
+			// outer envelope is already excluded - inner fields are sensor data.
+			if !unwrapped && reservedFields[k] {
 				continue
 			}
 			if timeField != "" && k == timeField {

--- a/converters/service.go
+++ b/converters/service.go
@@ -308,7 +308,7 @@ func toSenMLEntries(record map[string]any) ([]map[string]any, error) {
 		}
 		v, ok := val.(float64)
 		if !ok {
-			return nil, ErrInvalidTimeField
+			continue // non-numeric fields have no SenML representation in multi-measurement mode
 		}
 		entries = append(entries, map[string]any{"n": k, "v": v, "t": t})
 	}

--- a/converters/service.go
+++ b/converters/service.go
@@ -373,10 +373,14 @@ func parseJSONRecord(inputRecord map[string]any, timeField string, msg *protomfx
 		// Format A — unwrap outer envelope, prefer timeField over "created".
 		var ts float64
 		if timeField != "" {
-			ts, _ = inputRecord[timeField].(float64)
+			if t, ok := inputRecord[timeField].(float64); ok {
+				ts = t
+			}
 		}
 		if ts == 0 {
-			ts, _ = inputRecord["created"].(float64)
+			if t, ok := inputRecord["created"].(float64); ok {
+				ts = t
+			}
 		}
 		if ts != 0 {
 			record["Created"] = ts
@@ -429,27 +433,26 @@ func (as *adapterService) publishMsgs(ctx context.Context, key string, msgs []ma
 		return err
 	}
 	msg.Payload = data
-	_, err = as.publish(ctx, key, msg)
-	return err
+	return as.publish(ctx, key, msg)
 }
 
-func (as *adapterService) publish(ctx context.Context, key string, msg protomfx.Message) (m protomfx.Message, err error) {
+func (as *adapterService) publish(ctx context.Context, key string, msg protomfx.Message) error {
 	pcr := domain.ThingKey{Type: domain.KeyTypeInternal, Value: key}
 
 	pc, err := as.things.GetPubConfigByKey(ctx, pcr)
 	if err != nil {
-		return protomfx.Message{}, err
+		return err
 	}
 
 	if err := messaging.FormatMessage(pc, &msg); err != nil {
-		return protomfx.Message{}, err
+		return err
 	}
 
 	for _, subject := range nats.GetPublishSubjects(msg.Publisher, msg.Subtopic, pc.ProfileConfig) {
 		if err := as.publisher.Publish(subject, msg); err != nil {
-			return protomfx.Message{}, err
+			return err
 		}
 	}
 
-	return m, nil
+	return nil
 }

--- a/converters/service.go
+++ b/converters/service.go
@@ -315,11 +315,11 @@ func toSenMLEntries(record map[string]any) ([]map[string]any, error) {
 					entry["v"] = f
 				}
 			case "vs", "string_value":
-				if s, ok := v.(string); ok {
+				if s, ok := v.(string); ok && s != "" {
 					entry["vs"] = s
 				}
 			case "vd", "data_value":
-				if s, ok := v.(string); ok {
+				if s, ok := v.(string); ok && s != "" {
 					entry["vd"] = s
 				}
 			case "vb", "bool_value":

--- a/converters/service.go
+++ b/converters/service.go
@@ -63,52 +63,69 @@ func (as *adapterService) PublishSenMLMessagesFromCSV(ctx context.Context, key s
 		Protocol: protocol,
 		Created:  time.Now().UnixNano(),
 	}
-	keys := csvLines[0][1:]
+	headers := csvLines[0]
 	msgs := []map[string]any{}
 	size := 0
-	for i := 1; i < len(csvLines); i++ {
-		t, err := strconv.ParseFloat(csvLines[i][0], 64)
-		if err != nil {
-			return ErrInvalidTimeField
+
+	flush := func() error {
+		if len(msgs) == 0 {
+			return nil
 		}
-		for j, n := range keys {
-			v, err := strconv.ParseFloat(csvLines[i][j+1], 64)
-			if err != nil {
-				return err
-			}
-			rec := map[string]any{"n": n, "v": v, "t": t}
-			recData, err := json.Marshal(rec)
-			if err != nil {
-				return err
-			}
-			msgs = append(msgs, rec)
-			size += len(recData)
-			if size >= maxBatchBytes {
-				data, err := json.Marshal(msgs)
-				if err != nil {
-					return err
-				}
-				msg.Payload = data
-				if _, err = as.publish(ctx, key, msg); err != nil {
-					return err
-				}
-				msgs = []map[string]any{}
-				size = 0
-				time.Sleep(batchDelay)
-			}
-		}
-	}
-	if len(msgs) > 0 {
 		data, err := json.Marshal(msgs)
 		if err != nil {
 			return err
 		}
 		msg.Payload = data
-		if _, err := as.publish(ctx, key, msg); err != nil {
+		if _, err = as.publish(ctx, key, msg); err != nil {
 			return err
 		}
+		msgs = []map[string]any{}
+		size = 0
+		return nil
 	}
-	return nil
+
+	for i := 1; i < len(csvLines); i++ {
+		row := csvLines[i]
+		record := map[string]any{}
+		for j, col := range headers {
+			if j >= len(row) || row[j] == "" {
+				continue
+			}
+			val := row[j]
+			switch col {
+			case "t", "time", "v", "value", "s", "sum":
+				if f, err := strconv.ParseFloat(val, 64); err == nil {
+					record[col] = f
+				}
+			case "vb", "bool_value":
+				if b, err := strconv.ParseBool(val); err == nil {
+					record[col] = b
+				}
+			case "n", "name", "vs", "string_value", "vd", "data_value", "u", "unit":
+				record[col] = val
+			}
+		}
+		entries, err := toSenMLEntries(record)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			entryData, err := json.Marshal(entry)
+			if err != nil {
+				return err
+			}
+			msgs = append(msgs, entry)
+			size += len(entryData)
+			if size >= maxBatchBytes {
+				if err := flush(); err != nil {
+					return err
+				}
+				time.Sleep(batchDelay)
+			}
+		}
+	}
+
+	return flush()
 }
 
 func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key string, csvLines [][]string) error {

--- a/converters/service.go
+++ b/converters/service.go
@@ -189,53 +189,113 @@ func (as *adapterService) PublishSenMLMessagesFromJSON(ctx context.Context, key 
 		Protocol: protocol,
 		Created:  time.Now().UnixNano(),
 	}
-	counter := 0
 	msgs := []map[string]any{}
-	for i, record := range records {
-		tVal, ok := record["t"]
-		if !ok {
-			return ErrInvalidTimeField
+	size := 0
+
+	flush := func() error {
+		if len(msgs) == 0 {
+			return nil
 		}
-		t, ok := tVal.(float64)
-		if !ok {
-			return ErrInvalidTimeField
+		data, err := json.Marshal(msgs)
+		if err != nil {
+			return err
 		}
-		for n, val := range record {
-			if n == "t" {
-				continue
-			}
-			v, ok := val.(float64)
-			if !ok {
-				return ErrInvalidTimeField
-			}
-			msgs = append(msgs, map[string]any{"n": n, "v": v, "t": t})
-			counter++
-			if counter >= 50000 {
-				data, err := json.Marshal(msgs)
-				if err != nil {
-					return err
-				}
-				msg.Payload = data
-				if _, err = as.publish(ctx, key, msg); err != nil {
-					return err
-				}
-				counter = 0
-				msgs = []map[string]any{}
-				time.Sleep(30 * time.Second)
-			}
+		msg.Payload = data
+		if _, err = as.publish(ctx, key, msg); err != nil {
+			return err
 		}
-		if i == len(records)-1 && len(msgs) > 0 {
-			data, err := json.Marshal(msgs)
+		msgs = []map[string]any{}
+		size = 0
+		return nil
+	}
+
+	for _, record := range records {
+		entries, err := toSenMLEntries(record)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			entryData, err := json.Marshal(entry)
 			if err != nil {
 				return err
 			}
-			msg.Payload = data
-			if _, err = as.publish(ctx, key, msg); err != nil {
-				return err
+			msgs = append(msgs, entry)
+			size += len(entryData)
+			if size >= maxBatchBytes {
+				if err := flush(); err != nil {
+					return err
+				}
+				time.Sleep(batchDelay)
 			}
 		}
 	}
-	return nil
+
+	return flush()
+}
+
+// toSenMLEntries converts one input record into SenML measurement entries.
+// Accepts both standard SenML keys (t, n, v, vs, vd, vb, u, s) and
+// reader-export aliases (time, name, value, string_value, data_value, bool_value, unit, sum).
+func toSenMLEntries(record map[string]any) ([]map[string]any, error) {
+	var t float64
+	if v, ok := record["t"].(float64); ok {
+		t = v
+	} else if v, ok := record["time"].(float64); ok {
+		t = v / 1e9 // reader export is nanoseconds; SenML t field is seconds
+	} else {
+		return nil, ErrInvalidTimeField
+	}
+
+	n, _ := record["n"].(string)
+	if n == "" {
+		n, _ = record["name"].(string)
+	}
+
+	if n != "" {
+		entry := map[string]any{"n": n, "t": t}
+		for k, v := range record {
+			switch k {
+			case "v", "value":
+				if f, ok := v.(float64); ok {
+					entry["v"] = f
+				}
+			case "vs", "string_value":
+				if s, ok := v.(string); ok {
+					entry["vs"] = s
+				}
+			case "vd", "data_value":
+				if s, ok := v.(string); ok {
+					entry["vd"] = s
+				}
+			case "vb", "bool_value":
+				if b, ok := v.(bool); ok {
+					entry["vb"] = b
+				}
+			case "u", "unit":
+				if s, ok := v.(string); ok {
+					entry["u"] = s
+				}
+			case "s", "sum":
+				if f, ok := v.(float64); ok {
+					entry["s"] = f
+				}
+			}
+		}
+		return []map[string]any{entry}, nil
+	}
+
+	var entries []map[string]any
+	for k, val := range record {
+		if k == "t" || k == "time" {
+			continue
+		}
+		v, ok := val.(float64)
+		if !ok {
+			return nil, ErrInvalidTimeField
+		}
+		entries = append(entries, map[string]any{"n": k, "v": v, "t": t})
+	}
+	return entries, nil
 }
 
 func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key string, records []map[string]any) error {

--- a/converters/service.go
+++ b/converters/service.go
@@ -258,7 +258,6 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 	counter := 0
 	msgs := []map[string]any{}
 	for i, inputRecord := range records {
-		// Auto-unwrap reader-exported Format A: {"payload":{...},"created":...,...}
 		source := inputRecord
 		var outerTimestamp float64
 		if pld, ok := inputRecord["payload"].(map[string]any); ok {

--- a/converters/service.go
+++ b/converters/service.go
@@ -70,12 +70,7 @@ func (as *adapterService) PublishSenMLMessagesFromCSV(ctx context.Context, key s
 		if len(msgs) == 0 {
 			return nil
 		}
-		data, err := json.Marshal(msgs)
-		if err != nil {
-			return err
-		}
-		msg.Payload = data
-		if _, err = as.publish(ctx, key, msg); err != nil {
+		if err := as.publishMsgs(ctx, key, msgs, msg); err != nil {
 			return err
 		}
 		msgs = []map[string]any{}
@@ -188,12 +183,7 @@ func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key st
 		msgs = append(msgs, record)
 		size += len(recData)
 		if size >= maxBatchBytes {
-			data, err := json.Marshal(msgs)
-			if err != nil {
-				return err
-			}
-			msg.Payload = data
-			if _, err = as.publish(ctx, key, msg); err != nil {
+			if err := as.publishMsgs(ctx, key, msgs, msg); err != nil {
 				return err
 			}
 			msgs = []map[string]any{}
@@ -202,12 +192,7 @@ func (as *adapterService) PublishJSONMessagesFromCSV(ctx context.Context, key st
 		}
 	}
 	if len(msgs) > 0 {
-		data, err := json.Marshal(msgs)
-		if err != nil {
-			return err
-		}
-		msg.Payload = data
-		if _, err := as.publish(ctx, key, msg); err != nil {
+		if err := as.publishMsgs(ctx, key, msgs, msg); err != nil {
 			return err
 		}
 	}
@@ -226,12 +211,7 @@ func (as *adapterService) PublishSenMLMessagesFromJSON(ctx context.Context, key 
 		if len(msgs) == 0 {
 			return nil
 		}
-		data, err := json.Marshal(msgs)
-		if err != nil {
-			return err
-		}
-		msg.Payload = data
-		if _, err = as.publish(ctx, key, msg); err != nil {
+		if err := as.publishMsgs(ctx, key, msgs, msg); err != nil {
 			return err
 		}
 		msgs = []map[string]any{}
@@ -240,12 +220,7 @@ func (as *adapterService) PublishSenMLMessagesFromJSON(ctx context.Context, key 
 	}
 
 	for _, record := range records {
-		if s, ok := record["protocol"].(string); ok && s != "" {
-			msg.Protocol = s
-		}
-		if s, ok := record["subtopic"].(string); ok {
-			msg.Subtopic = s
-		}
+		applyEnvelopeFields(&msg, record)
 		entries, err := toSenMLEntries(record)
 		if err != nil {
 			return err
@@ -267,6 +242,50 @@ func (as *adapterService) PublishSenMLMessagesFromJSON(ctx context.Context, key 
 	}
 
 	return flush()
+}
+
+func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key string, records []map[string]any) error {
+	thKey := domain.ThingKey{
+		Value: key,
+		Type:  domain.KeyTypeInternal,
+	}
+
+	pc, err := as.things.GetPubConfigByKey(ctx, thKey)
+	if err != nil {
+		return err
+	}
+
+	timeField := pc.ProfileConfig.Transformer.TimeField
+
+	msg := protomfx.Message{
+		Protocol: protocol,
+		Created:  time.Now().UnixNano(),
+	}
+	msgs := []map[string]any{}
+	size := 0
+	for _, inputRecord := range records {
+		record := parseJSONRecord(inputRecord, timeField, &msg)
+		recData, err := json.Marshal(record)
+		if err != nil {
+			return err
+		}
+		msgs = append(msgs, record)
+		size += len(recData)
+		if size >= maxBatchBytes {
+			if err := as.publishMsgs(ctx, key, msgs, msg); err != nil {
+				return err
+			}
+			msgs = []map[string]any{}
+			size = 0
+			time.Sleep(batchDelay)
+		}
+	}
+	if len(msgs) > 0 {
+		if err := as.publishMsgs(ctx, key, msgs, msg); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // toSenMLEntries converts one input record into SenML measurement entries.
@@ -334,75 +353,36 @@ func toSenMLEntries(record map[string]any) ([]map[string]any, error) {
 	return entries, nil
 }
 
-func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key string, records []map[string]any) error {
-	thKey := domain.ThingKey{
-		Value: key,
-		Type:  domain.KeyTypeInternal,
+// applyEnvelopeFields sets msg.Protocol and msg.Subtopic from a source map.
+func applyEnvelopeFields(msg *protomfx.Message, src map[string]any) {
+	if s, ok := src["protocol"].(string); ok && s != "" {
+		msg.Protocol = s
 	}
-
-	pc, err := as.things.GetPubConfigByKey(ctx, thKey)
-	if err != nil {
-		return err
+	if s, ok := src["subtopic"].(string); ok {
+		msg.Subtopic = s
 	}
+}
 
-	timeField := pc.ProfileConfig.Transformer.TimeField
+// parseJSONRecord converts one input record into a payload record and updates
+// msg.Protocol / msg.Subtopic from envelope fields. Handles both Format A
+// (reader-exported {"payload":{...},"created":...}) and flat records.
+func parseJSONRecord(inputRecord map[string]any, timeField string, msg *protomfx.Message) map[string]any {
+	record := map[string]any{}
 
-	msg := protomfx.Message{
-		Protocol: protocol,
-		Created:  time.Now().UnixNano(),
-	}
-	msgs := []map[string]any{}
-	size := 0
-	for _, inputRecord := range records {
-		// Auto-unwrap reader-exported Format A: {"payload":{...},"created":...,...}
-		source := inputRecord
-		unwrapped := false
-		var outerTimestamp float64
-		if pld, ok := inputRecord["payload"].(map[string]any); ok {
-			source = pld
-			unwrapped = true
-			// Prefer the outer timeField value (numeric); fall back to outer "created".
-			if timeField != "" {
-				outerTimestamp, _ = inputRecord[timeField].(float64)
-			}
-			if outerTimestamp == 0 {
-				outerTimestamp, _ = inputRecord["created"].(float64)
-			}
-			// Preserve envelope fields from the outer record into the message.
-			if s, ok := inputRecord["protocol"].(string); ok && s != "" {
-				msg.Protocol = s
-			}
-			if s, ok := inputRecord["subtopic"].(string); ok {
-				msg.Subtopic = s
-			}
+	if pld, ok := inputRecord["payload"].(map[string]any); ok {
+		// Format A — unwrap outer envelope, prefer timeField over "created".
+		var ts float64
+		if timeField != "" {
+			ts, _ = inputRecord[timeField].(float64)
 		}
-
-		record := map[string]any{}
-		if outerTimestamp != 0 {
-			record["Created"] = outerTimestamp
+		if ts == 0 {
+			ts, _ = inputRecord["created"].(float64)
 		}
-
-		for k, v := range source {
-			// For flat records, envelope fields are lifted into the message rather
-			// than stored in the payload. For unwrapped Format A the outer envelope
-			// is already handled above; inner fields are sensor data.
-			if !unwrapped && reservedFields[k] {
-				switch k {
-				case "protocol":
-					if s, ok := v.(string); ok && s != "" {
-						msg.Protocol = s
-					}
-				case "subtopic":
-					if s, ok := v.(string); ok {
-						msg.Subtopic = s
-					}
-				case "created":
-					if t, ok := v.(float64); ok && t != 0 {
-						record["Created"] = t
-					}
-				}
-				continue
-			}
+		if ts != 0 {
+			record["Created"] = ts
+		}
+		applyEnvelopeFields(msg, inputRecord)
+		for k, v := range pld {
 			if timeField != "" && k == timeField {
 				if t, ok := v.(float64); ok {
 					record["Created"] = t
@@ -410,37 +390,47 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 			}
 			record[k] = v
 		}
-		recData, err := json.Marshal(record)
-		if err != nil {
-			return err
-		}
-		msgs = append(msgs, record)
-		size += len(recData)
-		if size >= maxBatchBytes {
-			data, err := json.Marshal(msgs)
-			if err != nil {
-				return err
-			}
-			msg.Payload = data
-			if _, err = as.publish(ctx, key, msg); err != nil {
-				return err
-			}
-			msgs = []map[string]any{}
-			size = 0
-			time.Sleep(batchDelay)
-		}
+		return record
 	}
-	if len(msgs) > 0 {
-		data, err := json.Marshal(msgs)
-		if err != nil {
-			return err
+
+	// Flat record — lift envelope fields into msg, store the rest in record.
+	for k, v := range inputRecord {
+		if reservedFields[k] {
+			switch k {
+			case "protocol":
+				if s, ok := v.(string); ok && s != "" {
+					msg.Protocol = s
+				}
+			case "subtopic":
+				if s, ok := v.(string); ok {
+					msg.Subtopic = s
+				}
+			case "created":
+				if t, ok := v.(float64); ok && t != 0 {
+					record["Created"] = t
+				}
+			}
+			continue
 		}
-		msg.Payload = data
-		if _, err := as.publish(ctx, key, msg); err != nil {
-			return err
+		if timeField != "" && k == timeField {
+			if t, ok := v.(float64); ok {
+				record["Created"] = t
+			}
 		}
+		record[k] = v
 	}
-	return nil
+	return record
+}
+
+// publishMsgs marshals a batch of records, sets msg.Payload, and publishes.
+func (as *adapterService) publishMsgs(ctx context.Context, key string, msgs []map[string]any, msg protomfx.Message) error {
+	data, err := json.Marshal(msgs)
+	if err != nil {
+		return err
+	}
+	msg.Payload = data
+	_, err = as.publish(ctx, key, msg)
+	return err
 }
 
 func (as *adapterService) publish(ctx context.Context, key string, msg protomfx.Message) (m protomfx.Message, err error) {

--- a/converters/service.go
+++ b/converters/service.go
@@ -264,7 +264,10 @@ func (as *adapterService) PublishJSONMessagesFromJSON(ctx context.Context, key s
 	msgs := []map[string]any{}
 	size := 0
 	for _, inputRecord := range records {
-		record := parseJSONRecord(inputRecord, timeField, &msg)
+		record, err := parseJSONRecord(inputRecord, timeField, &msg)
+		if err != nil {
+			return err
+		}
 		recData, err := json.Marshal(record)
 		if err != nil {
 			return err
@@ -371,19 +374,27 @@ func applyEnvelopeFields(msg *protomfx.Message, src map[string]any) {
 // parseJSONRecord converts one input record into a payload record and updates
 // msg.Protocol / msg.Subtopic from envelope fields. Handles both Format A
 // (reader-exported {"payload":{...},"created":...}) and flat records.
-func parseJSONRecord(inputRecord map[string]any, timeField string, msg *protomfx.Message) map[string]any {
+func parseJSONRecord(inputRecord map[string]any, timeField string, msg *protomfx.Message) (map[string]any, error) {
 	record := map[string]any{}
 
 	if pld, ok := inputRecord["payload"].(map[string]any); ok {
 		// Format A — unwrap outer envelope, prefer timeField over "created".
 		var ts float64
 		if timeField != "" {
-			if t, ok := inputRecord[timeField].(float64); ok {
+			if v, exists := inputRecord[timeField]; exists {
+				t, ok := v.(float64)
+				if !ok {
+					return nil, ErrInvalidTimeField
+				}
 				ts = t
 			}
 		}
 		if ts == 0 {
-			if t, ok := inputRecord["created"].(float64); ok {
+			if v, exists := inputRecord["created"]; exists {
+				t, ok := v.(float64)
+				if !ok {
+					return nil, ErrInvalidTimeField
+				}
 				ts = t
 			}
 		}
@@ -393,13 +404,15 @@ func parseJSONRecord(inputRecord map[string]any, timeField string, msg *protomfx
 		applyEnvelopeFields(msg, inputRecord)
 		for k, v := range pld {
 			if timeField != "" && k == timeField {
-				if t, ok := v.(float64); ok {
-					record["Created"] = t
+				t, ok := v.(float64)
+				if !ok {
+					return nil, ErrInvalidTimeField
 				}
+				record["Created"] = t
 			}
 			record[k] = v
 		}
-		return record
+		return record, nil
 	}
 
 	// Flat record — lift envelope fields into msg, store the rest in record.
@@ -415,20 +428,26 @@ func parseJSONRecord(inputRecord map[string]any, timeField string, msg *protomfx
 					msg.Subtopic = s
 				}
 			case "created":
-				if t, ok := v.(float64); ok && t != 0 {
+				t, ok := v.(float64)
+				if !ok {
+					return nil, ErrInvalidTimeField
+				}
+				if t != 0 {
 					record["Created"] = t
 				}
 			}
 			continue
 		}
 		if timeField != "" && k == timeField {
-			if t, ok := v.(float64); ok {
-				record["Created"] = t
+			t, ok := v.(float64)
+			if !ok {
+				return nil, ErrInvalidTimeField
 			}
+			record["Created"] = t
 		}
 		record[k] = v
 	}
-	return record
+	return record, nil
 }
 
 // publishMsgs marshals a batch of records, sets msg.Payload, and publishes.


### PR DESCRIPTION
Resolves #1250 

- Add POST /json/convert?to=senml and POST /json/convert?to=json converter endpoints that accept a JSON file via multipart/form-data, mirroring the existing CSV endpoints

- Consolidate four path-based routes (/csv/senml, /csv/json, /json/senml, /json/json) into two routes (/csv/convert, /json/convert) with a required ?to=senml|json query parameter selecting the output format

- Extend SenML converter to accept both standard SenML field names (n, t, v, vs, vd, vb, u, s) and reader-exported field names (name, time, value, string_value, data_value, bool_value, unit, sum); reader-exported time values (nanoseconds) are automatically converted to seconds

- Strip envelope fields (protocol, publisher, subtopic, created, Created) from all converted records so they don't leak into the stored payload

- Auto-unwrap reader-exported Format A records ({"payload":{...},"created":...}) in the JSON→JSON path — both flat upload files and reader exports produce identical results

- Rename PublishSenMLMessages/PublishJSONMessages to PublishSenMLMessagesFromCSV/PublishJSONMessagesFromCSV for consistency with the new JSON variants
