### PR TITLE
MF-1290 - use transaction tx instead of db in groupMembershipsReposit…

### DIFF
--- a/things/postgres/memberships.go
+++ b/things/postgres/memberships.go
@@ -36,7 +36,7 @@ func (mr groupMembershipsRepository) Save(ctx context.Context, gms ...things.Gro
 
 	for _, g := range gms {
 		dbgm := toDBGroupMembership(g)
-		if _, err := mr.db.NamedExecContext(ctx, q, dbgm); err != nil {
+		if _, err := tx.NamedExecContext(ctx, q, dbgm); err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {
 				switch pgErr.Code {


### PR DESCRIPTION
### What does this do?
Fixes transaction bypass in `groupMembershipsRepository.Save` where `mr.db.NamedExecContext` was mistakenly used inside the batch loop instead of `tx.NamedExecContext`.

### Which issue(s) does this PR fix/relate to?
Resolves #1290

### List any changes that modify/break current functionality
None.

### Have you included tests for your changes?
N/A

### Did you document any new/modified functionality?
N/A

### Notes
None.