### PR TITLE
MF-1143 - Publishing Will message and handling duplicate messages

### DIFF
--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -208,7 +208,7 @@ func (h *handler) Publish(c *session.Client, topic *string, payload *[]byte) {
 	}
 
 	if err := h.publishToBus(c, *topic, *payload); err != nil {
-		h.logger.Error(err.Error())
+		h.logger.Error(fmt.Sprintf("client_id %s failed to publish to topic %s: %s", c.ID, *topic, err))
 		return
 	}
 

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -207,7 +207,7 @@ func (h *handler) Publish(c *session.Client, topic *string, payload *[]byte) {
 	}
 
 	if err := h.publishToBus(c, *topic, *payload); err != nil {
-		h.logger.Error(fmt.Sprintf("client_id %s failed to publish to topic %s", c.ID, *topic))
+		h.logger.Error(fmt.Sprintf("client_id %s failed to publish to topic %s: %s", c.ID, *topic, err))
 		return
 	}
 
@@ -222,7 +222,7 @@ func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) 
 
 	pc, err := h.things.GetPubConfigByKey(context.Background(), tk)
 	if err != nil {
-		return errors.Wrap(messaging.ErrPublishMessage, err)
+		return err
 	}
 
 	subject, subtopic, err := parseTopic(topic, pc.PublisherID)
@@ -237,18 +237,18 @@ func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) 
 	}
 
 	if err := messaging.FormatMessage(pc, &msg); err != nil {
-		return errors.Wrap(messaging.ErrPublishMessage, err)
+		return err
 	}
 
 	if isCommandSubject(subject) {
 		if err := h.publishCommand(subject, msg); err != nil {
-			return errors.Wrap(messaging.ErrPublishMessage, err)
+			return err
 		}
 		return nil
 	}
 
 	if err := h.publishMessage(pc, msg); err != nil {
-		return errors.Wrap(messaging.ErrPublishMessage, err)
+		return err
 	}
 
 	return nil

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -29,8 +29,8 @@ const (
 	topicSuffixCommands = "commands"
 	topicSuffixMessages = "messages"
 
-	typeCommand = "command"
-	typeMessage = "message"
+	kindMessage = "message"
+	kindCommand = "command"
 )
 
 var (
@@ -220,7 +220,7 @@ func (h *handler) Publish(c *session.Client, topic *string, payload *[]byte) {
 }
 
 // publishToBus routes a client's topic and payload onto the internal message bus,
-// returning "command" or "message" to describe what was published.
+// reporting the kind of what was published.
 func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) (string, error) {
 	tk := domain.ThingKey{
 		Value: string(c.Password),
@@ -251,14 +251,14 @@ func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) 
 		if err := h.publishCommand(subject, msg); err != nil {
 			return "", errors.Wrap(messaging.ErrPublishMessage, err)
 		}
-		return typeCommand, nil
+		return kindCommand, nil
 	}
 
 	if err := h.publishMessage(pc, msg); err != nil {
 		return "", errors.Wrap(messaging.ErrPublishMessage, err)
 	}
 
-	return typeMessage, nil
+	return kindMessage, nil
 }
 
 func (h *handler) publishCommand(subject string, msg protomfx.Message) error {

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -383,7 +383,7 @@ func (h *handler) Disconnect(c *session.Client) {
 		return
 	}
 
-	h.logger.Info(fmt.Sprintf("client_id %s will published to topic %s", c.ID, c.WillTopic))
+	h.logger.Info(fmt.Sprintf("client_id %s published will message to topic %s", c.ID, c.WillTopic))
 }
 
 func (h *handler) identify(c *session.Client) (string, error) {

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -375,22 +375,16 @@ func (h *handler) Disconnect(c *session.Client) {
 		return
 	}
 
-	// The broker publishes the Will to MQTT subscribers itself, but that publish never
-	// transits the proxy, so it would otherwise never reach the internal bus and the
-	// writers, rules and webhooks would never see it. Mirror it here.
-	if c.WillFlag && !c.CleanDisconnect {
-		h.publishWill(c)
-	}
-
 	if err := h.cache.Disconnect(context.Background(), c.ID); err != nil {
 		h.logger.Error(errors.Wrap(errFailedCacheDisconnection, err).Error())
 	}
 
 	h.logger.Info(fmt.Sprintf("client_id %s disconnected", c.ID))
-}
 
-// publishWill mirrors a client's Last Will onto the internal bus.
-func (h *handler) publishWill(c *session.Client) {
+	if !c.WillFlag || c.CleanDisconnect {
+		return
+	}
+
 	if _, err := h.publishToBus(c, c.WillTopic, c.WillMessage); err != nil {
 		h.logger.Error(errors.Wrap(errFailedPublishWill, err).Error())
 		return

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -28,6 +28,9 @@ const (
 	topicPrefixGroups   = "groups"
 	topicSuffixCommands = "commands"
 	topicSuffixMessages = "messages"
+
+	typeCommand = "command"
+	typeMessage = "message"
 )
 
 var (
@@ -207,22 +210,17 @@ func (h *handler) Publish(c *session.Client, topic *string, payload *[]byte) {
 		return
 	}
 
-	subject, err := h.publishToBus(c, *topic, *payload)
+	kind, err := h.publishToBus(c, *topic, *payload)
 	if err != nil {
 		h.logger.Error(err.Error())
 		return
-	}
-
-	kind := "message"
-	if isCommandSubject(subject) {
-		kind = "command"
 	}
 
 	h.logger.Info(fmt.Sprintf("client_id %s published %s to topic %s", c.ID, kind, *topic))
 }
 
 // publishToBus routes a client's topic and payload onto the internal message bus,
-// returning the subject it was published to.
+// returning "command" or "message" to describe what was published.
 func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) (string, error) {
 	tk := domain.ThingKey{
 		Value: string(c.Password),
@@ -253,14 +251,14 @@ func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) 
 		if err := h.publishCommand(subject, msg); err != nil {
 			return "", errors.Wrap(messaging.ErrPublishMessage, err)
 		}
-		return subject, nil
+		return typeCommand, nil
 	}
 
 	if err := h.publishMessage(pc, msg); err != nil {
 		return "", errors.Wrap(messaging.ErrPublishMessage, err)
 	}
 
-	return subject, nil
+	return typeMessage, nil
 }
 
 func (h *handler) publishCommand(subject string, msg protomfx.Message) error {

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -28,9 +28,6 @@ const (
 	topicPrefixGroups   = "groups"
 	topicSuffixCommands = "commands"
 	topicSuffixMessages = "messages"
-
-	kindMessage = "message"
-	kindCommand = "command"
 )
 
 var (
@@ -210,18 +207,15 @@ func (h *handler) Publish(c *session.Client, topic *string, payload *[]byte) {
 		return
 	}
 
-	kind, err := h.publishToBus(c, *topic, *payload)
-	if err != nil {
+	if err := h.publishToBus(c, *topic, *payload); err != nil {
 		h.logger.Error(err.Error())
 		return
 	}
 
-	h.logger.Info(fmt.Sprintf("client_id %s published %s to topic %s", c.ID, kind, *topic))
+	h.logger.Info(fmt.Sprintf("client_id %s published to topic %s", c.ID, *topic))
 }
 
-// publishToBus routes a client's topic and payload onto the internal message bus,
-// reporting the kind of what was published.
-func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) (string, error) {
+func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) error {
 	tk := domain.ThingKey{
 		Value: string(c.Password),
 		Type:  c.Username,
@@ -229,12 +223,12 @@ func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) 
 
 	pc, err := h.things.GetPubConfigByKey(context.Background(), tk)
 	if err != nil {
-		return "", errors.Wrap(messaging.ErrPublishMessage, err)
+		return errors.Wrap(messaging.ErrPublishMessage, err)
 	}
 
 	subject, subtopic, err := parseTopic(topic, pc.PublisherID)
 	if err != nil {
-		return "", errors.Wrap(errFailedParseSubtopic, err)
+		return errors.Wrap(errFailedParseSubtopic, err)
 	}
 
 	msg := protomfx.Message{
@@ -244,21 +238,21 @@ func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) 
 	}
 
 	if err := messaging.FormatMessage(pc, &msg); err != nil {
-		return "", errors.Wrap(messaging.ErrPublishMessage, err)
+		return errors.Wrap(messaging.ErrPublishMessage, err)
 	}
 
 	if isCommandSubject(subject) {
 		if err := h.publishCommand(subject, msg); err != nil {
-			return "", errors.Wrap(messaging.ErrPublishMessage, err)
+			return errors.Wrap(messaging.ErrPublishMessage, err)
 		}
-		return kindCommand, nil
+		return nil
 	}
 
 	if err := h.publishMessage(pc, msg); err != nil {
-		return "", errors.Wrap(messaging.ErrPublishMessage, err)
+		return errors.Wrap(messaging.ErrPublishMessage, err)
 	}
 
-	return kindMessage, nil
+	return nil
 }
 
 func (h *handler) publishCommand(subject string, msg protomfx.Message) error {
@@ -385,7 +379,7 @@ func (h *handler) Disconnect(c *session.Client) {
 		return
 	}
 
-	if _, err := h.publishToBus(c, c.WillTopic, c.WillMessage); err != nil {
+	if err := h.publishToBus(c, c.WillTopic, c.WillMessage); err != nil {
 		h.logger.Error(errors.Wrap(errFailedPublishWill, err).Error())
 		return
 	}

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -45,7 +45,6 @@ var (
 	errFailedParseSubtopic      = errors.New("failed to parse subtopic")
 	errFailedCacheConnection    = errors.New("failed to cache connection")
 	errFailedCacheDisconnection = errors.New("failed to remove connection from cache")
-	errFailedPublishWill        = errors.New("failed to publish will message")
 )
 
 // handler implements session.Handler interface
@@ -380,7 +379,7 @@ func (h *handler) Disconnect(c *session.Client) {
 	}
 
 	if err := h.publishToBus(c, c.WillTopic, c.WillMessage); err != nil {
-		h.logger.Error(errors.Wrap(errFailedPublishWill, err).Error())
+		h.logger.Error(fmt.Sprintf("client_id %s failed to publish will to topic %s: %s", c.ID, c.WillTopic, err))
 		return
 	}
 

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -207,7 +207,7 @@ func (h *handler) Publish(c *session.Client, topic *string, payload *[]byte) {
 	}
 
 	if err := h.publishToBus(c, *topic, *payload); err != nil {
-		h.logger.Error(fmt.Sprintf("client_id %s failed to publish to topic %s: %s", c.ID, *topic, err))
+		h.logger.Error(fmt.Sprintf("client_id %s failed to publish to topic %s", c.ID, *topic))
 		return
 	}
 

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -45,6 +45,7 @@ var (
 	errFailedParseSubtopic      = errors.New("failed to parse subtopic")
 	errFailedCacheConnection    = errors.New("failed to cache connection")
 	errFailedCacheDisconnection = errors.New("failed to remove connection from cache")
+	errFailedPublishWill        = errors.New("failed to publish will message")
 )
 
 // handler implements session.Handler interface
@@ -206,6 +207,23 @@ func (h *handler) Publish(c *session.Client, topic *string, payload *[]byte) {
 		return
 	}
 
+	subject, err := h.publishToBus(c, *topic, *payload)
+	if err != nil {
+		h.logger.Error(err.Error())
+		return
+	}
+
+	kind := "message"
+	if isCommandSubject(subject) {
+		kind = "command"
+	}
+
+	h.logger.Info(fmt.Sprintf("client_id %s published %s to topic %s", c.ID, kind, *topic))
+}
+
+// publishToBus routes a client's topic and payload onto the internal message bus,
+// returning the subject it was published to.
+func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) (string, error) {
 	tk := domain.ThingKey{
 		Value: string(c.Password),
 		Type:  c.Username,
@@ -213,42 +231,36 @@ func (h *handler) Publish(c *session.Client, topic *string, payload *[]byte) {
 
 	pc, err := h.things.GetPubConfigByKey(context.Background(), tk)
 	if err != nil {
-		h.logger.Error(errors.Wrap(messaging.ErrPublishMessage, err).Error())
-		return
+		return "", errors.Wrap(messaging.ErrPublishMessage, err)
 	}
 
-	subject, subtopic, err := parseTopic(*topic, pc.PublisherID)
+	subject, subtopic, err := parseTopic(topic, pc.PublisherID)
 	if err != nil {
-		h.logger.Error(errors.Wrap(errFailedParseSubtopic, err).Error())
-		return
+		return "", errors.Wrap(errFailedParseSubtopic, err)
 	}
 
 	msg := protomfx.Message{
 		Protocol: protocol,
 		Subtopic: subtopic,
-		Payload:  *payload,
+		Payload:  payload,
 	}
 
 	if err := messaging.FormatMessage(pc, &msg); err != nil {
-		h.logger.Error(errors.Wrap(messaging.ErrPublishMessage, err).Error())
-		return
+		return "", errors.Wrap(messaging.ErrPublishMessage, err)
 	}
 
 	if isCommandSubject(subject) {
 		if err := h.publishCommand(subject, msg); err != nil {
-			h.logger.Error(errors.Wrap(messaging.ErrPublishMessage, err).Error())
-			return
+			return "", errors.Wrap(messaging.ErrPublishMessage, err)
 		}
-		h.logger.Info(fmt.Sprintf("client_id %s published command to topic %s", c.ID, *topic))
-		return
+		return subject, nil
 	}
 
 	if err := h.publishMessage(pc, msg); err != nil {
-		h.logger.Error(errors.Wrap(messaging.ErrPublishMessage, err).Error())
-		return
+		return "", errors.Wrap(messaging.ErrPublishMessage, err)
 	}
 
-	h.logger.Info(fmt.Sprintf("client_id %s published message to topic %s", c.ID, *topic))
+	return subject, nil
 }
 
 func (h *handler) publishCommand(subject string, msg protomfx.Message) error {
@@ -365,11 +377,28 @@ func (h *handler) Disconnect(c *session.Client) {
 		return
 	}
 
+	// The broker publishes the Will to MQTT subscribers itself, but that publish never
+	// transits the proxy, so it would otherwise never reach the internal bus and the
+	// writers, rules and webhooks would never see it. Mirror it here.
+	if c.WillFlag && !c.CleanDisconnect {
+		h.publishWill(c)
+	}
+
 	if err := h.cache.Disconnect(context.Background(), c.ID); err != nil {
 		h.logger.Error(errors.Wrap(errFailedCacheDisconnection, err).Error())
 	}
 
 	h.logger.Info(fmt.Sprintf("client_id %s disconnected", c.ID))
+}
+
+// publishWill mirrors a client's Last Will onto the internal bus.
+func (h *handler) publishWill(c *session.Client) {
+	if _, err := h.publishToBus(c, c.WillTopic, c.WillMessage); err != nil {
+		h.logger.Error(errors.Wrap(errFailedPublishWill, err).Error())
+		return
+	}
+
+	h.logger.Info(fmt.Sprintf("client_id %s will published to topic %s", c.ID, c.WillTopic))
 }
 
 func (h *handler) identify(c *session.Client) (string, error) {

--- a/mqtt/handler_test.go
+++ b/mqtt/handler_test.go
@@ -442,7 +442,7 @@ func TestDisconnectPublishesWill(t *testing.T) {
 		publishesWill bool
 	}{
 		{
-			desc:          "abnormal disconnect publishes the will",
+			desc:          "unexpected disconnect publishes the will",
 			client:        willClient(false),
 			publishesWill: true,
 		},

--- a/mqtt/handler_test.go
+++ b/mqtt/handler_test.go
@@ -17,14 +17,15 @@ import (
 )
 
 const (
-	thingID      = "513d02d2-16c1-4f23-98be-9e12f8fee898"
-	groupID      = "9e12f8fe-e89b-a456-12d3-513d02d21212"
-	recipientID  = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-	otherThingID = "11111111-2222-3333-4444-555555555555"
-	otherGroupID = "66666666-7777-8888-9999-000000000000"
-	clientID     = "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb"
-	password     = "cccccccc-dddd-eeee-ffff-aaaaaaaaaaaa"
-	subtopic     = "test-subtopic"
+	thingID          = "513d02d2-16c1-4f23-98be-9e12f8fee898"
+	groupID          = "9e12f8fe-e89b-a456-12d3-513d02d21212"
+	recipientID      = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	otherThingID     = "11111111-2222-3333-4444-555555555555"
+	otherGroupID     = "66666666-7777-8888-9999-000000000000"
+	clientID         = "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb"
+	password         = "cccccccc-dddd-eeee-ffff-aaaaaaaaaaaa"
+	subtopic         = "test-subtopic"
+	logFailedPublish = "failed to publish to topic"
 )
 
 var (
@@ -297,14 +298,14 @@ func TestPublish(t *testing.T) {
 			client:  &sessionClient,
 			topic:   malformedSubtopics,
 			payload: payload,
-			logMsg:  "failed to publish to topic",
+			logMsg:  logFailedPublish,
 		},
 		{
 			desc:    "publish with subtopic containing wrong character",
 			client:  &sessionClient,
 			topic:   wrongCharSubtopics,
 			payload: payload,
-			logMsg:  "failed to publish to topic",
+			logMsg:  logFailedPublish,
 		},
 		{
 			desc:    "publish with subtopic",

--- a/mqtt/handler_test.go
+++ b/mqtt/handler_test.go
@@ -420,6 +420,57 @@ func TestDisconnect(t *testing.T) {
 	}
 }
 
+func TestDisconnectPublishesWill(t *testing.T) {
+	handler := newHandler()
+
+	willTopic := "things/" + thingID + "/messages"
+	willClient := func(cleanDisconnect bool) *session.Client {
+		return &session.Client{
+			ID:              clientID,
+			Username:        things.KeyTypeInternal,
+			Password:        []byte(password),
+			WillFlag:        true,
+			WillTopic:       willTopic,
+			WillMessage:     payload,
+			CleanDisconnect: cleanDisconnect,
+		}
+	}
+
+	cases := []struct {
+		desc          string
+		client        *session.Client
+		publishesWill bool
+	}{
+		{
+			desc:          "abnormal disconnect publishes the will",
+			client:        willClient(false),
+			publishesWill: true,
+		},
+		{
+			desc:          "clean disconnect does not publish the will",
+			client:        willClient(true),
+			publishesWill: false,
+		},
+		{
+			desc:          "disconnect without a will publishes nothing",
+			client:        &sessionClient,
+			publishesWill: false,
+		},
+	}
+
+	for _, tc := range cases {
+		logBuffer.Reset()
+		handler.Disconnect(tc.client)
+
+		logMsg := fmt.Sprintf("client_id %s will published to topic %s", clientID, willTopic)
+		if tc.publishesWill {
+			assert.Contains(t, logBuffer.String(), logMsg, tc.desc)
+			continue
+		}
+		assert.NotContains(t, logBuffer.String(), "will published", tc.desc)
+	}
+}
+
 func newHandler() session.Handler {
 	logger, err := logger.New(&logBuffer, "debug")
 	if err != nil {

--- a/mqtt/handler_test.go
+++ b/mqtt/handler_test.go
@@ -462,12 +462,12 @@ func TestDisconnectPublishesWill(t *testing.T) {
 		logBuffer.Reset()
 		handler.Disconnect(tc.client)
 
-		logMsg := fmt.Sprintf("client_id %s will published to topic %s", clientID, willTopic)
+		logMsg := fmt.Sprintf("client_id %s published will message to topic %s", clientID, willTopic)
 		if tc.publishesWill {
 			assert.Contains(t, logBuffer.String(), logMsg, tc.desc)
 			continue
 		}
-		assert.NotContains(t, logBuffer.String(), "will published", tc.desc)
+		assert.NotContains(t, logBuffer.String(), "published will message", tc.desc)
 	}
 }
 

--- a/mqtt/handler_test.go
+++ b/mqtt/handler_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/mqtt"
 	"github.com/MainfluxLabs/mainflux/mqtt/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
-	"github.com/MainfluxLabs/mainflux/pkg/messaging"
 	pkgmocks "github.com/MainfluxLabs/mainflux/pkg/mocks"
 	"github.com/MainfluxLabs/mainflux/pkg/mproxy/session"
 	"github.com/MainfluxLabs/mainflux/things"
@@ -298,14 +297,14 @@ func TestPublish(t *testing.T) {
 			client:  &sessionClient,
 			topic:   malformedSubtopics,
 			payload: payload,
-			logMsg:  messaging.ErrMalformedSubtopic.Error(),
+			logMsg:  "failed to publish to topic",
 		},
 		{
 			desc:    "publish with subtopic containing wrong character",
 			client:  &sessionClient,
 			topic:   wrongCharSubtopics,
 			payload: payload,
-			logMsg:  messaging.ErrMalformedSubtopic.Error(),
+			logMsg:  "failed to publish to topic",
 		},
 		{
 			desc:    "publish with subtopic",

--- a/pkg/mproxy/session/client.go
+++ b/pkg/mproxy/session/client.go
@@ -8,4 +8,10 @@ type Client struct {
 	Username string
 	Password []byte
 	Cert     x509.Certificate
+
+	WillFlag    bool
+	WillTopic   string
+	WillMessage []byte
+
+	CleanDisconnect bool
 }

--- a/pkg/mproxy/session/session.go
+++ b/pkg/mproxy/session/session.go
@@ -103,6 +103,22 @@ func (s *Session) authorize(pkt packets.ControlPacket) error {
 		p.ClientIdentifier = s.Client.ID
 		p.Username = s.Client.Username
 		p.Password = s.Client.Password
+
+		// A Will is a deferred publish, so it must clear the same authorization a
+		// live publish would. Without this an unauthorized Will topic reaches the
+		// broker, which publishes it on abnormal termination with no check at all.
+		//
+		// Authorize before recording the Will on the Client: a failure here tears
+		// the connection down, and Disconnect must not then mirror an unauthorized
+		// Will onto the internal bus.
+		if p.WillFlag {
+			if err := s.handler.AuthPublish(&s.Client, &p.WillTopic, &p.WillMessage); err != nil {
+				return err
+			}
+			s.Client.WillFlag = true
+			s.Client.WillTopic = p.WillTopic
+			s.Client.WillMessage = p.WillMessage
+		}
 		return nil
 	case *packets.PublishPacket:
 		return s.handler.AuthPublish(&s.Client, &p.TopicName, &p.Payload)
@@ -118,11 +134,18 @@ func (s *Session) notify(pkt packets.ControlPacket) {
 	case *packets.ConnectPacket:
 		s.handler.Connect(&s.Client)
 	case *packets.PublishPacket:
+		// If this publish is a retransmission, don't copy it onto the internal bus.
+		// The packet itself is already forwarded to the broker.
+		if p.Dup {
+			return
+		}
 		s.handler.Publish(&s.Client, &p.TopicName, &p.Payload)
 	case *packets.SubscribePacket:
 		s.handler.Subscribe(&s.Client, &p.Topics)
 	case *packets.UnsubscribePacket:
 		s.handler.Unsubscribe(&s.Client, &p.Topics)
+	case *packets.DisconnectPacket:
+		s.Client.CleanDisconnect = true
 	default:
 		return
 	}

--- a/pkg/mproxy/session/session_test.go
+++ b/pkg/mproxy/session/session_test.go
@@ -1,0 +1,215 @@
+package session_test
+
+import (
+	"crypto/x509"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/pkg/mproxy/session"
+	"github.com/eclipse/paho.mqtt.golang/packets"
+	"github.com/stretchr/testify/assert"
+)
+
+const readTimeout = 500 * time.Millisecond
+
+var errUnauthorized = errors.New("unauthorized")
+
+// recordingHandler is a session.Handler that reports, over channels, which hooks
+// the proxy invoked. Tests assert on those channels rather than on shared fields,
+// so they never race the Session goroutine.
+type recordingHandler struct {
+	authPublishErr error
+	published      chan string         // one topic per Publish hook
+	disconnected   chan session.Client // the client state seen at Disconnect
+}
+
+func newRecordingHandler(authPublishErr error) *recordingHandler {
+	return &recordingHandler{
+		authPublishErr: authPublishErr,
+		published:      make(chan string, 4),
+		disconnected:   make(chan session.Client, 1),
+	}
+}
+
+func (h *recordingHandler) AuthConnect(c *session.Client) error { return nil }
+
+func (h *recordingHandler) AuthPublish(c *session.Client, topic *string, payload *[]byte) error {
+	return h.authPublishErr
+}
+
+func (h *recordingHandler) AuthSubscribe(c *session.Client, topics *[]string) error { return nil }
+func (h *recordingHandler) Connect(c *session.Client)                               {}
+
+func (h *recordingHandler) Publish(c *session.Client, topic *string, payload *[]byte) {
+	h.published <- *topic
+}
+
+func (h *recordingHandler) Subscribe(c *session.Client, topics *[]string)   {}
+func (h *recordingHandler) Unsubscribe(c *session.Client, topics *[]string) {}
+func (h *recordingHandler) Disconnect(c *session.Client)                    { h.disconnected <- *c }
+
+// proxy wires a Session between a fake client and a fake broker over in-memory
+// pipes, so tests can drive real MQTT packets through the public Stream API and
+// observe what reaches the broker.
+type proxy struct {
+	client  net.Conn
+	broker  net.Conn
+	handler *recordingHandler
+}
+
+func newProxy(t *testing.T, h *recordingHandler) *proxy {
+	t.Helper()
+
+	clientConn, proxyIn := net.Pipe()
+	proxyOut, brokerConn := net.Pipe()
+
+	log, err := logger.New(io.Discard, "error")
+	assert.Nil(t, err)
+
+	s := session.New(proxyIn, proxyOut, h, log, x509.Certificate{})
+	go s.Stream()
+
+	t.Cleanup(func() {
+		clientConn.Close()
+		brokerConn.Close()
+	})
+
+	return &proxy{client: clientConn, broker: brokerConn, handler: h}
+}
+
+// send writes a packet from the client into the proxy.
+func (p *proxy) send(t *testing.T, pkt packets.ControlPacket) {
+	t.Helper()
+	go pkt.Write(p.client)
+}
+
+// readBroker returns the next packet the broker receives, or nil if none arrives
+// before the deadline.
+func (p *proxy) readBroker(t *testing.T) packets.ControlPacket {
+	t.Helper()
+
+	assert.Nil(t, p.broker.SetReadDeadline(time.Now().Add(readTimeout)))
+	pkt, err := packets.ReadPacket(p.broker)
+	if err != nil {
+		return nil
+	}
+	return pkt
+}
+
+func connectPacket(willTopic string) *packets.ConnectPacket {
+	p := packets.NewControlPacket(packets.Connect).(*packets.ConnectPacket)
+	p.ClientIdentifier = "client-1"
+	if willTopic != "" {
+		p.WillFlag = true
+		p.WillTopic = willTopic
+		p.WillMessage = []byte("will-payload")
+	}
+	return p
+}
+
+func publishPacket(topic string, dup bool) *packets.PublishPacket {
+	p := packets.NewControlPacket(packets.Publish).(*packets.PublishPacket)
+	p.TopicName = topic
+	p.Payload = []byte("payload")
+	p.Qos = 1
+	p.Dup = dup
+	return p
+}
+
+// An unauthorized Will must never reach the broker: if the CONNECT gets through,
+// the broker publishes the Will, unchecked, on abnormal termination.
+func TestStreamRejectsUnauthorizedWill(t *testing.T) {
+	h := newRecordingHandler(errUnauthorized)
+	p := newProxy(t, h)
+
+	p.send(t, connectPacket("groups/victim-group/commands"))
+
+	assert.Nil(t, p.readBroker(t), "unauthorized will: CONNECT must not be forwarded to the broker")
+
+	// The Will must also not be recorded on the client. Otherwise teardown would
+	// mirror the unauthorized Will onto the internal bus despite the refused connection.
+	select {
+	case c := <-h.disconnected:
+		assert.False(t, c.WillFlag, "unauthorized will must not be recorded on the client")
+	case <-time.After(time.Second):
+		t.Fatal("session did not disconnect")
+	}
+}
+
+// An authorized Will is forwarded to the broker intact.
+func TestStreamForwardsAuthorizedWill(t *testing.T) {
+	h := newRecordingHandler(nil)
+	p := newProxy(t, h)
+
+	p.send(t, connectPacket("things/thing-1/messages"))
+
+	cp, ok := p.readBroker(t).(*packets.ConnectPacket)
+	assert.True(t, ok, "authorized will: CONNECT must reach the broker")
+	assert.True(t, cp.WillFlag)
+	assert.Equal(t, "things/thing-1/messages", cp.WillTopic)
+	assert.Equal(t, []byte("will-payload"), cp.WillMessage)
+}
+
+// A retransmission is still forwarded to the broker verbatim - the broker owns the
+// QoS handshake - but the duplicate publish onto the internal bus is suppressed.
+func TestStreamForwardsPublishSkippingDupOnBus(t *testing.T) {
+	cases := []struct {
+		desc           string
+		dup            bool
+		wantBusPublish bool
+	}{
+		{
+			desc:           "first delivery reaches the broker and the bus",
+			dup:            false,
+			wantBusPublish: true,
+		},
+		{
+			desc:           "retransmit reaches the broker but not the bus",
+			dup:            true,
+			wantBusPublish: false,
+		},
+	}
+
+	for _, tc := range cases {
+		h := newRecordingHandler(nil)
+		p := newProxy(t, h)
+
+		p.send(t, publishPacket("things/thing-1/messages", tc.dup))
+
+		pp, ok := p.readBroker(t).(*packets.PublishPacket)
+		assert.True(t, ok, "%s: PUBLISH must always be forwarded to the broker", tc.desc)
+		assert.Equal(t, tc.dup, pp.Dup, tc.desc)
+
+		select {
+		case topic := <-h.published:
+			assert.True(t, tc.wantBusPublish, "%s: unexpected bus publish of %q", tc.desc, topic)
+		case <-time.After(200 * time.Millisecond):
+			assert.False(t, tc.wantBusPublish, "%s: expected a bus publish, got none", tc.desc)
+		}
+	}
+}
+
+// An explicit DISCONNECT marks the disconnect clean, so the Will is not fired.
+func TestStreamMarksCleanDisconnect(t *testing.T) {
+	h := newRecordingHandler(nil)
+	p := newProxy(t, h)
+
+	p.send(t, connectPacket(""))
+	assert.NotNil(t, p.readBroker(t), "CONNECT must reach the broker")
+
+	p.send(t, packets.NewControlPacket(packets.Disconnect))
+	assert.NotNil(t, p.readBroker(t), "DISCONNECT must reach the broker")
+
+	p.client.Close()
+
+	select {
+	case c := <-h.disconnected:
+		assert.True(t, c.CleanDisconnect, "explicit DISCONNECT must mark a clean disconnect")
+	case <-time.After(time.Second):
+		t.Fatal("session did not disconnect")
+	}
+}


### PR DESCRIPTION
Originally, I wanted to cover all the missing pieces described in the issue. After thorough examination, I realized that only fixing double writes with DUP and handling Last Will is what we were missing. This PR is adding those two features to the codebase.

| Issue claim | What I found | Status |
|---|---|---|
| QoS 0/1/2 flags | Mosquitto already handles these | not broken |
| Retained messages ignored | Mosquitto stores and replays them | not broken |
| Persistent sessions ignored | works — Mosquitto respects `clean_session=false` | not broken |
| Last Will ignored | true, and it lets a thing bypass command auth | fixed |
| Everything downgraded to QoS 0 | nothing downgrades anything; the forwarder uses QoS 2 | not broken |
| DUP retransmits (not in the issue) | these were getting written to the DB twice | fixed |


Resolves #1143 