### PR TITLE
MF-1287 - rename email named parameter to actor_email in audit postgres

### DIFF
--- a/audit/postgres/events.go
+++ b/audit/postgres/events.go
@@ -52,7 +52,7 @@ func (r *eventRepository) SaveEvent(ctx context.Context, e audit.Event) error {
 }
 
 func (r *eventRepository) RetrieveEvents(ctx context.Context, pm audit.PageMetadata) (audit.EventsPage, error) {
-	emailQ, emailVal := emailQuery(pm.Email)
+	actorEmailQ, actorEmailVal := actorEmailQuery(pm.Email)
 	opQ, opVal := operationQuery(pm.Operation)
 	fromQ, fromVal := occurredFromQuery(pm.From)
 	toQ, toVal := occurredToQuery(pm.To)
@@ -62,7 +62,7 @@ func (r *eventRepository) RetrieveEvents(ctx context.Context, pm audit.PageMetad
 		return audit.EventsPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
-	whereClause := dbutil.BuildWhereClause(emailQ, opQ, fromQ, toQ, dataQ)
+	whereClause := dbutil.BuildWhereClause(actorEmailQ, opQ, fromQ, toQ, dataQ)
 	query := fmt.Sprintf(
 		`SELECT id, occurred_at, operation, actor_id, actor_email, org_id, group_id, action_data FROM events %s ORDER BY %s %s %s`,
 		whereClause, dbutil.GetOrderQuery(pm.Order), dbutil.GetDirQuery(pm.Dir), dbutil.GetOffsetLimitQuery(pm.Limit),
@@ -70,7 +70,7 @@ func (r *eventRepository) RetrieveEvents(ctx context.Context, pm audit.PageMetad
 	cquery := fmt.Sprintf(`SELECT COUNT(*) FROM events %s`, whereClause)
 
 	params := map[string]any{
-		"email":       emailVal,
+		"actor_email": actorEmailVal,
 		"operation":   opVal,
 		"from":        fromVal,
 		"to":          toVal,
@@ -83,7 +83,7 @@ func (r *eventRepository) RetrieveEvents(ctx context.Context, pm audit.PageMetad
 }
 
 func (r *eventRepository) RetrieveEventsByOrg(ctx context.Context, orgID string, pm audit.PageMetadata) (audit.EventsPage, error) {
-	emailQ, emailVal := emailQuery(pm.Email)
+	actorEmailQ, actorEmailVal := actorEmailQuery(pm.Email)
 	opQ, opVal := operationQuery(pm.Operation)
 	orgQ, orgVal := orgQuery(orgID)
 	fromQ, fromVal := occurredFromQuery(pm.From)
@@ -94,7 +94,7 @@ func (r *eventRepository) RetrieveEventsByOrg(ctx context.Context, orgID string,
 		return audit.EventsPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
-	whereClause := dbutil.BuildWhereClause(emailQ, opQ, orgQ, fromQ, toQ, dataQ)
+	whereClause := dbutil.BuildWhereClause(actorEmailQ, opQ, orgQ, fromQ, toQ, dataQ)
 	query := fmt.Sprintf(
 		`SELECT id, occurred_at, operation, actor_id, actor_email, org_id, group_id, action_data FROM events %s ORDER BY %s %s %s`,
 		whereClause, dbutil.GetOrderQuery(pm.Order), dbutil.GetDirQuery(pm.Dir), dbutil.GetOffsetLimitQuery(pm.Limit),
@@ -102,7 +102,7 @@ func (r *eventRepository) RetrieveEventsByOrg(ctx context.Context, orgID string,
 	cquery := fmt.Sprintf(`SELECT COUNT(*) FROM events %s`, whereClause)
 
 	params := map[string]any{
-		"email":       emailVal,
+		"actor_email": actorEmailVal,
 		"operation":   opVal,
 		"org_id":      orgVal,
 		"from":        fromVal,
@@ -116,7 +116,7 @@ func (r *eventRepository) RetrieveEventsByOrg(ctx context.Context, orgID string,
 }
 
 func (r *eventRepository) RetrieveEventsByGroup(ctx context.Context, groupID string, pm audit.PageMetadata) (audit.EventsPage, error) {
-	emailQ, emailVal := emailQuery(pm.Email)
+	actorEmailQ, actorEmailVal := actorEmailQuery(pm.Email)
 	opQ, opVal := operationQuery(pm.Operation)
 	groupQ, groupVal := groupQuery(groupID)
 	fromQ, fromVal := occurredFromQuery(pm.From)
@@ -127,7 +127,7 @@ func (r *eventRepository) RetrieveEventsByGroup(ctx context.Context, groupID str
 		return audit.EventsPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
 	}
 
-	whereClause := dbutil.BuildWhereClause(emailQ, opQ, groupQ, fromQ, toQ, dataQ)
+	whereClause := dbutil.BuildWhereClause(actorEmailQ, opQ, groupQ, fromQ, toQ, dataQ)
 	query := fmt.Sprintf(
 		`SELECT id, occurred_at, operation, actor_id, actor_email, org_id, group_id, action_data FROM events %s ORDER BY %s %s %s`,
 		whereClause, dbutil.GetOrderQuery(pm.Order), dbutil.GetDirQuery(pm.Dir), dbutil.GetOffsetLimitQuery(pm.Limit),
@@ -135,7 +135,7 @@ func (r *eventRepository) RetrieveEventsByGroup(ctx context.Context, groupID str
 	cquery := fmt.Sprintf(`SELECT COUNT(*) FROM events %s`, whereClause)
 
 	params := map[string]any{
-		"email":       emailVal,
+		"actor_email": actorEmailVal,
 		"operation":   opVal,
 		"group_id":    groupVal,
 		"from":        fromVal,
@@ -179,11 +179,11 @@ func (r *eventRepository) retrieve(ctx context.Context, query, cquery string, pa
 	}, nil
 }
 
-func emailQuery(email string) (string, string) {
+func actorEmailQuery(email string) (string, string) {
 	if email == "" {
 		return "", ""
 	}
-	return "actor_email = :email", email
+	return "actor_email = :actor_email", email
 }
 
 func operationQuery(op string) (string, string) {


### PR DESCRIPTION
### What does this do?
Renames the `:email` named parameter placeholder to `:actor_email` in audit postgres query builders, and updates the corresponding `params` map keys from `"email"` to `"actor_email"` for consistency with sibling helpers (`:org_id`, `:group_id`, `:operation`).

### Which issue(s) does this PR fix/relate to?
Resolves #1287

### List any changes that modify/break current functionality
None.

### Have you included tests for your changes?
N/A , the audit package has no integration tests. The change is a parameter rename that does not alter query behavior.

### Did you document any new/modified functionality?
N/A

### Notes
None.