### PR TITLE
NOISSUE - Remove unused command input type

### DIFF
--- a/api/openapi/rules.yml
+++ b/api/openapi/rules.yml
@@ -446,7 +446,7 @@ components:
       properties:
         type:
           type: string
-          enum: [message, alarm, command]
+          enum: [message, alarm]
           example: "message"
         thing_ids:
           type: array
@@ -468,7 +468,7 @@ components:
       properties:
         type:
           type: string
-          enum: [message, alarm, command]
+          enum: [message, alarm]
           example: "message"
         config:
           type: object
@@ -778,7 +778,7 @@ components:
       in: query
       schema:
         type: string
-        enum: [message, alarm, command]
+        enum: [message, alarm]
       example: "message"
 
   requestBodies:

--- a/rules/README.md
+++ b/rules/README.md
@@ -35,7 +35,7 @@ The `input` field defines what triggers rule evaluation.
 
 | Field       | Description                                       |
 | ----------- | ------------------------------------------------- |
-| `type`      | Trigger type: `message`, `alarm`, or `command`    |
+| `type`      | Trigger type: `message` or `alarm`                |
 | `thing_ids` | IDs of things to which this rule applies          |
 | `config`    | Optional input-type-specific settings (see below) |
 

--- a/rules/api/http/rules/requests.go
+++ b/rules/api/http/rules/requests.go
@@ -224,7 +224,7 @@ func validateThingIDs(ids []string) error {
 
 func validateInputType(inputType string) error {
 	switch inputType {
-	case rules.InputTypeMessage, rules.InputTypeAlarm, rules.InputTypeCommand:
+	case rules.InputTypeMessage, rules.InputTypeAlarm:
 		return nil
 	default:
 		return apiutil.ErrInvalidInputType

--- a/rules/api/validation.go
+++ b/rules/api/validation.go
@@ -27,7 +27,7 @@ func ValidatePageMetadata(pm rules.PageMetadata, maxLimitSize, maxNameSize int) 
 
 	if pm.InputType != "" {
 		switch pm.InputType {
-		case rules.InputTypeMessage, rules.InputTypeAlarm, rules.InputTypeCommand:
+		case rules.InputTypeMessage, rules.InputTypeAlarm:
 		default:
 			return apiutil.ErrInvalidInputType
 		}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -15,7 +15,6 @@ import (
 const (
 	InputTypeMessage = "message"
 	InputTypeAlarm   = "alarm"
-	InputTypeCommand = "command"
 )
 
 type InputConfig map[string]any


### PR DESCRIPTION
The `rules` service defined `command` as a valid input type alongside `message` and `alarm`, but no subscription or consumer was ever wired for it - a rule created with `input_type: "command"` was accepted but would never fire. 
The command input was an early idea (#1163) that has since been dropped, so this PR removes the unused definitions.