### PR TITLE
MF-1293 - Dedupe JSON messages by payload hash

### DIFF
--- a/consumers/writers/postgres/consumer.go
+++ b/consumers/writers/postgres/consumer.go
@@ -5,7 +5,6 @@ package postgres
 
 import (
 	"context"
-	"hash/fnv"
 
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
@@ -99,14 +98,6 @@ type jsonRow struct {
 	PayloadHash int32 `db:"payload_hash"`
 }
 
-// jsonPayloadHash hashes the payload, letting the unique index dedupe exact
-// repeats while still storing distinct content at the same timestamp.
-func jsonPayloadHash(msg mfjson.Message) int32 {
-	h := fnv.New32a()
-	h.Write(msg.Payload)
-	return int32(h.Sum32())
-}
-
 func (pr postgresRepo) saveJSON(msgs []protomfx.Message) error {
 	q := `INSERT INTO json (created, subtopic, publisher, protocol, payload, payload_hash)
           VALUES (:created, :subtopic, :publisher, :protocol, :payload, :payload_hash)
@@ -132,7 +123,7 @@ func (pr postgresRepo) saveJSON(msgs []protomfx.Message) error {
 	for _, msg := range msgs {
 		dbmsg := messaging.ToJSONMessage(msg)
 
-		row := jsonRow{Message: dbmsg, PayloadHash: jsonPayloadHash(dbmsg)}
+		row := jsonRow{Message: dbmsg, PayloadHash: messaging.PayloadHash(dbmsg.Payload)}
 		if _, err := tx.NamedExec(q, row); err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {

--- a/consumers/writers/postgres/consumer.go
+++ b/consumers/writers/postgres/consumer.go
@@ -5,11 +5,13 @@ package postgres
 
 import (
 	"context"
+	"hash/fnv"
 
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
+	mfjson "github.com/MainfluxLabs/mainflux/pkg/transformers/json"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jmoiron/sqlx" // required for DB access
@@ -92,9 +94,23 @@ func (pr postgresRepo) saveSenML(msgs []protomfx.Message) (err error) {
 	return err
 }
 
+type jsonRow struct {
+	mfjson.Message
+	PayloadHash int32 `db:"payload_hash"`
+}
+
+// jsonPayloadHash hashes the payload, letting the unique index dedupe exact
+// repeats while still storing distinct content at the same timestamp.
+func jsonPayloadHash(msg mfjson.Message) int32 {
+	h := fnv.New32a()
+	h.Write(msg.Payload)
+	return int32(h.Sum32())
+}
+
 func (pr postgresRepo) saveJSON(msgs []protomfx.Message) error {
-	q := `INSERT INTO json (created, subtopic, publisher, protocol, payload)
-          VALUES (:created, :subtopic, :publisher, :protocol, :payload);`
+	q := `INSERT INTO json (created, subtopic, publisher, protocol, payload, payload_hash)
+          VALUES (:created, :subtopic, :publisher, :protocol, :payload, :payload_hash)
+          ON CONFLICT (created, publisher, subtopic, payload_hash) DO NOTHING;`
 
 	tx, err := pr.db.BeginTxx(context.Background(), nil)
 	if err != nil {
@@ -116,7 +132,8 @@ func (pr postgresRepo) saveJSON(msgs []protomfx.Message) error {
 	for _, msg := range msgs {
 		dbmsg := messaging.ToJSONMessage(msg)
 
-		if _, err := tx.NamedExec(q, dbmsg); err != nil {
+		row := jsonRow{Message: dbmsg, PayloadHash: jsonPayloadHash(dbmsg)}
+		if _, err := tx.NamedExec(q, row); err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {
 				switch pgErr.Code {

--- a/consumers/writers/postgres/init.go
+++ b/consumers/writers/postgres/init.go
@@ -115,6 +115,17 @@ func migrateDB(db *sqlx.DB) error {
 					"DROP INDEX IF EXISTS idx_senml_publisher_time",
 				},
 			},
+			{
+				Id: "messages_7",
+				Up: []string{
+					`ALTER TABLE json ADD COLUMN IF NOT EXISTS payload_hash INTEGER`,
+					`CREATE UNIQUE INDEX IF NOT EXISTS idx_json_dedup ON json(created, publisher, subtopic, payload_hash)`,
+				},
+				Down: []string{
+					"DROP INDEX IF EXISTS idx_json_dedup",
+					"ALTER TABLE json DROP COLUMN IF EXISTS payload_hash",
+				},
+			},
 		},
 	}
 

--- a/consumers/writers/timescale/consumer.go
+++ b/consumers/writers/timescale/consumer.go
@@ -133,7 +133,6 @@ func (tr timescaleRepo) saveJSON(msgs []protomfx.Message) error {
 		dbmsg := messaging.ToJSONMessage(msg)
 
 		row := jsonRow{Message: dbmsg, PayloadHash: jsonPayloadHash(dbmsg)}
-
 		if _, err := tx.NamedExec(q, row); err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {

--- a/consumers/writers/timescale/consumer.go
+++ b/consumers/writers/timescale/consumer.go
@@ -5,11 +5,13 @@ package timescale
 
 import (
 	"context"
+	"hash/fnv"
 
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
+	mfjson "github.com/MainfluxLabs/mainflux/pkg/transformers/json"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jmoiron/sqlx" // required for DB access
@@ -92,9 +94,23 @@ func (tr timescaleRepo) saveSenML(msgs []protomfx.Message) (err error) {
 	return err
 }
 
+type jsonRow struct {
+	mfjson.Message
+	PayloadHash int32 `db:"payload_hash"`
+}
+
+// jsonPayloadHash hashes the payload, letting the unique index dedupe exact
+// repeats while still storing distinct content at the same timestamp.
+func jsonPayloadHash(msg mfjson.Message) int32 {
+	h := fnv.New32a()
+	h.Write(msg.Payload)
+	return int32(h.Sum32())
+}
+
 func (tr timescaleRepo) saveJSON(msgs []protomfx.Message) error {
-	q := `INSERT INTO json (created, subtopic, publisher, protocol, payload)
-          VALUES (:created, :subtopic, :publisher, :protocol, :payload);`
+	q := `INSERT INTO json (created, subtopic, publisher, protocol, payload, payload_hash)
+          VALUES (:created, :subtopic, :publisher, :protocol, :payload, :payload_hash)
+          ON CONFLICT (created, publisher, subtopic, payload_hash) DO NOTHING;`
 
 	tx, err := tr.db.BeginTxx(context.Background(), nil)
 	if err != nil {
@@ -116,7 +132,9 @@ func (tr timescaleRepo) saveJSON(msgs []protomfx.Message) error {
 	for _, msg := range msgs {
 		dbmsg := messaging.ToJSONMessage(msg)
 
-		if _, err := tx.NamedExec(q, dbmsg); err != nil {
+		row := jsonRow{Message: dbmsg, PayloadHash: jsonPayloadHash(dbmsg)}
+
+		if _, err := tx.NamedExec(q, row); err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {
 				switch pgErr.Code {

--- a/consumers/writers/timescale/consumer.go
+++ b/consumers/writers/timescale/consumer.go
@@ -5,7 +5,6 @@ package timescale
 
 import (
 	"context"
-	"hash/fnv"
 
 	"github.com/MainfluxLabs/mainflux/consumers"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
@@ -99,14 +98,6 @@ type jsonRow struct {
 	PayloadHash int32 `db:"payload_hash"`
 }
 
-// jsonPayloadHash hashes the payload, letting the unique index dedupe exact
-// repeats while still storing distinct content at the same timestamp.
-func jsonPayloadHash(msg mfjson.Message) int32 {
-	h := fnv.New32a()
-	h.Write(msg.Payload)
-	return int32(h.Sum32())
-}
-
 func (tr timescaleRepo) saveJSON(msgs []protomfx.Message) error {
 	q := `INSERT INTO json (created, subtopic, publisher, protocol, payload, payload_hash)
           VALUES (:created, :subtopic, :publisher, :protocol, :payload, :payload_hash)
@@ -132,7 +123,7 @@ func (tr timescaleRepo) saveJSON(msgs []protomfx.Message) error {
 	for _, msg := range msgs {
 		dbmsg := messaging.ToJSONMessage(msg)
 
-		row := jsonRow{Message: dbmsg, PayloadHash: jsonPayloadHash(dbmsg)}
+		row := jsonRow{Message: dbmsg, PayloadHash: messaging.PayloadHash(dbmsg.Payload)}
 		if _, err := tx.NamedExec(q, row); err != nil {
 			pgErr, ok := err.(*pgconn.PgError)
 			if ok {

--- a/consumers/writers/timescale/init.go
+++ b/consumers/writers/timescale/init.go
@@ -82,6 +82,18 @@ func migrateDB(db *sqlx.DB) error {
 					"DROP TABLE json",
 				},
 			},
+			{
+				Id: "messages_2",
+				Up: []string{
+					`ALTER TABLE json DROP CONSTRAINT IF EXISTS json_pkey`,
+					`ALTER TABLE json ADD COLUMN IF NOT EXISTS payload_hash INTEGER`,
+					`CREATE UNIQUE INDEX IF NOT EXISTS idx_json_dedup ON json(created, publisher, subtopic, payload_hash)`,
+				},
+				Down: []string{
+					"DROP INDEX IF EXISTS idx_json_dedup",
+					"ALTER TABLE json DROP COLUMN IF EXISTS payload_hash",
+				},
+			},
 		},
 	}
 

--- a/pkg/messaging/mapper.go
+++ b/pkg/messaging/mapper.go
@@ -37,8 +37,6 @@ func FormatMessage(pc domain.PubConfigInfo, msg *protomfx.Message) error {
 	return nil
 }
 
-// PayloadHash hashes a message payload, letting writers dedupe an exact
-// repeat while still storing distinct content at the same key.
 func PayloadHash(payload []byte) int32 {
 	h := fnv.New32a()
 	h.Write(payload)

--- a/pkg/messaging/mapper.go
+++ b/pkg/messaging/mapper.go
@@ -5,6 +5,7 @@ package messaging
 
 import (
 	"encoding/json"
+	"hash/fnv"
 	"time"
 
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
@@ -34,6 +35,14 @@ func FormatMessage(pc domain.PubConfigInfo, msg *protomfx.Message) error {
 	}
 
 	return nil
+}
+
+// PayloadHash hashes a message payload, letting writers dedupe an exact
+// repeat while still storing distinct content at the same key.
+func PayloadHash(payload []byte) int32 {
+	h := fnv.New32a()
+	h.Write(payload)
+	return int32(h.Sum32())
 }
 
 func ToJSONMessage(message protomfx.Message) mfjson.Message {

--- a/readers/postgres/init.go
+++ b/readers/postgres/init.go
@@ -115,6 +115,17 @@ func migrateDB(db *sqlx.DB) error {
 					"DROP INDEX IF EXISTS idx_senml_publisher_time",
 				},
 			},
+			{
+				Id: "messages_7",
+				Up: []string{
+					`ALTER TABLE json ADD COLUMN IF NOT EXISTS payload_hash INTEGER`,
+					`CREATE UNIQUE INDEX IF NOT EXISTS idx_json_dedup ON json(created, publisher, subtopic, payload_hash)`,
+				},
+				Down: []string{
+					"DROP INDEX IF EXISTS idx_json_dedup",
+					"ALTER TABLE json DROP COLUMN IF EXISTS payload_hash",
+				},
+			},
 		},
 	}
 

--- a/readers/postgres/json.go
+++ b/readers/postgres/json.go
@@ -78,7 +78,7 @@ func (jr *jsonRepository) readMessages(ctx context.Context, rpm readers.JSONPage
 	dq := dbutil.GetDirQuery(rpm.Dir)
 	condition := jr.fmtCondition(rpm)
 
-	query := fmt.Sprintf(`SELECT * FROM json %s ORDER BY created %s %s;`, condition, dq, olq)
+	query := fmt.Sprintf(`SELECT created, subtopic, publisher, protocol, payload FROM json %s ORDER BY created %s %s;`, condition, dq, olq)
 	rows, err := jr.db.NamedQueryContext(ctx, query, params)
 	if err != nil {
 		if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code == pgerrcode.UndefinedTable {

--- a/readers/timescale/init.go
+++ b/readers/timescale/init.go
@@ -82,6 +82,18 @@ func migrateDB(db *sqlx.DB) error {
 					"DROP TABLE json",
 				},
 			},
+			{
+				Id: "messages_2",
+				Up: []string{
+					`ALTER TABLE json DROP CONSTRAINT IF EXISTS json_pkey`,
+					`ALTER TABLE json ADD COLUMN IF NOT EXISTS payload_hash INTEGER`,
+					`CREATE UNIQUE INDEX IF NOT EXISTS idx_json_dedup ON json(created, publisher, subtopic, payload_hash)`,
+				},
+				Down: []string{
+					"DROP INDEX IF EXISTS idx_json_dedup",
+					"ALTER TABLE json DROP COLUMN IF EXISTS payload_hash",
+				},
+			},
 		},
 	}
 

--- a/readers/timescale/json.go
+++ b/readers/timescale/json.go
@@ -154,7 +154,7 @@ func (jr *jsonRepository) readMessages(ctx context.Context, rpm readers.JSONPage
 	dq := dbutil.GetDirQuery(rpm.Dir)
 	condition := jr.fmtCondition(rpm)
 
-	q := fmt.Sprintf(`SELECT * FROM json %s ORDER BY created %s %s;`, condition, dq, olq)
+	q := fmt.Sprintf(`SELECT created, subtopic, publisher, protocol, payload FROM json %s ORDER BY created %s %s;`, condition, dq, olq)
 	rows, err := jr.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
 		if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code == pgerrcode.UndefinedTable {


### PR DESCRIPTION
Added a `payload_hash` column (FNV-1a 32-bit hash of the payload) and a unique index on `(created, publisher, subtopic, payload_hash)`, with `INSERT ... ON CONFLICT DO NOTHING`. 
An exact duplicate payload at the same key is silently dropped by the DB; different payload content at the same key is still stored. 
Applied to both the postgres and timescale `json` writers/readers; `senml` is unaffected.

Resolves #1293 