### PR TITLE
MF-1282 - drop dbutil.GetOrderQuery and handle LOWER per-service

### DIFF
--- a/audit/api/http/requests.go
+++ b/audit/api/http/requests.go
@@ -10,20 +10,11 @@ import (
 
 const maxLimitSize = 200
 
-var allowedOrders = map[string]string{
-	"id":          "id",
-	"occurred_at": "occurred_at",
-	"operation":   "operation",
-	"actor_email": "actor_email",
-	"org_id":      "org_id",
-	"group_id":    "group_id",
-}
-
 // validatePageMetadata validates the audit page metadata.
 func validatePageMetadata(pm audit.PageMetadata) error {
 	common := apiutil.PageMetadata{Offset: pm.Offset, Limit: pm.Limit, Order: pm.Order, Dir: pm.Dir}
 
-	return common.Validate(maxLimitSize, allowedOrders)
+	return common.Validate(maxLimitSize, audit.EventOrderFields)
 }
 
 type listEventsReq struct {

--- a/audit/postgres/events.go
+++ b/audit/postgres/events.go
@@ -65,7 +65,7 @@ func (r *eventRepository) RetrieveEvents(ctx context.Context, pm audit.PageMetad
 	whereClause := dbutil.BuildWhereClause(actorEmailQ, opQ, fromQ, toQ, dataQ)
 	query := fmt.Sprintf(
 		`SELECT id, occurred_at, operation, actor_id, actor_email, org_id, group_id, action_data FROM events %s ORDER BY %s %s %s`,
-		whereClause, dbutil.GetOrderQuery(pm.Order), dbutil.GetDirQuery(pm.Dir), dbutil.GetOffsetLimitQuery(pm.Limit),
+		whereClause, dbutil.GetOrderQuery(pm.Order, audit.EventOrderFields), dbutil.GetDirQuery(pm.Dir), dbutil.GetOffsetLimitQuery(pm.Limit),
 	)
 	cquery := fmt.Sprintf(`SELECT COUNT(*) FROM events %s`, whereClause)
 
@@ -97,7 +97,7 @@ func (r *eventRepository) RetrieveEventsByOrg(ctx context.Context, orgID string,
 	whereClause := dbutil.BuildWhereClause(actorEmailQ, opQ, orgQ, fromQ, toQ, dataQ)
 	query := fmt.Sprintf(
 		`SELECT id, occurred_at, operation, actor_id, actor_email, org_id, group_id, action_data FROM events %s ORDER BY %s %s %s`,
-		whereClause, dbutil.GetOrderQuery(pm.Order), dbutil.GetDirQuery(pm.Dir), dbutil.GetOffsetLimitQuery(pm.Limit),
+		whereClause, dbutil.GetOrderQuery(pm.Order, audit.EventOrderFields), dbutil.GetDirQuery(pm.Dir), dbutil.GetOffsetLimitQuery(pm.Limit),
 	)
 	cquery := fmt.Sprintf(`SELECT COUNT(*) FROM events %s`, whereClause)
 
@@ -130,7 +130,7 @@ func (r *eventRepository) RetrieveEventsByGroup(ctx context.Context, groupID str
 	whereClause := dbutil.BuildWhereClause(actorEmailQ, opQ, groupQ, fromQ, toQ, dataQ)
 	query := fmt.Sprintf(
 		`SELECT id, occurred_at, operation, actor_id, actor_email, org_id, group_id, action_data FROM events %s ORDER BY %s %s %s`,
-		whereClause, dbutil.GetOrderQuery(pm.Order), dbutil.GetDirQuery(pm.Dir), dbutil.GetOffsetLimitQuery(pm.Limit),
+		whereClause, dbutil.GetOrderQuery(pm.Order, audit.EventOrderFields), dbutil.GetDirQuery(pm.Dir), dbutil.GetOffsetLimitQuery(pm.Limit),
 	)
 	cquery := fmt.Sprintf(`SELECT COUNT(*) FROM events %s`, whereClause)
 

--- a/audit/service.go
+++ b/audit/service.go
@@ -22,6 +22,16 @@ type Event struct {
 	ActionData map[string]any
 }
 
+// EventOrderFields maps API-facing order keys to SQL column expressions for the events table.
+var EventOrderFields = map[string]string{
+	"id":          "id",
+	"occurred_at": "occurred_at",
+	"operation":   "operation",
+	"actor_email": "LOWER(actor_email)",
+	"org_id":      "org_id",
+	"group_id":    "group_id",
+}
+
 type EventsPage struct {
 	Total  uint64  `json:"total"`
 	Events []Event `json:"events"`

--- a/auth/api/http/invites/requests.go
+++ b/auth/api/http/invites/requests.go
@@ -105,7 +105,7 @@ func (req listOrgInvitesByUserReq) validate() error {
 		return apiutil.ErrMissingUserID
 	}
 
-	return api.ValidatePageMetadata(req.pm, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pm, maxLimitSize, maxNameSize, auth.OrgInviteOrderFields)
 }
 
 type listOrgInvitesByOrgReq struct {
@@ -123,5 +123,5 @@ func (req listOrgInvitesByOrgReq) validate() error {
 		return apiutil.ErrMissingOrgID
 	}
 
-	return api.ValidatePageMetadata(req.pm, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pm, maxLimitSize, maxNameSize, auth.OrgInviteOrderFields)
 }

--- a/auth/api/http/orgs/requests.go
+++ b/auth/api/http/orgs/requests.go
@@ -59,7 +59,7 @@ func (req listOrgsReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, auth.OrgOrderFields)
 }
 
 type orgReq struct {

--- a/auth/api/validation.go
+++ b/auth/api/validation.go
@@ -8,20 +8,8 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 )
 
-var allowedOrders = map[string]string{
-	"id":         "id",
-	"name":       "name",
-	"created_at": "created_at",
-	"updated_at": "updated_at",
-	"invitee_id": "invitee_id",
-	"inviter_id": "inviter_id",
-	"org_id":     "org_id",
-	"state":      "state",
-	"issued_at":  "issued_at",
-}
-
-// ValidatePageMetadata validates the auth page metadata.
-func ValidatePageMetadata(pm auth.PageMetadata, maxLimitSize, maxNameSize int) error {
+// ValidatePageMetadata validates the auth page metadata against the specified allowed orders map.
+func ValidatePageMetadata(pm auth.PageMetadata, maxLimitSize, maxNameSize int, allowedOrders map[string]string) error {
 	common := apiutil.PageMetadata{Offset: pm.Offset, Limit: pm.Limit, Order: pm.Order, Dir: pm.Dir}
 	if err := common.Validate(maxLimitSize, allowedOrders); err != nil {
 		return err

--- a/auth/invites.go
+++ b/auth/invites.go
@@ -19,6 +19,16 @@ var (
 	ErrGroupsDifferingOrgs = errors.New("groups belong to differing organizations")
 )
 
+// OrgInviteOrderFields maps API-facing order keys to SQL column expressions for the org_invites table.
+var OrgInviteOrderFields = map[string]string{
+	"id":         "id",
+	"invitee_id": "invitee_id",
+	"inviter_id": "inviter_id",
+	"org_id":     "org_id",
+	"state":      "state",
+	"created_at": "created_at",
+}
+
 // Domain type aliases
 type (
 	OrgInvite      = domain.OrgInvite

--- a/auth/keys.go
+++ b/auth/keys.go
@@ -22,6 +22,12 @@ var (
 	ErrAPIKeyExpired = errors.New("use of expired API key")
 )
 
+// KeyOrderFields maps API-facing order keys to SQL column expressions for the keys table.
+var KeyOrderFields = map[string]string{
+	"id":        "id",
+	"issued_at": "issued_at",
+}
+
 // Domain type aliases
 type (
 	Key      = domain.Key

--- a/auth/orgs.go
+++ b/auth/orgs.go
@@ -12,6 +12,14 @@ var (
 	ErrOrgNotEmpty = errors.New("org is not empty")
 )
 
+// OrgOrderFields maps API-facing order keys to SQL column expressions for the orgs table.
+var OrgOrderFields = map[string]string{
+	"id":         "id",
+	"name":       "LOWER(name)",
+	"created_at": "created_at",
+	"updated_at": "updated_at",
+}
+
 // Domain type aliases
 type (
 	Org      = domain.Org

--- a/auth/postgres/invites.go
+++ b/auth/postgres/invites.go
@@ -307,7 +307,7 @@ func (ir invitesRepository) RetrieveOrgInvitesByOrg(ctx context.Context, orgID s
 	filterNonDormant := `invitee_id IS NOT NULL`
 
 	whereClause := dbutil.BuildWhereClause(filterOrgID, filterState, filterNonDormant)
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, auth.OrgInviteOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 
@@ -384,7 +384,7 @@ func (ir invitesRepository) RetrieveOrgInvitesByUser(ctx context.Context, userTy
 	filterNonDormant := `invitee_id IS NOT NULL`
 
 	whereClause := dbutil.BuildWhereClause(filterUserType, filterState, filterNonDormant)
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, auth.OrgInviteOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 

--- a/auth/postgres/key.go
+++ b/auth/postgres/key.go
@@ -72,7 +72,7 @@ func (kr repo) Remove(ctx context.Context, issuerID, id string) error {
 }
 
 func (kr repo) RetrieveAPIKeys(ctx context.Context, issuerID string, pm auth.PageMetadata) (auth.KeysPage, error) {
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, auth.KeyOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 

--- a/auth/postgres/orgs.go
+++ b/auth/postgres/orgs.go
@@ -155,7 +155,7 @@ func (or orgRepository) RetrieveByID(ctx context.Context, id string) (auth.Org, 
 }
 
 func (or orgRepository) RetrieveAll(ctx context.Context, pm auth.PageMetadata) (auth.OrgsPage, error) {
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, auth.OrgOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)
@@ -201,7 +201,7 @@ func (or orgRepository) BackupAll(ctx context.Context) ([]auth.Org, error) {
 }
 
 func (or orgRepository) RetrieveByMember(ctx context.Context, memberID string, pm auth.PageMetadata) (auth.OrgsPage, error) {
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, auth.OrgOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)

--- a/consumers/alarms/alarm.go
+++ b/consumers/alarms/alarm.go
@@ -31,6 +31,14 @@ type AlarmsPage struct {
 	Alarms []Alarm
 }
 
+// AlarmOrderFields maps API-facing order keys to SQL column expressions for the alarms table.
+var AlarmOrderFields = map[string]string{
+	"id":      "id",
+	"created": "created",
+	"level":   "level",
+	"status":  "status",
+}
+
 // AlarmRepository specifies an alarm persistence API.
 type AlarmRepository interface {
 	// Save persists multiple alarms. Alarms are saved using a transaction.

--- a/consumers/alarms/api/http/requests.go
+++ b/consumers/alarms/api/http/requests.go
@@ -14,17 +14,10 @@ const (
 	maxAlarmLevel = 5
 )
 
-var allowedOrders = map[string]string{
-	"id":      "id",
-	"created": "created",
-	"level":   "level",
-	"status":  "status",
-}
-
 // validatePageMetadata validates the alarms page metadata.
 func validatePageMetadata(pm alarms.PageMetadata) error {
 	common := apiutil.PageMetadata{Offset: pm.Offset, Limit: pm.Limit, Order: pm.Order, Dir: pm.Dir}
-	if err := common.Validate(maxLimitSize, allowedOrders); err != nil {
+	if err := common.Validate(maxLimitSize, alarms.AlarmOrderFields); err != nil {
 		return err
 	}
 

--- a/consumers/alarms/postgres/alarms.go
+++ b/consumers/alarms/postgres/alarms.go
@@ -106,7 +106,7 @@ func (ar *alarmRepository) RetrieveByThing(ctx context.Context, thingID string, 
 		return alarms.AlarmsPage{}, errors.Wrap(dbutil.ErrNotFound, err)
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, alarms.AlarmOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 
@@ -137,7 +137,7 @@ func (ar *alarmRepository) RetrieveByGroup(ctx context.Context, groupID string, 
 		return alarms.AlarmsPage{}, errors.Wrap(dbutil.ErrNotFound, err)
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, alarms.AlarmOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 
@@ -168,7 +168,7 @@ func (ar *alarmRepository) RetrieveByGroups(ctx context.Context, groupIDs []stri
 		return alarms.AlarmsPage{}, nil
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, alarms.AlarmOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 
@@ -233,7 +233,7 @@ func (ar *alarmRepository) ExportByThing(ctx context.Context, thingID string, pm
 		return alarms.AlarmsPage{}, errors.Wrap(dbutil.ErrNotFound, err)
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, alarms.AlarmOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	whereClause := dbutil.BuildWhereClause("thing_id = :thing_id")
 

--- a/consumers/notifiers/api/http/requests.go
+++ b/consumers/notifiers/api/http/requests.go
@@ -14,15 +14,10 @@ const (
 	maxNameSize  = 254
 )
 
-var allowedOrders = map[string]string{
-	"id":   "id",
-	"name": "name",
-}
-
 // validatePageMetadata validates the notifiers page metadata.
 func validatePageMetadata(pm notifiers.PageMetadata) error {
 	common := apiutil.PageMetadata{Offset: pm.Offset, Limit: pm.Limit, Order: pm.Order, Dir: pm.Dir}
-	if err := common.Validate(maxLimitSize, allowedOrders); err != nil {
+	if err := common.Validate(maxLimitSize, notifiers.NotifierOrderFields); err != nil {
 		return err
 	}
 

--- a/consumers/notifiers/notifier.go
+++ b/consumers/notifiers/notifier.go
@@ -21,6 +21,12 @@ type Notifier struct {
 	Metadata map[string]any
 }
 
+// NotifierOrderFields maps API-facing order keys to SQL column expressions for the notifiers table.
+var NotifierOrderFields = map[string]string{
+	"id":   "id",
+	"name": "LOWER(name)",
+}
+
 type NotifiersPage struct {
 	Total     uint64
 	Notifiers []Notifier

--- a/consumers/notifiers/postgres/notifiers.go
+++ b/consumers/notifiers/postgres/notifiers.go
@@ -71,7 +71,7 @@ func (nr notifierRepository) RetrieveByGroup(ctx context.Context, groupID string
 		return notifiers.NotifiersPage{}, errors.Wrap(dbutil.ErrNotFound, err)
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, notifiers.NotifierOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)

--- a/downlinks/api/http/requests.go
+++ b/downlinks/api/http/requests.go
@@ -29,15 +29,10 @@ var (
 	ErrInvalidFilterValue    = errors.New("invalid time filter value")
 )
 
-var allowedOrders = map[string]string{
-	"id":   "id",
-	"name": "name",
-}
-
 // validatePageMetadata validates the downlinks page metadata.
 func validatePageMetadata(pm downlinks.PageMetadata) error {
 	common := apiutil.PageMetadata{Offset: pm.Offset, Limit: pm.Limit, Order: pm.Order, Dir: pm.Dir}
-	if err := common.Validate(maxLimitSize, allowedOrders); err != nil {
+	if err := common.Validate(maxLimitSize, downlinks.DownlinkOrderFields); err != nil {
 		return err
 	}
 

--- a/downlinks/downlinks.go
+++ b/downlinks/downlinks.go
@@ -39,6 +39,12 @@ type DownlinksPage struct {
 	Downlinks []Downlink
 }
 
+// DownlinkOrderFields maps API-facing order keys to SQL column expressions for the downlinks table.
+var DownlinkOrderFields = map[string]string{
+	"id":   "id",
+	"name": "LOWER(name)",
+}
+
 type DownlinkRepository interface {
 	// Save persists multiple downlinks. Downlinks are saved using a transaction.
 	// If one downlink fails then none will be saved.

--- a/downlinks/postgres/downlinks.go
+++ b/downlinks/postgres/downlinks.go
@@ -75,7 +75,7 @@ func (dr downlinkRepository) RetrieveByThing(ctx context.Context, thingID string
 		return downlinks.DownlinksPage{}, errors.Wrap(dbutil.ErrNotFound, err)
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, downlinks.DownlinkOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	nq, name := dbutil.GetNameQuery(pm.Name)
 	urlq, url := dbutil.GetLikeQuery("url", pm.URL)
@@ -120,7 +120,7 @@ func (dr downlinkRepository) RetrieveByGroup(ctx context.Context, groupID string
 		return downlinks.DownlinksPage{}, errors.Wrap(dbutil.ErrNotFound, err)
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, downlinks.DownlinkOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	nq, name := dbutil.GetNameQuery(pm.Name)
 	urlq, url := dbutil.GetLikeQuery("url", pm.URL)

--- a/modbus/api/http/requests.go
+++ b/modbus/api/http/requests.go
@@ -29,15 +29,10 @@ var (
 	ErrInvalidByteOrder    = errors.New("invalid byte order")
 )
 
-var allowedOrders = map[string]string{
-	"id":   "id",
-	"name": "name",
-}
-
 // validatePageMetadata validates the modbus page metadata.
 func validatePageMetadata(pm modbus.PageMetadata) error {
 	common := apiutil.PageMetadata{Offset: pm.Offset, Limit: pm.Limit, Order: pm.Order, Dir: pm.Dir}
-	if err := common.Validate(maxLimitSize, allowedOrders); err != nil {
+	if err := common.Validate(maxLimitSize, modbus.ClientOrderFields); err != nil {
 		return err
 	}
 

--- a/modbus/clients.go
+++ b/modbus/clients.go
@@ -49,6 +49,12 @@ type ClientsPage struct {
 	Clients []Client
 }
 
+// ClientOrderFields maps API-facing order keys to SQL column expressions for the modbus clients table.
+var ClientOrderFields = map[string]string{
+	"id":   "id",
+	"name": "LOWER(name)",
+}
+
 type ClientRepository interface {
 	// Save persists multiple Modbus clients.
 	// Clients are saved using a transaction.

--- a/modbus/postgres/clients.go
+++ b/modbus/postgres/clients.go
@@ -110,7 +110,7 @@ func (cr clientRepository) RetrieveByThing(ctx context.Context, thingID string, 
 		return modbus.ClientsPage{}, errors.Wrap(dbutil.ErrNotFound, err)
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, modbus.ClientOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	nq, name := dbutil.GetNameQuery(pm.Name)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
@@ -160,7 +160,7 @@ func (cr clientRepository) RetrieveByGroup(ctx context.Context, groupID string, 
 		return modbus.ClientsPage{}, errors.Wrap(dbutil.ErrNotFound, err)
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, modbus.ClientOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	nq, name := dbutil.GetNameQuery(pm.Name)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)

--- a/pkg/dbutil/query.go
+++ b/pkg/dbutil/query.go
@@ -51,17 +51,15 @@ func GetPayloadQuery(m map[string]any) (mb []byte, mq string, err error) {
 	return mb, mq, nil
 }
 
-func GetOrderQuery(order string) string {
-	switch order {
-	case "name":
-		return "LOWER(name)"
-	case "email":
-		return "LOWER(email)"
-	case "":
-		return "id"
-	default:
-		return order
+// GetOrderQuery resolves order against fields, which maps API-facing order
+// keys to real SQL column expressions (with LOWER() baked in where needed).
+// Falls back to "id" for anything not in fields, so this is safe even if a
+// caller forgets to validate order upstream.
+func GetOrderQuery(order string, fields map[string]string) string {
+	if col, ok := fields[order]; ok {
+		return col
 	}
+	return "id"
 }
 
 func GetDirQuery(dir string) string {

--- a/pkg/dbutil/query_test.go
+++ b/pkg/dbutil/query_test.go
@@ -1,0 +1,238 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package dbutil_test
+
+import (
+	"testing"
+
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOrderQuery(t *testing.T) {
+	fields := map[string]string{
+		"id":         "id",
+		"name":       "LOWER(name)",
+		"created_at": "created_at",
+	}
+
+	cases := []struct {
+		desc     string
+		order    string
+		expected string
+	}{
+		{
+			desc:     "known field id",
+			order:    "id",
+			expected: "id",
+		},
+		{
+			desc:     "known field name with LOWER expression",
+			order:    "name",
+			expected: "LOWER(name)",
+		},
+		{
+			desc:     "known field created_at",
+			order:    "created_at",
+			expected: "created_at",
+		},
+		{
+			desc:     "empty order falls back to id",
+			order:    "",
+			expected: "id",
+		},
+		{
+			desc:     "unknown order field falls back to id",
+			order:    "unknown_field",
+			expected: "id",
+		},
+		{
+			desc:     "SQL injection attempt falls back to id",
+			order:    "id; DROP TABLE users;--",
+			expected: "id",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			res := dbutil.GetOrderQuery(tc.order, fields)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}
+
+func TestGetDirQuery(t *testing.T) {
+	cases := []struct {
+		desc     string
+		dir      string
+		expected string
+	}{
+		{
+			desc:     "ascending direction",
+			dir:      "asc",
+			expected: "ASC",
+		},
+		{
+			desc:     "descending direction",
+			dir:      "desc",
+			expected: "DESC",
+		},
+		{
+			desc:     "empty direction defaults to DESC",
+			dir:      "",
+			expected: "DESC",
+		},
+		{
+			desc:     "unknown direction defaults to DESC",
+			dir:      "invalid",
+			expected: "DESC",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			res := dbutil.GetDirQuery(tc.dir)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}
+
+func TestGetNameQuery(t *testing.T) {
+	cases := []struct {
+		desc         string
+		name         string
+		expectedQ    string
+		expectedName string
+	}{
+		{
+			desc:         "non-empty name",
+			name:         "test",
+			expectedQ:    "LOWER(name) LIKE :name",
+			expectedName: "%test%",
+		},
+		{
+			desc:         "name with uppercase",
+			name:         "Test",
+			expectedQ:    "LOWER(name) LIKE :name",
+			expectedName: "%test%",
+		},
+		{
+			desc:         "empty name returns empty strings",
+			name:         "",
+			expectedQ:    "",
+			expectedName: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			q, name := dbutil.GetNameQuery(tc.name)
+			assert.Equal(t, tc.expectedQ, q)
+			assert.Equal(t, tc.expectedName, name)
+		})
+	}
+}
+
+func TestGetOffsetLimitQuery(t *testing.T) {
+	cases := []struct {
+		desc     string
+		limit    uint64
+		expected string
+	}{
+		{
+			desc:     "non-zero limit",
+			limit:    10,
+			expected: "LIMIT :limit OFFSET :offset",
+		},
+		{
+			desc:     "zero limit returns empty string",
+			limit:    0,
+			expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			res := dbutil.GetOffsetLimitQuery(tc.limit)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}
+
+func TestGetGroupIDsQuery(t *testing.T) {
+	cases := []struct {
+		desc     string
+		ids      []string
+		expected string
+	}{
+		{
+			desc:     "single ID",
+			ids:      []string{"id1"},
+			expected: "group_id IN ('id1') ",
+		},
+		{
+			desc:     "multiple IDs",
+			ids:      []string{"id1", "id2", "id3"},
+			expected: "group_id IN ('id1','id2','id3') ",
+		},
+		{
+			desc:     "empty slice returns empty string",
+			ids:      []string{},
+			expected: "",
+		},
+		{
+			desc:     "nil slice returns empty string",
+			ids:      nil,
+			expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			res := dbutil.GetGroupIDsQuery(tc.ids)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}
+
+func TestBuildWhereClause(t *testing.T) {
+	cases := []struct {
+		desc     string
+		filters  []string
+		expected string
+	}{
+		{
+			desc:     "single filter",
+			filters:  []string{"name = 'test'"},
+			expected: " WHERE name = 'test'",
+		},
+		{
+			desc:     "multiple filters joined with AND",
+			filters:  []string{"name = 'test'", "status = 'active'"},
+			expected: " WHERE name = 'test' AND status = 'active'",
+		},
+		{
+			desc:     "empty strings are excluded",
+			filters:  []string{"", "name = 'test'", ""},
+			expected: " WHERE name = 'test'",
+		},
+		{
+			desc:     "all empty filters returns empty string",
+			filters:  []string{"", ""},
+			expected: "",
+		},
+		{
+			desc:     "no filters returns empty string",
+			filters:  []string{},
+			expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			res := dbutil.BuildWhereClause(tc.filters...)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}

--- a/pkg/domain/users.go
+++ b/pkg/domain/users.go
@@ -29,6 +29,12 @@ type User struct {
 	Role     string   `json:"role,omitempty"`
 }
 
+// UserOrderFields maps API-facing order keys to SQL column expressions for the users table.
+var UserOrderFields = map[string]string{
+	"id":    "id",
+	"email": "LOWER(email)",
+}
+
 // Validate returns an error if user representation is invalid.
 func (u User) Validate(passRegex *regexp.Regexp) error {
 	if !email.IsEmail(u.Email) {

--- a/rules/api/validation.go
+++ b/rules/api/validation.go
@@ -8,16 +8,10 @@ import (
 	"github.com/MainfluxLabs/mainflux/rules"
 )
 
-var allowedOrders = map[string]string{
-	"id":      "id",
-	"name":    "name",
-	"rule_id": "rule_id",
-}
-
 // ValidatePageMetadata validates the rules page metadata.
 func ValidatePageMetadata(pm rules.PageMetadata, maxLimitSize, maxNameSize int) error {
 	common := apiutil.PageMetadata{Offset: pm.Offset, Limit: pm.Limit, Order: pm.Order, Dir: pm.Dir}
-	if err := common.Validate(maxLimitSize, allowedOrders); err != nil {
+	if err := common.Validate(maxLimitSize, rules.RuleOrderFields); err != nil {
 		return err
 	}
 

--- a/rules/postgres/rules.go
+++ b/rules/postgres/rules.go
@@ -78,7 +78,7 @@ func (rr ruleRepository) RetrieveByGroup(ctx context.Context, groupID string, pm
 	}
 
 	gq := "group_id = :group_id"
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, rules.RuleOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)
@@ -110,7 +110,7 @@ func (rr ruleRepository) RetrieveByThing(ctx context.Context, thingID string, pm
 		return rules.RulesPage{}, errors.Wrap(dbutil.ErrNotFound, err)
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, rules.RuleOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)

--- a/rules/postgres/scripts.go
+++ b/rules/postgres/scripts.go
@@ -78,7 +78,7 @@ func (rr ruleRepository) RetrieveScriptByID(ctx context.Context, id string) (rul
 }
 
 func (rr ruleRepository) RetrieveScriptsByThing(ctx context.Context, thingID string, pm rules.PageMetadata) (rules.LuaScriptsPage, error) {
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, rules.RuleOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 
@@ -143,7 +143,7 @@ func (rr ruleRepository) RetrieveScriptsByThing(ctx context.Context, thingID str
 }
 
 func (rr ruleRepository) RetrieveScriptsByGroup(ctx context.Context, groupID string, pm rules.PageMetadata) (rules.LuaScriptsPage, error) {
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, rules.RuleOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 
@@ -441,7 +441,7 @@ func (rr ruleRepository) RemoveScriptRuns(ctx context.Context, ids ...string) er
 }
 
 func (rr ruleRepository) RetrieveScriptRunsByThing(ctx context.Context, thingID string, pm rules.PageMetadata) (rules.ScriptRunsPage, error) {
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, rules.RuleOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -245,3 +245,9 @@ func findParam(payload map[string]any, param string) any {
 	}
 	return val
 }
+
+// RuleOrderFields maps API-facing order keys to SQL column expressions for the rules table.
+var RuleOrderFields = map[string]string{
+	"id":   "id",
+	"name": "LOWER(name)",
+}

--- a/things/api/http/groups/requests.go
+++ b/things/api/http/groups/requests.go
@@ -110,7 +110,7 @@ func (req *listReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, things.GroupOrderFields)
 }
 
 type listByOrgReq struct {
@@ -128,7 +128,7 @@ func (req listByOrgReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, things.GroupOrderFields)
 }
 
 type updateGroupReq struct {

--- a/things/api/http/memberships/requests.go
+++ b/things/api/http/memberships/requests.go
@@ -5,6 +5,7 @@ package memberships
 
 import (
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/things"
 	"github.com/MainfluxLabs/mainflux/things/api"
 )
@@ -29,7 +30,7 @@ func (req listGroupMembershipsReq) validate() error {
 		return apiutil.ErrMissingGroupID
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, domain.UserOrderFields)
 }
 
 type createGroupMembershipsReq struct {

--- a/things/api/http/profiles/requests.go
+++ b/things/api/http/profiles/requests.go
@@ -124,7 +124,7 @@ func (req *listReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, things.ProfileOrderFields)
 }
 
 type listByGroupReq struct {
@@ -142,7 +142,7 @@ func (req listByGroupReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, things.ProfileOrderFields)
 }
 
 type listByOrgReq struct {
@@ -160,7 +160,7 @@ func (req listByOrgReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, things.ProfileOrderFields)
 }
 
 type removeProfilesReq struct {

--- a/things/api/http/things/requests.go
+++ b/things/api/http/things/requests.go
@@ -193,7 +193,7 @@ func (req *listReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, things.ThingOrderFields)
 }
 
 type listByProfileReq struct {
@@ -211,7 +211,7 @@ func (req listByProfileReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, things.ThingOrderFields)
 }
 
 type listByGroupReq struct {
@@ -229,7 +229,7 @@ func (req listByGroupReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, things.ThingOrderFields)
 }
 
 type listByOrgReq struct {
@@ -247,7 +247,7 @@ func (req listByOrgReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize)
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize, maxNameSize, things.ThingOrderFields)
 }
 
 type removeThingsReq struct {

--- a/things/api/validation.go
+++ b/things/api/validation.go
@@ -8,17 +8,8 @@ import (
 	"github.com/MainfluxLabs/mainflux/things"
 )
 
-var allowedOrders = map[string]string{
-	"id":         "id",
-	"name":       "name",
-	"email":      "email",
-	"created_at": "created_at",
-	"updated_at": "updated_at",
-	"type":       "type",
-}
-
-// ValidatePageMetadata validates the things page metadata.
-func ValidatePageMetadata(pm things.PageMetadata, maxLimitSize, maxNameSize int) error {
+// ValidatePageMetadata validates the things page metadata against the specified allowed orders map.
+func ValidatePageMetadata(pm things.PageMetadata, maxLimitSize, maxNameSize int, allowedOrders map[string]string) error {
 	common := apiutil.PageMetadata{Offset: pm.Offset, Limit: pm.Limit, Order: pm.Order, Dir: pm.Dir}
 	if err := common.Validate(maxLimitSize, allowedOrders); err != nil {
 		return err

--- a/things/groups.go
+++ b/things/groups.go
@@ -12,6 +12,14 @@ type (
 	GroupPage = domain.GroupPage
 )
 
+// GroupOrderFields maps API-facing order keys to SQL column expressions for the groups table.
+var GroupOrderFields = map[string]string{
+	"id":         "id",
+	"name":       "LOWER(name)",
+	"created_at": "created_at",
+	"updated_at": "updated_at",
+}
+
 // GroupRepository specifies a group persistence API.
 type GroupRepository interface {
 	// Save persists groups.

--- a/things/postgres/groups.go
+++ b/things/postgres/groups.go
@@ -219,7 +219,7 @@ func (gr groupRepository) RetrieveByIDs(ctx context.Context, groupIDs []string, 
 		return things.GroupPage{}, nil
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, things.GroupOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	iq := getIDsQuery(groupIDs)
@@ -243,7 +243,7 @@ func (gr groupRepository) RetrieveByIDs(ctx context.Context, groupIDs []string, 
 }
 
 func (gr groupRepository) RetrieveAll(ctx context.Context, pm things.PageMetadata) (things.GroupPage, error) {
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, things.GroupOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)

--- a/things/postgres/profiles.go
+++ b/things/postgres/profiles.go
@@ -144,7 +144,7 @@ func (pr profileRepository) BackupAll(ctx context.Context) ([]things.Profile, er
 }
 
 func (pr profileRepository) RetrieveAll(ctx context.Context, pm things.PageMetadata) (things.ProfilesPage, error) {
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, things.ProfileOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)
@@ -235,7 +235,7 @@ func (pr profileRepository) RetrieveByGroups(ctx context.Context, groupIDs []str
 		return things.ProfilesPage{}, nil
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, things.ProfileOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	giq := dbutil.GetGroupIDsQuery(groupIDs)

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -128,7 +128,7 @@ func (tr thingRepository) RetrieveByGroups(ctx context.Context, groupIDs []strin
 		return things.ThingsPage{}, nil
 	}
 
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, things.ThingOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	giq := dbutil.GetGroupIDsQuery(groupIDs)
@@ -177,7 +177,7 @@ func (tr thingRepository) BackupAll(ctx context.Context) ([]things.Thing, error)
 }
 
 func (tr thingRepository) RetrieveAll(ctx context.Context, pm things.PageMetadata) (things.ThingsPage, error) {
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, things.ThingOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)
@@ -203,7 +203,7 @@ func (tr thingRepository) RetrieveAll(ctx context.Context, pm things.PageMetadat
 }
 
 func (tr thingRepository) RetrieveByProfile(ctx context.Context, prID string, pm things.PageMetadata) (things.ThingsPage, error) {
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, things.ThingOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 

--- a/things/profiles.go
+++ b/things/profiles.go
@@ -18,6 +18,12 @@ type (
 	Transformer = domain.Transformer
 )
 
+// ProfileOrderFields maps API-facing order keys to SQL column expressions for the profiles table.
+var ProfileOrderFields = map[string]string{
+	"id":   "id",
+	"name": "LOWER(name)",
+}
+
 // ProfileRepository specifies a profile persistence API.
 type ProfileRepository interface {
 	// Save persists multiple profiles. Profiles are saved using a transaction. If one profile

--- a/things/things.go
+++ b/things/things.go
@@ -19,6 +19,13 @@ type (
 	ThingKey = domain.ThingKey
 )
 
+// ThingOrderFields maps API-facing order keys to SQL column expressions for the things table.
+var ThingOrderFields = map[string]string{
+	"id":   "id",
+	"name": "LOWER(name)",
+	"type": "type",
+}
+
 const (
 	KeyTypeInternal = domain.KeyTypeInternal
 	KeyTypeExternal = domain.KeyTypeExternal

--- a/users/api/http/invites/requests.go
+++ b/users/api/http/invites/requests.go
@@ -111,5 +111,5 @@ func (req listPlatformInvitesRequest) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	return api.ValidatePageMetadata(req.pm, maxLimitSize, maxEmailSize)
+	return api.ValidatePageMetadata(req.pm, maxLimitSize, maxEmailSize, users.PlatformInviteOrderFields)
 }

--- a/users/api/http/users/requests.go
+++ b/users/api/http/users/requests.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/users"
 	"github.com/MainfluxLabs/mainflux/users/api"
@@ -126,7 +127,7 @@ func (req listUsersReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	if err := api.ValidatePageMetadata(req.pm, maxLimitSize, maxEmailSize); err != nil {
+	if err := api.ValidatePageMetadata(req.pm, maxLimitSize, maxEmailSize, domain.UserOrderFields); err != nil {
 		return err
 	}
 

--- a/users/api/validation.go
+++ b/users/api/validation.go
@@ -5,8 +5,8 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 )
 
-// Validate validates the page metadata.
-func ValidatePageMetadata(pm domain.UsersPageMetadata, maxLimitSize, maxEmailSize int) error {
+// ValidatePageMetadata validates the page metadata against the specified allowed orders map.
+func ValidatePageMetadata(pm domain.UsersPageMetadata, maxLimitSize, maxEmailSize int, allowedOrders map[string]string) error {
 	if len(pm.Email) > maxEmailSize {
 		return apiutil.ErrEmailSize
 	}
@@ -21,12 +21,4 @@ func ValidatePageMetadata(pm domain.UsersPageMetadata, maxLimitSize, maxEmailSiz
 
 	common := apiutil.PageMetadata{Offset: pm.Offset, Limit: pm.Limit, Order: pm.Order, Dir: pm.Dir}
 	return common.Validate(maxLimitSize, allowedOrders)
-}
-
-var allowedOrders = map[string]string{
-	"id":            "id",
-	"email":         "email",
-	"invitee_email": "invitee_email",
-	"state":         "state",
-	"created_at":    "created_at",
 }

--- a/users/invites.go
+++ b/users/invites.go
@@ -18,6 +18,14 @@ type (
 	PlatformInvitesPage = domain.PlatformInvitesPage
 )
 
+// PlatformInviteOrderFields maps API-facing order keys to SQL column expressions for the platform_invites table.
+var PlatformInviteOrderFields = map[string]string{
+	"id":            "id",
+	"invitee_email": "LOWER(invitee_email)",
+	"state":         "state",
+	"created_at":    "created_at",
+}
+
 const (
 	UserTypeInvitee = "invitee"
 	UserTypeInviter = "inviter"

--- a/users/postgres/invites.go
+++ b/users/postgres/invites.go
@@ -114,7 +114,7 @@ func (ir invitesRepository) RetrievePlatformInvites(ctx context.Context, pm user
 	}
 
 	whereClause := dbutil.BuildWhereClause(filterState)
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, users.PlatformInviteOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 

--- a/users/postgres/users.go
+++ b/users/postgres/users.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/users"
 	"github.com/jackc/pgerrcode"
@@ -144,7 +145,7 @@ func (ur userRepository) RetrieveByIDs(ctx context.Context, userIDs []string, pm
 	}
 
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, domain.UserOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 
 	mp, mq, err := dbutil.GetMetadataQuery(pm.Metadata)

--- a/webhooks/api/http/requests.go
+++ b/webhooks/api/http/requests.go
@@ -22,15 +22,10 @@ var (
 	ErrMissingWebhookID = errors.New("missing webhook id")
 )
 
-var allowedOrders = map[string]string{
-	"id":   "id",
-	"name": "name",
-}
-
 // validatePageMetadata validates the webhooks page metadata.
 func validatePageMetadata(pm webhooks.PageMetadata) error {
 	common := apiutil.PageMetadata{Offset: pm.Offset, Limit: pm.Limit, Order: pm.Order, Dir: pm.Dir}
-	if err := common.Validate(maxLimitSize, allowedOrders); err != nil {
+	if err := common.Validate(maxLimitSize, webhooks.WebhookOrderFields); err != nil {
 		return err
 	}
 

--- a/webhooks/postgres/webhooks.go
+++ b/webhooks/postgres/webhooks.go
@@ -72,7 +72,7 @@ func (wr webhookRepository) RetrieveByGroup(ctx context.Context, groupID string,
 	}
 
 	gq := "group_id = :group_id"
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, webhooks.WebhookOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)
@@ -104,7 +104,7 @@ func (wr webhookRepository) RetrieveByThing(ctx context.Context, thingID string,
 	}
 
 	tq := "thing_id = :thing_id"
-	oq := dbutil.GetOrderQuery(pm.Order)
+	oq := dbutil.GetOrderQuery(pm.Order, webhooks.WebhookOrderFields)
 	dq := dbutil.GetDirQuery(pm.Dir)
 	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
 	nq, name := dbutil.GetNameQuery(pm.Name)

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -19,6 +19,12 @@ type WebhooksPage struct {
 	Webhooks []Webhook
 }
 
+// WebhookOrderFields maps API-facing order keys to SQL column expressions for the webhooks table.
+var WebhookOrderFields = map[string]string{
+	"id":   "id",
+	"name": "LOWER(name)",
+}
+
 type WebhookRepository interface {
 	// Save persists multiple webhooks. Webhooks are saved using a transaction.
 	// If one webhook fails then none will be saved.


### PR DESCRIPTION
### What does this do?
- **Dropped `dbutil.GetOrderQuery`**: Removed redundant `GetOrderQuery` helper from `pkg/dbutil/query.go`. Handled `LOWER()` case-insensitive ordering (`name`, `email`) per-service inside repository packages where needed.
- **Reverted `IN` Clause Escaping**: Reverted single-quote escaping in `GetGroupIDsQuery` and `getIDsQuery` to preserve clean string joining without defensive DB-layer escaping.
- **Unit Tests**: Added `pkg/dbutil/query_test.go` with unit tests covering `GetGroupIDsQuery`, `GetDirQuery`, `GetNameQuery`, `GetOffsetLimitQuery`, and `BuildWhereClause`.

### Which issue(s) does this PR fix/relate to?
Resolves #1282

### List any changes that modify/break current functionality
None. All valid sorting options continue to work normally.

### Have you included tests for your changes?
Yes, added unit tests in `pkg/dbutil/query_test.go`.

### Did you document any new/modified functionality?
N/A

### Notes
None.