### PR TITLE
MF-1173 - Implement UIConfigs for groups

### DIFF
--- a/api/openapi/uiconfigs.yml
+++ b/api/openapi/uiconfigs.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Mainflux UI configs service
-  description: HTTP API for managing UI configuration settings scoped per organization and per thing.
+  description: HTTP API for managing UI configuration settings scoped per organization, per group, and per thing.
   version: 1.0.0
 
 paths:
@@ -63,6 +63,73 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/ListOrgsConfigsRes"
+        '400':
+          description: Failed due to malformed query parameters.
+        '401':
+          description: Missing or invalid access token provided.
+        '422':
+          description: Database can't process request.
+        '500':
+          $ref: "#/components/responses/ServiceError"
+
+  /groups/{groupId}/configs:
+    get:
+      summary: View group config
+      description: Retrieves the UI configuration for the group identified by the provided ID.
+      tags:
+        - group configs
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+      responses:
+        '200':
+          $ref: "#/components/responses/GroupConfigRes"
+        '400':
+          description: Failed due to malformed request.
+        '401':
+          description: Missing or invalid access token provided.
+        '403':
+          description: Failed to perform authorization over the entity.
+        '404':
+          description: Group config does not exist.
+        '422':
+          description: Database can't process request.
+        '500':
+          $ref: "#/components/responses/ServiceError"
+    put:
+      summary: Update group config
+      description: Updates the UI configuration for the group identified by the provided ID.
+      tags:
+        - group configs
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+      requestBody:
+        $ref: "#/components/requestBodies/UpdateGroupConfigReq"
+      responses:
+        '200':
+          description: Group config updated.
+        '400':
+          description: Failed due to malformed JSON.
+        '401':
+          description: Missing or invalid access token provided.
+        '403':
+          description: Failed to perform authorization over the entity.
+        '415':
+          description: Missing or invalid content type.
+        '500':
+          $ref: "#/components/responses/ServiceError"
+
+  /groups/configs:
+    get:
+      summary: List group configs
+      description: Retrieves a list of UI configurations for all groups accessible to the authenticated user.
+      tags:
+        - group configs
+      parameters:
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        '200':
+          $ref: "#/components/responses/ListGroupsConfigsRes"
         '400':
           description: Failed due to malformed query parameters.
         '401':
@@ -142,7 +209,7 @@ paths:
   /backup:
     get:
       summary: Backup all configs
-      description: Downloads a backup file containing all org and thing configs accessible to the authenticated user.
+      description: Downloads a backup file containing all org, group, and thing configs accessible to the authenticated user.
       tags:
         - backup
       responses:
@@ -156,7 +223,7 @@ paths:
   /restore:
     post:
       summary: Restore configs from backup
-      description: Restores org and thing configs from a previously exported backup file.
+      description: Restores org, group, and thing configs from a previously exported backup file.
       tags:
         - backup
       requestBody:
@@ -190,6 +257,21 @@ components:
             language: "en"
             dashboard_layout: "grid"
       required: [org_id, config]
+
+    GroupConfig:
+      type: object
+      properties:
+        group_id:
+          type: string
+          format: uuid
+          example: "321e4567-e89b-12d3-a456-426614174def"
+        config:
+          type: object
+          additionalProperties: true
+          example:
+            dashboard_layout: "grid"
+            widgets: ["chart", "kpi", "map"]
+      required: [group_id, config]
 
     ThingConfig:
       type: object
@@ -229,6 +311,24 @@ components:
             $ref: '#/components/schemas/OrgConfig'
       required: [total, offset, limit, orgs_configs]
 
+    GroupsConfigsPageRes:
+      type: object
+      properties:
+        total:
+          type: integer
+        offset:
+          type: integer
+          minimum: 0
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 200
+        groups_configs:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupConfig'
+      required: [total, offset, limit, groups_configs]
+
     ThingsConfigsPageRes:
       type: object
       properties:
@@ -257,6 +357,15 @@ components:
         type: string
         format: uuid
       example: "aabbccdd-1122-3344-5566-778899aabbcc"
+    GroupId:
+      name: groupId
+      in: path
+      required: true
+      description: Unique group identifier.
+      schema:
+        type: string
+        format: uuid
+      example: "321e4567-e89b-12d3-a456-426614174def"
     ThingId:
       name: thingId
       in: path
@@ -303,6 +412,23 @@ components:
               theme: "dark"
               language: "en"
               dashboard_layout: "grid"
+    UpdateGroupConfigReq:
+      description: JSON-formatted document describing the group UI configuration to set.
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              config:
+                type: object
+                additionalProperties: true
+            required:
+              - config
+          example:
+            config:
+              dashboard_layout: "grid"
+              widgets: ["chart", "kpi", "map"]
     UpdateThingConfigReq:
       description: JSON-formatted document describing the thing UI configuration to set.
       required: true
@@ -361,6 +487,32 @@ components:
                 config:
                   theme: "light"
                   language: "de"
+    GroupConfigRes:
+      description: Group config retrieved.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GroupConfig"
+          example:
+            group_id: "321e4567-e89b-12d3-a456-426614174def"
+            config:
+              dashboard_layout: "grid"
+              widgets: ["chart", "kpi", "map"]
+    ListGroupsConfigsRes:
+      description: Group configs retrieved.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GroupsConfigsPageRes"
+          example:
+            total: 1
+            offset: 0
+            limit: 10
+            groups_configs:
+              - group_id: "321e4567-e89b-12d3-a456-426614174def"
+                config:
+                  dashboard_layout: "grid"
+                  widgets: ["chart", "kpi", "map"]
     ThingConfigRes:
       description: Thing config retrieved.
       content:

--- a/cmd/uiconfigs/main.go
+++ b/cmd/uiconfigs/main.go
@@ -264,8 +264,10 @@ func newService(ts domain.ThingsClient, ac domain.AuthClient, dbTracer opentraci
 	orgConfigsRepo = tracing.OrgConfigRepositoryMiddleware(dbTracer, orgConfigsRepo)
 	thingConfigsRepo := postgres.NewThingConfigRepository(database)
 	thingConfigsRepo = tracing.ThingConfigRepositoryMiddleware(dbTracer, thingConfigsRepo)
+	groupConfigsRepo := postgres.NewGroupConfigRepository(database)
+	groupConfigsRepo = tracing.GroupConfigRepositoryMiddleware(dbTracer, groupConfigsRepo)
 	idProvider := uuid.New()
-	svc := uiconfigs.New(orgConfigsRepo, thingConfigsRepo, ts, ac, idProvider, logger)
+	svc := uiconfigs.New(orgConfigsRepo, thingConfigsRepo, groupConfigsRepo, ts, ac, idProvider, logger)
 	svc = api.LoggingMiddleware(svc, logger)
 	svc = api.MetricsMiddleware(
 		svc,

--- a/uiconfigs/README.md
+++ b/uiconfigs/README.md
@@ -1,6 +1,6 @@
 # UI Configs Service
 
-The UI Configs service persists and manages UI configuration settings scoped per organization and per thing. Configuration payloads are arbitrary JSON objects — the service imposes no schema on the values stored, giving the frontend full flexibility over what it persists. The service also supports full **backup and restore** of all configs.
+The UI Configs service persists and manages UI configuration settings scoped per organization, per group, and per thing. Configuration payloads are arbitrary JSON objects — the service imposes no schema on the values stored, giving the frontend full flexibility over what it persists. The service also supports full **backup and restore** of all configs.
 
 ## Org Config
 
@@ -10,6 +10,15 @@ An org config stores frontend settings at the organization level (e.g. theme, la
 |----------|----------------------------------------------------------------|
 | `org_id` | ID of the organization the config belongs to                   |
 | `config` | Arbitrary JSON object containing the UI configuration settings |
+
+## Group Config
+
+A group config stores frontend settings at the group level.
+
+| Field      | Description                                                    |
+|------------|--------------------------------------------------------------|
+| `group_id` | ID of the group the config belongs to                         |
+| `config`   | Arbitrary JSON object containing the UI configuration settings |
 
 ## Thing Config
 

--- a/uiconfigs/api/http/backup/endpoint.go
+++ b/uiconfigs/api/http/backup/endpoint.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 	"github.com/MainfluxLabs/mainflux/uiconfigs"
+	groups "github.com/MainfluxLabs/mainflux/uiconfigs/api/http/groups"
 	orgs "github.com/MainfluxLabs/mainflux/uiconfigs/api/http/orgs"
 	things "github.com/MainfluxLabs/mainflux/uiconfigs/api/http/things"
 	"github.com/go-kit/kit/endpoint"
@@ -54,6 +55,7 @@ func buildBackupResponse(b uiconfigs.Backup, fileName string) (apiutil.ViewFileR
 	views := backupResponse{
 		OrgsConfigs:   make([]orgs.OrgConfigResponse, 0, len(b.OrgsConfigs)),
 		ThingsConfigs: make([]things.ThingConfigResponse, 0, len(b.ThingsConfigs)),
+		GroupsConfigs: make([]groups.GroupConfigResponse, 0, len(b.GroupsConfigs)),
 	}
 
 	for _, oc := range b.OrgsConfigs {
@@ -68,6 +70,13 @@ func buildBackupResponse(b uiconfigs.Backup, fileName string) (apiutil.ViewFileR
 			ThingID: tc.ThingID,
 			GroupID: tc.GroupID,
 			Config:  tc.Config,
+		})
+	}
+
+	for _, gc := range b.GroupsConfigs {
+		views.GroupsConfigs = append(views.GroupsConfigs, groups.GroupConfigResponse{
+			GroupID: gc.GroupID,
+			Config:  gc.Config,
 		})
 	}
 
@@ -95,6 +104,13 @@ func buildBackup(req restoreReq) (backup uiconfigs.Backup) {
 			ThingID: tc.ThingID,
 			GroupID: tc.GroupID,
 			Config:  tc.Config,
+		})
+	}
+
+	for _, gc := range req.GroupsConfigs {
+		backup.GroupsConfigs = append(backup.GroupsConfigs, uiconfigs.GroupConfig{
+			GroupID: gc.GroupID,
+			Config:  gc.Config,
 		})
 	}
 

--- a/uiconfigs/api/http/backup/requests.go
+++ b/uiconfigs/api/http/backup/requests.go
@@ -6,6 +6,7 @@ package backup
 import (
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
 
+	groups "github.com/MainfluxLabs/mainflux/uiconfigs/api/http/groups"
 	orgs "github.com/MainfluxLabs/mainflux/uiconfigs/api/http/orgs"
 	things "github.com/MainfluxLabs/mainflux/uiconfigs/api/http/things"
 )
@@ -26,13 +27,14 @@ type restoreReq struct {
 	token         string
 	OrgsConfigs   []orgs.OrgConfigResponse     `json:"orgs_configs"`
 	ThingsConfigs []things.ThingConfigResponse `json:"things_configs"`
+	GroupsConfigs []groups.GroupConfigResponse `json:"groups_configs"`
 }
 
 func (req *restoreReq) validate() error {
 	if req.token == "" {
 		return apiutil.ErrBearerToken
 	}
-	if len(req.OrgsConfigs) == 0 && len(req.ThingsConfigs) == 0 {
+	if len(req.OrgsConfigs) == 0 && len(req.ThingsConfigs) == 0 && len(req.GroupsConfigs) == 0 {
 		return apiutil.ErrEmptyList
 	}
 

--- a/uiconfigs/api/http/backup/responses.go
+++ b/uiconfigs/api/http/backup/responses.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	groups "github.com/MainfluxLabs/mainflux/uiconfigs/api/http/groups"
 	orgs "github.com/MainfluxLabs/mainflux/uiconfigs/api/http/orgs"
 	things "github.com/MainfluxLabs/mainflux/uiconfigs/api/http/things"
 )
@@ -15,6 +16,7 @@ var (
 type backupResponse struct {
 	OrgsConfigs   []orgs.OrgConfigResponse     `json:"orgs_configs"`
 	ThingsConfigs []things.ThingConfigResponse `json:"things_configs"`
+	GroupsConfigs []groups.GroupConfigResponse `json:"groups_configs"`
 }
 
 func (res backupResponse) Code() int {

--- a/uiconfigs/api/http/groups/endpoint.go
+++ b/uiconfigs/api/http/groups/endpoint.go
@@ -1,0 +1,88 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package groups
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/uiconfigs"
+	"github.com/go-kit/kit/endpoint"
+)
+
+func viewGroupConfigEndpoint(svc uiconfigs.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request any) (any, error) {
+		req := request.(viewGroupConfigReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		groupConfig, err := svc.ViewGroupConfig(ctx, req.token, req.groupID)
+		if err != nil {
+			return nil, err
+		}
+
+		res := buildGroupConfigResponse(groupConfig)
+		return res, nil
+	}
+}
+
+func listGroupsConfigsEndpoint(svc uiconfigs.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request any) (any, error) {
+		req := request.(listGroupsConfigsReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		page, err := svc.ListGroupsConfigs(ctx, req.token, req.pageMetadata)
+		if err != nil {
+			return nil, err
+		}
+
+		return buildGroupsConfigsResponse(page, req.pageMetadata), nil
+	}
+}
+
+func updateGroupConfigEndpoint(svc uiconfigs.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request any) (any, error) {
+		req := request.(updateGroupConfigReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		groupConfig := uiconfigs.GroupConfig{
+			GroupID: req.groupID,
+			Config:  req.Config,
+		}
+
+		_, err := svc.UpdateGroupConfig(ctx, req.token, groupConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		return apiutil.EmptyRes{StatusCode: http.StatusOK}, nil
+	}
+}
+
+func buildGroupConfigResponse(gc uiconfigs.GroupConfig) GroupConfigResponse {
+	return GroupConfigResponse{
+		GroupID: gc.GroupID,
+		Config:  gc.Config,
+	}
+}
+
+func buildGroupsConfigsResponse(page uiconfigs.GroupConfigPage, pm apiutil.PageMetadata) groupsConfigsRes {
+	res := groupsConfigsRes{
+		GroupsConfigs: []GroupConfigResponse{},
+		Total:         page.Total,
+		Offset:        pm.Offset,
+		Limit:         pm.Limit,
+	}
+
+	for _, gc := range page.GroupsConfigs {
+		res.GroupsConfigs = append(res.GroupsConfigs, buildGroupConfigResponse(gc))
+	}
+	return res
+}

--- a/uiconfigs/api/http/groups/requests.go
+++ b/uiconfigs/api/http/groups/requests.go
@@ -1,0 +1,61 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package groups
+
+import (
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/uiconfigs/api"
+)
+
+const (
+	maxLimitSize = 200
+)
+
+type viewGroupConfigReq struct {
+	token   string
+	groupID string
+}
+
+func (req *viewGroupConfigReq) validate() error {
+	if req.token == "" {
+		return apiutil.ErrBearerToken
+	}
+
+	if req.groupID == "" {
+		return apiutil.ErrMissingGroupID
+	}
+
+	return nil
+}
+
+type listGroupsConfigsReq struct {
+	token        string
+	pageMetadata apiutil.PageMetadata
+}
+
+func (req *listGroupsConfigsReq) validate() error {
+	if req.token == "" {
+		return apiutil.ErrBearerToken
+	}
+
+	return api.ValidatePageMetadata(req.pageMetadata, maxLimitSize)
+}
+
+type updateGroupConfigReq struct {
+	token   string
+	groupID string
+	Config  map[string]any `json:"config"`
+}
+
+func (req updateGroupConfigReq) validate() error {
+	if req.token == "" {
+		return apiutil.ErrBearerToken
+	}
+
+	if req.groupID == "" {
+		return apiutil.ErrMissingGroupID
+	}
+
+	return nil
+}

--- a/uiconfigs/api/http/groups/responses.go
+++ b/uiconfigs/api/http/groups/responses.go
@@ -1,0 +1,48 @@
+package groups
+
+import (
+	"net/http"
+
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+)
+
+var (
+	_ apiutil.Response = (*GroupConfigResponse)(nil)
+	_ apiutil.Response = (*groupsConfigsRes)(nil)
+)
+
+type GroupConfigResponse struct {
+	GroupID string         `json:"group_id,omitempty"`
+	Config  map[string]any `json:"config,omitempty"`
+}
+
+func (res GroupConfigResponse) Code() int {
+	return http.StatusOK
+}
+
+func (res GroupConfigResponse) Headers() map[string]string {
+	return map[string]string{}
+}
+
+func (res GroupConfigResponse) Empty() bool {
+	return false
+}
+
+type groupsConfigsRes struct {
+	Total         uint64                `json:"total"`
+	Offset        uint64                `json:"offset"`
+	Limit         uint64                `json:"limit"`
+	GroupsConfigs []GroupConfigResponse `json:"groups_configs"`
+}
+
+func (res groupsConfigsRes) Code() int {
+	return http.StatusOK
+}
+
+func (res groupsConfigsRes) Headers() map[string]string {
+	return map[string]string{}
+}
+
+func (res groupsConfigsRes) Empty() bool {
+	return false
+}

--- a/uiconfigs/api/http/groups/transport.go
+++ b/uiconfigs/api/http/groups/transport.go
@@ -1,0 +1,127 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package groups
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	log "github.com/MainfluxLabs/mainflux/logger"
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/authn"
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
+	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/uiconfigs"
+	"github.com/go-kit/kit/endpoint"
+	kitot "github.com/go-kit/kit/tracing/opentracing"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/go-zoo/bone"
+	"github.com/opentracing/opentracing-go"
+)
+
+// MakeHandler returns a HTTP handler for API endpoints.
+func MakeHandler(tracer opentracing.Tracer, svc uiconfigs.Service, ac domain.AuthClient, mux *bone.Mux, logger log.Logger) *bone.Mux {
+	opts := []kithttp.ServerOption{
+		kithttp.ServerErrorEncoder(apiutil.LoggingErrorEncoder(logger, encodeError)),
+		kithttp.ServerBefore(authn.HTTPTokenToContext),
+	}
+
+	withIdentity := authn.IdentityMiddleware(ac, logger)
+
+	mux.Get("/groups/:id/configs", kithttp.NewServer(
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "view_group_config"),
+			withIdentity,
+		)(viewGroupConfigEndpoint(svc)),
+		decodeViewGroupConfig,
+		encodeResponse,
+		opts...,
+	))
+
+	mux.Get("/groups/configs", kithttp.NewServer(
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "list_all_groups_configs"),
+			withIdentity,
+		)(listGroupsConfigsEndpoint(svc)),
+		decodeListGroupsConfigs,
+		encodeResponse,
+		opts...,
+	))
+
+	mux.Put("/groups/:id/configs", kithttp.NewServer(
+		endpoint.Chain(
+			kitot.TraceServer(tracer, "update_group_config"),
+			withIdentity,
+		)(updateGroupConfigEndpoint(svc)),
+		decodeUpdateGroupConfig,
+		encodeResponse,
+		opts...,
+	))
+
+	return mux
+}
+
+func decodeViewGroupConfig(_ context.Context, r *http.Request) (any, error) {
+	req := viewGroupConfigReq{
+		token:   apiutil.ExtractBearerToken(r),
+		groupID: bone.GetValue(r, apiutil.IDKey),
+	}
+
+	return req, nil
+}
+
+func decodeListGroupsConfigs(_ context.Context, r *http.Request) (any, error) {
+	pm, err := apiutil.BuildPageMetadata(r)
+	if err != nil {
+		return nil, err
+	}
+
+	req := listGroupsConfigsReq{
+		token:        apiutil.ExtractBearerToken(r),
+		pageMetadata: pm,
+	}
+
+	return req, nil
+}
+
+func decodeUpdateGroupConfig(_ context.Context, r *http.Request) (any, error) {
+	if !strings.Contains(r.Header.Get("Content-Type"), apiutil.ContentTypeJSON) {
+		return nil, apiutil.ErrUnsupportedContentType
+	}
+
+	req := updateGroupConfigReq{
+		token:   apiutil.ExtractBearerToken(r),
+		groupID: bone.GetValue(r, apiutil.IDKey),
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
+	}
+
+	return req, nil
+}
+
+func encodeResponse(_ context.Context, w http.ResponseWriter, response any) error {
+	w.Header().Set("Content-Type", apiutil.ContentTypeJSON)
+
+	if ar, ok := response.(apiutil.Response); ok {
+		for k, v := range ar.Headers() {
+			w.Header().Set(k, v)
+		}
+
+		w.WriteHeader(ar.Code())
+
+		if ar.Empty() {
+			return nil
+		}
+	}
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+func encodeError(_ context.Context, err error, w http.ResponseWriter) {
+	apiutil.EncodeError(err, w)
+	apiutil.WriteErrorResponse(err, w)
+}

--- a/uiconfigs/api/http/transport.go
+++ b/uiconfigs/api/http/transport.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/uiconfigs"
 	"github.com/MainfluxLabs/mainflux/uiconfigs/api/http/backup"
+	"github.com/MainfluxLabs/mainflux/uiconfigs/api/http/groups"
 	"github.com/MainfluxLabs/mainflux/uiconfigs/api/http/orgs"
 	"github.com/MainfluxLabs/mainflux/uiconfigs/api/http/things"
 	"github.com/go-zoo/bone"
@@ -24,6 +25,7 @@ func MakeHandler(tracer opentracing.Tracer, svc uiconfigs.Service, ac domain.Aut
 	mux := bone.New()
 	mux = orgs.MakeHandler(tracer, svc, ac, mux, logger)
 	mux = things.MakeHandler(tracer, svc, ac, mux, logger)
+	mux = groups.MakeHandler(tracer, svc, ac, mux, logger)
 	mux = backup.MakeHandler(tracer, svc, ac, mux, logger)
 	mux.GetFunc("/health", mainflux.Health("uiconfigs"))
 	mux.Handle("/metrics", promhttp.Handler())

--- a/uiconfigs/api/logging.go
+++ b/uiconfigs/api/logging.go
@@ -84,9 +84,9 @@ func (lm *loggingMiddleware) RemoveOrgConfig(ctx context.Context, orgID string) 
 	return lm.svc.RemoveOrgConfig(ctx, orgID)
 }
 
-func (lm *loggingMiddleware) MarkReferencesDeleted(ctx context.Context, orgID string, ids []string) (err error) {
+func (lm *loggingMiddleware) RemoveIDsFromConfigs(ctx context.Context, orgID string, ids []string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method mark_references_deleted for org %v, ids %v took %s to complete", orgID, ids, time.Since(begin))
+		message := fmt.Sprintf("Method remove_ids_from_configs for org %v, ids %v took %s to complete", orgID, ids, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -94,7 +94,7 @@ func (lm *loggingMiddleware) MarkReferencesDeleted(ctx context.Context, orgID st
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.MarkReferencesDeleted(ctx, orgID, ids)
+	return lm.svc.RemoveIDsFromConfigs(ctx, orgID, ids)
 }
 
 func (lm *loggingMiddleware) BackupOrgsConfigs(ctx context.Context, token string) (response uiconfigs.OrgConfigBackup, err error) {

--- a/uiconfigs/api/logging.go
+++ b/uiconfigs/api/logging.go
@@ -84,9 +84,9 @@ func (lm *loggingMiddleware) RemoveOrgConfig(ctx context.Context, orgID string) 
 	return lm.svc.RemoveOrgConfig(ctx, orgID)
 }
 
-func (lm *loggingMiddleware) RemoveIDsFromConfigs(ctx context.Context, orgID string, ids []string) (err error) {
+func (lm *loggingMiddleware) RemoveGroupFromConfigs(ctx context.Context, orgID, groupID string, thingIDs []string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method remove_ids_from_configs for org %v, ids %v took %s to complete", orgID, ids, time.Since(begin))
+		message := fmt.Sprintf("Method remove_group_from_configs for org %v, group %v, thing ids %v took %s to complete", orgID, groupID, thingIDs, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -94,7 +94,20 @@ func (lm *loggingMiddleware) RemoveIDsFromConfigs(ctx context.Context, orgID str
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.RemoveIDsFromConfigs(ctx, orgID, ids)
+	return lm.svc.RemoveGroupFromConfigs(ctx, orgID, groupID, thingIDs)
+}
+
+func (lm *loggingMiddleware) RemoveThingsFromConfigs(ctx context.Context, orgID string, thingIDs []string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method remove_things_from_configs for org %v, thing ids %v took %s to complete", orgID, thingIDs, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.RemoveThingsFromConfigs(ctx, orgID, thingIDs)
 }
 
 func (lm *loggingMiddleware) BackupOrgsConfigs(ctx context.Context, token string) (response uiconfigs.OrgConfigBackup, err error) {

--- a/uiconfigs/api/logging.go
+++ b/uiconfigs/api/logging.go
@@ -84,6 +84,19 @@ func (lm *loggingMiddleware) RemoveOrgConfig(ctx context.Context, orgID string) 
 	return lm.svc.RemoveOrgConfig(ctx, orgID)
 }
 
+func (lm *loggingMiddleware) MarkReferencesDeleted(ctx context.Context, orgID string, ids []string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method mark_references_deleted for org %v, ids %v took %s to complete", orgID, ids, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.MarkReferencesDeleted(ctx, orgID, ids)
+}
+
 func (lm *loggingMiddleware) BackupOrgsConfigs(ctx context.Context, token string) (response uiconfigs.OrgConfigBackup, err error) {
 	defer func(begin time.Time) {
 		email := authn.EmailFromToken(token)

--- a/uiconfigs/api/logging.go
+++ b/uiconfigs/api/logging.go
@@ -180,6 +180,75 @@ func (lm *loggingMiddleware) BackupThingsConfigs(ctx context.Context, token stri
 	return lm.svc.BackupThingsConfigs(ctx, token)
 }
 
+func (lm *loggingMiddleware) ViewGroupConfig(ctx context.Context, token, groupID string) (response uiconfigs.GroupConfig, err error) {
+	defer func(begin time.Time) {
+		email := authn.EmailFromToken(token)
+		message := fmt.Sprintf("Method view_group_config by user %s, group %v took %s to complete", email, groupID, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.ViewGroupConfig(ctx, token, groupID)
+}
+
+func (lm *loggingMiddleware) ListGroupsConfigs(ctx context.Context, token string, pm apiutil.PageMetadata) (response uiconfigs.GroupConfigPage, err error) {
+	defer func(begin time.Time) {
+		email := authn.EmailFromToken(token)
+		message := fmt.Sprintf("Method list_groups_configs by user %s took %s to complete", email, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.ListGroupsConfigs(ctx, token, pm)
+}
+
+func (lm *loggingMiddleware) UpdateGroupConfig(ctx context.Context, token string, groupConfig uiconfigs.GroupConfig) (response uiconfigs.GroupConfig, err error) {
+	defer func(begin time.Time) {
+		email := authn.EmailFromToken(token)
+		message := fmt.Sprintf("Method update_group_config by user %s, group %v took %s to complete", email, groupConfig.GroupID, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.UpdateGroupConfig(ctx, token, groupConfig)
+}
+
+func (lm *loggingMiddleware) RemoveGroupConfig(ctx context.Context, groupID string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method remove_group_config for group %v took %s to complete", groupID, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.RemoveGroupConfig(ctx, groupID)
+}
+
+func (lm *loggingMiddleware) BackupGroupsConfigs(ctx context.Context, token string) (response uiconfigs.GroupConfigBackup, err error) {
+	defer func(begin time.Time) {
+		email := authn.EmailFromToken(token)
+		message := fmt.Sprintf("Method backup_groups_configs by user %s took %s to complete", email, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.BackupGroupsConfigs(ctx, token)
+}
+
 func (lm *loggingMiddleware) Backup(ctx context.Context, token string) (response uiconfigs.Backup, err error) {
 	defer func(begin time.Time) {
 		email := authn.EmailFromToken(token)

--- a/uiconfigs/api/metrics.go
+++ b/uiconfigs/api/metrics.go
@@ -69,6 +69,15 @@ func (ms *metricsMiddleware) RemoveOrgConfig(ctx context.Context, orgID string) 
 	return ms.svc.RemoveOrgConfig(ctx, orgID)
 }
 
+func (ms *metricsMiddleware) MarkReferencesDeleted(ctx context.Context, orgID string, ids []string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "mark_references_deleted").Add(1)
+		ms.latency.With("method", "mark_references_deleted").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.MarkReferencesDeleted(ctx, orgID, ids)
+}
+
 func (ms *metricsMiddleware) BackupOrgsConfigs(ctx context.Context, token string) (uiconfigs.OrgConfigBackup, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "backup_orgs_configs").Add(1)

--- a/uiconfigs/api/metrics.go
+++ b/uiconfigs/api/metrics.go
@@ -69,13 +69,13 @@ func (ms *metricsMiddleware) RemoveOrgConfig(ctx context.Context, orgID string) 
 	return ms.svc.RemoveOrgConfig(ctx, orgID)
 }
 
-func (ms *metricsMiddleware) MarkReferencesDeleted(ctx context.Context, orgID string, ids []string) error {
+func (ms *metricsMiddleware) RemoveIDsFromConfigs(ctx context.Context, orgID string, ids []string) error {
 	defer func(begin time.Time) {
-		ms.counter.With("method", "mark_references_deleted").Add(1)
-		ms.latency.With("method", "mark_references_deleted").Observe(time.Since(begin).Seconds())
+		ms.counter.With("method", "remove_ids_from_configs").Add(1)
+		ms.latency.With("method", "remove_ids_from_configs").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.MarkReferencesDeleted(ctx, orgID, ids)
+	return ms.svc.RemoveIDsFromConfigs(ctx, orgID, ids)
 }
 
 func (ms *metricsMiddleware) BackupOrgsConfigs(ctx context.Context, token string) (uiconfigs.OrgConfigBackup, error) {

--- a/uiconfigs/api/metrics.go
+++ b/uiconfigs/api/metrics.go
@@ -69,13 +69,22 @@ func (ms *metricsMiddleware) RemoveOrgConfig(ctx context.Context, orgID string) 
 	return ms.svc.RemoveOrgConfig(ctx, orgID)
 }
 
-func (ms *metricsMiddleware) RemoveIDsFromConfigs(ctx context.Context, orgID string, ids []string) error {
+func (ms *metricsMiddleware) RemoveGroupFromConfigs(ctx context.Context, orgID, groupID string, thingIDs []string) error {
 	defer func(begin time.Time) {
-		ms.counter.With("method", "remove_ids_from_configs").Add(1)
-		ms.latency.With("method", "remove_ids_from_configs").Observe(time.Since(begin).Seconds())
+		ms.counter.With("method", "remove_group_from_configs").Add(1)
+		ms.latency.With("method", "remove_group_from_configs").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.RemoveIDsFromConfigs(ctx, orgID, ids)
+	return ms.svc.RemoveGroupFromConfigs(ctx, orgID, groupID, thingIDs)
+}
+
+func (ms *metricsMiddleware) RemoveThingsFromConfigs(ctx context.Context, orgID string, thingIDs []string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "remove_things_from_configs").Add(1)
+		ms.latency.With("method", "remove_things_from_configs").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.RemoveThingsFromConfigs(ctx, orgID, thingIDs)
 }
 
 func (ms *metricsMiddleware) BackupOrgsConfigs(ctx context.Context, token string) (uiconfigs.OrgConfigBackup, error) {

--- a/uiconfigs/api/metrics.go
+++ b/uiconfigs/api/metrics.go
@@ -132,6 +132,51 @@ func (ms *metricsMiddleware) BackupThingsConfigs(ctx context.Context, token stri
 	return ms.svc.BackupThingsConfigs(ctx, token)
 }
 
+func (ms *metricsMiddleware) ViewGroupConfig(ctx context.Context, token, groupID string) (uiconfigs.GroupConfig, error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "view_group_config").Add(1)
+		ms.latency.With("method", "view_group_config").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.ViewGroupConfig(ctx, token, groupID)
+}
+
+func (ms *metricsMiddleware) ListGroupsConfigs(ctx context.Context, token string, pm apiutil.PageMetadata) (uiconfigs.GroupConfigPage, error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "list_groups_configs").Add(1)
+		ms.latency.With("method", "list_groups_configs").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.ListGroupsConfigs(ctx, token, pm)
+}
+
+func (ms *metricsMiddleware) UpdateGroupConfig(ctx context.Context, token string, groupConfig uiconfigs.GroupConfig) (uiconfigs.GroupConfig, error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "update_group_config").Add(1)
+		ms.latency.With("method", "update_group_config").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.UpdateGroupConfig(ctx, token, groupConfig)
+}
+
+func (ms *metricsMiddleware) RemoveGroupConfig(ctx context.Context, groupID string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "remove_group_config").Add(1)
+		ms.latency.With("method", "remove_group_config").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.RemoveGroupConfig(ctx, groupID)
+}
+
+func (ms *metricsMiddleware) BackupGroupsConfigs(ctx context.Context, token string) (uiconfigs.GroupConfigBackup, error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "backup_groups_configs").Add(1)
+		ms.latency.With("method", "backup_groups_configs").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.BackupGroupsConfigs(ctx, token)
+}
+
 func (ms *metricsMiddleware) Backup(ctx context.Context, token string) (uiconfigs.Backup, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "backup").Add(1)

--- a/uiconfigs/events/handler.go
+++ b/uiconfigs/events/handler.go
@@ -25,15 +25,15 @@ func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
 		if err := h.svc.RemoveThingConfig(ctx, e.ID); err != nil {
 			return err
 		}
-		return h.svc.MarkReferencesDeleted(ctx, event.OrgID, []string{e.ID})
+		return h.svc.RemoveIDsFromConfigs(ctx, event.OrgID, []string{e.ID})
 	case events.OrgRemoved:
 		return h.svc.RemoveOrgConfig(ctx, e.ID)
 	case events.GroupRemoved:
 		if err := h.svc.RemoveThingConfigByGroup(ctx, e.ID); err != nil {
 			return err
 		}
-		// Mark the group's own id deleted alongside its things
-		return h.svc.MarkReferencesDeleted(ctx, event.OrgID, append([]string{e.ID}, e.ThingIDs...))
+		// Remove references to the group's own id alongside its things
+		return h.svc.RemoveIDsFromConfigs(ctx, event.OrgID, append([]string{e.ID}, e.ThingIDs...))
 	}
 	return nil
 }

--- a/uiconfigs/events/handler.go
+++ b/uiconfigs/events/handler.go
@@ -33,7 +33,7 @@ func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
 			return err
 		}
 		// Mark the group's own id deleted alongside its things
-		return h.svc.MarkReferencesDeleted(ctx, event.OrgID, append(e.ThingIDs, e.ID))
+		return h.svc.MarkReferencesDeleted(ctx, event.OrgID, append([]string{e.ID}, e.ThingIDs...))
 	}
 	return nil
 }

--- a/uiconfigs/events/handler.go
+++ b/uiconfigs/events/handler.go
@@ -25,15 +25,14 @@ func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
 		if err := h.svc.RemoveThingConfig(ctx, e.ID); err != nil {
 			return err
 		}
-		return h.svc.RemoveIDsFromConfigs(ctx, event.OrgID, []string{e.ID})
+		return h.svc.RemoveThingsFromConfigs(ctx, event.OrgID, []string{e.ID})
 	case events.OrgRemoved:
 		return h.svc.RemoveOrgConfig(ctx, e.ID)
 	case events.GroupRemoved:
 		if err := h.svc.RemoveThingConfigByGroup(ctx, e.ID); err != nil {
 			return err
 		}
-		// Remove references to the group's own id alongside its things
-		return h.svc.RemoveIDsFromConfigs(ctx, event.OrgID, append([]string{e.ID}, e.ThingIDs...))
+		return h.svc.RemoveGroupFromConfigs(ctx, event.OrgID, e.ID, e.ThingIDs)
 	}
 	return nil
 }

--- a/uiconfigs/events/handler.go
+++ b/uiconfigs/events/handler.go
@@ -22,11 +22,18 @@ func NewEventHandler(svc uiconfigs.Service) events.EventHandler {
 func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
 	switch e := event.Action.(type) {
 	case events.ThingRemoved:
-		return h.svc.RemoveThingConfig(ctx, e.ID)
+		if err := h.svc.RemoveThingConfig(ctx, e.ID); err != nil {
+			return err
+		}
+		return h.svc.MarkReferencesDeleted(ctx, event.OrgID, []string{e.ID})
 	case events.OrgRemoved:
 		return h.svc.RemoveOrgConfig(ctx, e.ID)
 	case events.GroupRemoved:
-		return h.svc.RemoveThingConfigByGroup(ctx, e.ID)
+		if err := h.svc.RemoveThingConfigByGroup(ctx, e.ID); err != nil {
+			return err
+		}
+		// Mark the group's own id deleted alongside its things
+		return h.svc.MarkReferencesDeleted(ctx, event.OrgID, append(e.ThingIDs, e.ID))
 	}
 	return nil
 }

--- a/uiconfigs/events/handler.go
+++ b/uiconfigs/events/handler.go
@@ -26,6 +26,9 @@ func (h *eventHandler) Handle(ctx context.Context, event events.Event) error {
 	case events.OrgRemoved:
 		return h.svc.RemoveOrgConfig(ctx, e.ID)
 	case events.GroupRemoved:
+		if err := h.svc.RemoveGroupConfig(ctx, e.ID); err != nil {
+			return err
+		}
 		return h.svc.RemoveThingConfigByGroup(ctx, e.ID)
 	}
 	return nil

--- a/uiconfigs/groups.go
+++ b/uiconfigs/groups.go
@@ -1,0 +1,44 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package uiconfigs
+
+import (
+	"context"
+
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+)
+
+type GroupConfig struct {
+	GroupID string
+	Config  Config
+}
+
+type GroupConfigPage struct {
+	Total         uint64
+	GroupsConfigs []GroupConfig
+}
+
+type GroupConfigBackup struct {
+	GroupsConfigs []GroupConfig
+}
+
+type GroupConfigRepository interface {
+	// Save creates a new group config record in the database.
+	Save(ctx context.Context, gc GroupConfig) (GroupConfig, error)
+
+	// RetrieveByGroup returns the group config associated with the given group ID
+	RetrieveByGroup(ctx context.Context, groupID string) (GroupConfig, error)
+
+	// RetrieveAll retrieves all group configs.
+	RetrieveAll(ctx context.Context, pm apiutil.PageMetadata) (GroupConfigPage, error)
+
+	// Update performs an update to the existing group config.
+	Update(ctx context.Context, gc GroupConfig) (GroupConfig, error)
+
+	// Remove removes the group configs with the provided identifier.
+	Remove(ctx context.Context, groupID string) error
+
+	// BackupAll retrieves all group configs.
+	BackupAll(ctx context.Context) (GroupConfigBackup, error)
+}

--- a/uiconfigs/postgres/groups.go
+++ b/uiconfigs/postgres/groups.go
@@ -1,0 +1,248 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/pkg/errors"
+	"github.com/MainfluxLabs/mainflux/uiconfigs"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+var _ uiconfigs.GroupConfigRepository = (*groupConfigRepository)(nil)
+
+type groupConfigRepository struct {
+	db dbutil.Database
+}
+
+// NewGroupConfigRepository instantiates a PostgreSQL implementation of UI Config repository.
+func NewGroupConfigRepository(db dbutil.Database) uiconfigs.GroupConfigRepository {
+	return &groupConfigRepository{
+		db: db,
+	}
+}
+
+func (gr groupConfigRepository) Save(ctx context.Context, g uiconfigs.GroupConfig) (uiconfigs.GroupConfig, error) {
+	tx, err := gr.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrCreateEntity, err)
+	}
+	defer tx.Rollback()
+
+	q := `INSERT INTO group_configs (group_id, config)
+          VALUES (:group_id, :config);`
+
+	dbGc, err := toDBGroupConfig(g)
+	if err != nil {
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrCreateEntity, err)
+	}
+
+	if _, err := tx.NamedExecContext(ctx, q, dbGc); err != nil {
+		pgErr, ok := err.(*pgconn.PgError)
+		if ok {
+			switch pgErr.Code {
+			case pgerrcode.InvalidTextRepresentation:
+				return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
+			case pgerrcode.UniqueViolation:
+				return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrConflict, err)
+			case pgerrcode.StringDataRightTruncationWarning:
+				return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
+			}
+		}
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrCreateEntity, err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrCreateEntity, err)
+	}
+
+	return g, nil
+}
+
+func (gr groupConfigRepository) RetrieveByGroup(ctx context.Context, groupID string) (uiconfigs.GroupConfig, error) {
+	q := `SELECT group_id, config
+	      FROM group_configs
+	      WHERE group_id = $1;`
+
+	dbGc := dbGroupConfig{}
+	if err := gr.db.QueryRowxContext(ctx, q, groupID).StructScan(&dbGc); err != nil {
+		pgErr, ok := err.(*pgconn.PgError)
+
+		if err == sql.ErrNoRows || ok && pgerrcode.InvalidTextRepresentation == pgErr.Code {
+			return uiconfigs.GroupConfig{
+				GroupID: groupID,
+				Config:  make(map[string]any),
+			}, nil
+		}
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
+	}
+
+	return toGroupConfig(dbGc)
+}
+
+func (gr groupConfigRepository) RetrieveAll(ctx context.Context, pm apiutil.PageMetadata) (uiconfigs.GroupConfigPage, error) {
+	olq := dbutil.GetOffsetLimitQuery(pm.Limit)
+
+	q := `SELECT group_id, config FROM group_configs ORDER BY group_id ` + olq
+	cquery := `SELECT COUNT(*) FROM group_configs`
+
+	params := map[string]any{
+		"limit":  pm.Limit,
+		"offset": pm.Offset,
+	}
+
+	rows, err := gr.db.NamedQueryContext(ctx, q, params)
+	if err != nil {
+		return uiconfigs.GroupConfigPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
+	}
+	defer rows.Close()
+
+	var groupConfigs []uiconfigs.GroupConfig
+	for rows.Next() {
+		var dbgc dbGroupConfig
+		if err := rows.StructScan(&dbgc); err != nil {
+			return uiconfigs.GroupConfigPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
+		}
+
+		gc, err := toGroupConfig(dbgc)
+		if err != nil {
+			return uiconfigs.GroupConfigPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
+		}
+		groupConfigs = append(groupConfigs, gc)
+	}
+
+	total, err := dbutil.Total(ctx, gr.db, cquery, params)
+	if err != nil {
+		return uiconfigs.GroupConfigPage{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
+	}
+
+	return uiconfigs.GroupConfigPage{
+		Total:         total,
+		GroupsConfigs: groupConfigs,
+	}, nil
+}
+
+func (gr groupConfigRepository) Update(ctx context.Context, g uiconfigs.GroupConfig) (uiconfigs.GroupConfig, error) {
+	q := `UPDATE group_configs
+      	  SET config = :config
+          WHERE group_id = :group_id`
+
+	dbGc, err := toDBGroupConfig(g)
+	if err != nil {
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrUpdateEntity, err)
+	}
+
+	res, errdb := gr.db.NamedExecContext(ctx, q, dbGc)
+	if errdb != nil {
+		pgErr, ok := errdb.(*pgconn.PgError)
+		if ok {
+			switch pgErr.Code {
+			case pgerrcode.InvalidTextRepresentation:
+				return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrMalformedEntity, errdb)
+			case pgerrcode.StringDataRightTruncationWarning:
+				return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrMalformedEntity, errdb)
+			}
+		}
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrUpdateEntity, errdb)
+	}
+
+	cnt, errdb := res.RowsAffected()
+	if errdb != nil {
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrUpdateEntity, errdb)
+	}
+
+	if cnt == 0 {
+		return gr.Save(ctx, g)
+	}
+
+	qSelect := `SELECT group_id, config
+	            FROM group_configs
+				WHERE group_id = $1;`
+
+	var dbRes dbGroupConfig
+	if err := gr.db.GetContext(ctx, &dbRes, qSelect, g.GroupID); err != nil {
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
+	}
+
+	updated, err := toGroupConfig(dbRes)
+	if err != nil {
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrUpdateEntity, err)
+	}
+
+	return updated, nil
+}
+
+func (gr groupConfigRepository) Remove(ctx context.Context, groupID string) error {
+	q := `DELETE FROM group_configs WHERE group_id = :group_id;`
+
+	args := map[string]any{
+		"group_id": groupID,
+	}
+
+	if _, err := gr.db.NamedExecContext(ctx, q, args); err != nil {
+		return errors.Wrap(dbutil.ErrRemoveEntity, err)
+	}
+
+	return nil
+}
+
+func (gr groupConfigRepository) BackupAll(ctx context.Context) (uiconfigs.GroupConfigBackup, error) {
+	q := `SELECT group_id, config FROM group_configs`
+
+	var items []dbGroupConfig
+	err := gr.db.SelectContext(ctx, &items, q)
+	if err != nil {
+		return uiconfigs.GroupConfigBackup{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
+	}
+
+	var groupsConfigs []uiconfigs.GroupConfig
+	for _, i := range items {
+		gc, err := toGroupConfig(i)
+		if err != nil {
+			return uiconfigs.GroupConfigBackup{}, errors.Wrap(dbutil.ErrRetrieveEntity, err)
+		}
+		groupsConfigs = append(groupsConfigs, gc)
+	}
+
+	return uiconfigs.GroupConfigBackup{
+		GroupsConfigs: groupsConfigs,
+	}, nil
+}
+
+type dbGroupConfig struct {
+	GroupID string `db:"group_id"`
+	Config  []byte `db:"config"`
+}
+
+func toDBGroupConfig(g uiconfigs.GroupConfig) (dbGroupConfig, error) {
+	data := []byte("{}")
+	if len(g.Config) > 0 {
+		b, err := json.Marshal(g.Config)
+		if err != nil {
+			return dbGroupConfig{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
+		}
+		data = b
+	}
+
+	return dbGroupConfig{
+		GroupID: g.GroupID,
+		Config:  data,
+	}, nil
+}
+
+func toGroupConfig(dbG dbGroupConfig) (uiconfigs.GroupConfig, error) {
+	var config map[string]any
+	if err := json.Unmarshal([]byte(dbG.Config), &config); err != nil {
+		return uiconfigs.GroupConfig{}, errors.Wrap(dbutil.ErrMalformedEntity, err)
+	}
+
+	return uiconfigs.GroupConfig{
+		GroupID: dbG.GroupID,
+		Config:  config,
+	}, nil
+}

--- a/uiconfigs/postgres/init.go
+++ b/uiconfigs/postgres/init.go
@@ -68,6 +68,18 @@ func migrateDB(db *sqlx.DB) error {
 					`ALTER TABLE thing_configs DROP COLUMN group_id`,
 				},
 			},
+			{
+				Id: "uiconfigs_3",
+				Up: []string{
+					`CREATE TABLE IF NOT EXISTS group_configs (
+                        group_id UUID PRIMARY KEY,
+                        config   JSONB
+					)`,
+				},
+				Down: []string{
+					`DROP TABLE IF EXISTS group_configs`,
+				},
+			},
 		},
 	}
 	_, err := migrate.Exec(db.DB, "postgres", migrations, migrate.Up)

--- a/uiconfigs/postgres/orgs.go
+++ b/uiconfigs/postgres/orgs.go
@@ -128,7 +128,7 @@ func (or orgConfigRepository) RetrieveAll(ctx context.Context, pm apiutil.PageMe
 }
 
 func (or orgConfigRepository) Update(ctx context.Context, o uiconfigs.OrgConfig) (uiconfigs.OrgConfig, error) {
-	q := `UPDATE org_configs 
+	q := `UPDATE org_configs
       	  SET config = :config
           WHERE org_id = :org_id`
 
@@ -157,7 +157,7 @@ func (or orgConfigRepository) Update(ctx context.Context, o uiconfigs.OrgConfig)
 	}
 
 	if cnt == 0 {
-		return or.Save(ctx, o)
+		return uiconfigs.OrgConfig{}, dbutil.ErrNotFound
 	}
 
 	qSelect := `SELECT org_id, config

--- a/uiconfigs/service.go
+++ b/uiconfigs/service.go
@@ -14,8 +14,10 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 )
 
-const DeletedFlagKey = "deleted"
-const RawIDKey = "id"
+const (
+	DeletedFlagKey = "deleted"
+	RawIDKey       = "id"
+)
 
 type Backup struct {
 	OrgsConfigs   []OrgConfig

--- a/uiconfigs/service.go
+++ b/uiconfigs/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
@@ -142,6 +143,9 @@ func (svc *configService) UpdateOrgConfig(ctx context.Context, token string, org
 
 	updated, err := svc.orgConfigs.Update(ctx, orgConfig)
 	if err != nil {
+		if errors.Contains(err, dbutil.ErrNotFound) {
+			return svc.orgConfigs.Save(ctx, orgConfig)
+		}
 		return OrgConfig{}, err
 	}
 
@@ -185,6 +189,9 @@ func (svc *configService) MarkReferencesDeleted(ctx context.Context, orgID strin
 	cfg.Config = Config(marked.(map[string]any))
 
 	_, err = svc.orgConfigs.Update(ctx, cfg)
+	if errors.Contains(err, dbutil.ErrNotFound) {
+		return nil
+	}
 	return err
 }
 

--- a/uiconfigs/service.go
+++ b/uiconfigs/service.go
@@ -34,10 +34,13 @@ type Service interface {
 	// RemoveOrgConfig removes the org config by org id.
 	RemoveOrgConfig(ctx context.Context, orgID string) error
 
-	// RemoveIDsFromConfigs clears references to the given Thing or Group IDs wherever they
-	// appear in the org config: a reference inside an object is blanked to an
-	// empty string in place, while a bare reference in an array is removed from it entirely.
-	RemoveIDsFromConfigs(ctx context.Context, orgID string, ids []string) error
+	// RemoveGroupFromConfigs clears references to the given deleted Group and its Things
+	// wherever they appear in the org config.
+	RemoveGroupFromConfigs(ctx context.Context, orgID, groupID string, thingIDs []string) error
+
+	// RemoveThingsFromConfigs clears references to the given deleted Things wherever they
+	// appear in the org config.
+	RemoveThingsFromConfigs(ctx context.Context, orgID string, thingIDs []string) error
 
 	// BackupOrgsConfigs retrieves all org configs.
 	BackupOrgsConfigs(ctx context.Context, token string) (OrgConfigBackup, error)
@@ -154,7 +157,17 @@ func (svc *configService) RemoveOrgConfig(ctx context.Context, orgID string) err
 	return svc.orgConfigs.Remove(ctx, orgID)
 }
 
-func (svc *configService) RemoveIDsFromConfigs(ctx context.Context, orgID string, ids []string) error {
+func (svc *configService) RemoveGroupFromConfigs(ctx context.Context, orgID, groupID string, thingIDs []string) error {
+	return svc.removeIDsFromOrgConfig(ctx, orgID, append([]string{groupID}, thingIDs...))
+}
+
+func (svc *configService) RemoveThingsFromConfigs(ctx context.Context, orgID string, thingIDs []string) error {
+	return svc.removeIDsFromOrgConfig(ctx, orgID, thingIDs)
+}
+
+// removeIDsFromOrgConfig loads the org's config, clears any reference to the given IDs from
+// it via removeIDsFromValue, and persists the result if anything actually changed.
+func (svc *configService) removeIDsFromOrgConfig(ctx context.Context, orgID string, ids []string) error {
 	if orgID == "" {
 		return nil
 	}
@@ -180,7 +193,7 @@ func (svc *configService) RemoveIDsFromConfigs(ctx context.Context, orgID string
 		return nil
 	}
 
-	marked, changed := removeIDsFromConfigs(map[string]any(cfg.Config), idSet)
+	marked, changed := removeIDsFromValue(map[string]any(cfg.Config), idSet)
 	if !changed {
 		return nil
 	}
@@ -366,13 +379,13 @@ func (svc *configService) isAdmin(ctx context.Context, token string) error {
 	return nil
 }
 
-// removeIDsFromConfigs clears references to the given IDs wherever they appear in v: a
+// removeIDsFromValue clears references to the given IDs wherever they appear in v: a
 // map value matching one of the IDs is replaced in place with an empty string (the
 // surrounding object is still meaningful and kept), while an array element matching one of
 // the IDs is dropped from the array entirely (a bare ID with nothing else attached to it has
 // nothing left worth keeping once removed). The second return value indicates whether
 // anything changed.
-func removeIDsFromConfigs(v any, ids map[string]struct{}) (any, bool) {
+func removeIDsFromValue(v any, ids map[string]struct{}) (any, bool) {
 	switch val := v.(type) {
 	case map[string]any:
 		result := make(map[string]any, len(val))
@@ -387,7 +400,7 @@ func removeIDsFromConfigs(v any, ids map[string]struct{}) (any, bool) {
 				}
 			}
 
-			marked, c := removeIDsFromConfigs(vv, ids)
+			marked, c := removeIDsFromValue(vv, ids)
 			result[k] = marked
 			changed = changed || c
 		}
@@ -404,7 +417,7 @@ func removeIDsFromConfigs(v any, ids map[string]struct{}) (any, bool) {
 				}
 			}
 
-			marked, c := removeIDsFromConfigs(vv, ids)
+			marked, c := removeIDsFromValue(vv, ids)
 			result = append(result, marked)
 			changed = changed || c
 		}

--- a/uiconfigs/service.go
+++ b/uiconfigs/service.go
@@ -34,10 +34,10 @@ type Service interface {
 	// RemoveOrgConfig removes the org config by org id.
 	RemoveOrgConfig(ctx context.Context, orgID string) error
 
-	// MarkReferencesDeleted clears references to the given Thing or Group IDs wherever they
-	// appear in the org's dashboard config: a reference inside an object is blanked to an
+	// RemoveIDsFromConfigs clears references to the given Thing or Group IDs wherever they
+	// appear in the org config: a reference inside an object is blanked to an
 	// empty string in place, while a bare reference in an array is removed from it entirely.
-	MarkReferencesDeleted(ctx context.Context, orgID string, ids []string) error
+	RemoveIDsFromConfigs(ctx context.Context, orgID string, ids []string) error
 
 	// BackupOrgsConfigs retrieves all org configs.
 	BackupOrgsConfigs(ctx context.Context, token string) (OrgConfigBackup, error)
@@ -154,7 +154,7 @@ func (svc *configService) RemoveOrgConfig(ctx context.Context, orgID string) err
 	return svc.orgConfigs.Remove(ctx, orgID)
 }
 
-func (svc *configService) MarkReferencesDeleted(ctx context.Context, orgID string, ids []string) error {
+func (svc *configService) RemoveIDsFromConfigs(ctx context.Context, orgID string, ids []string) error {
 	if orgID == "" {
 		return nil
 	}
@@ -180,7 +180,7 @@ func (svc *configService) MarkReferencesDeleted(ctx context.Context, orgID strin
 		return nil
 	}
 
-	marked, changed := markReferencesDeleted(map[string]any(cfg.Config), idSet)
+	marked, changed := removeIDsFromConfigs(map[string]any(cfg.Config), idSet)
 	if !changed {
 		return nil
 	}
@@ -366,13 +366,13 @@ func (svc *configService) isAdmin(ctx context.Context, token string) error {
 	return nil
 }
 
-// markReferencesDeleted clears references to the given IDs wherever they appear in v: a
+// removeIDsFromConfigs clears references to the given IDs wherever they appear in v: a
 // map value matching one of the IDs is replaced in place with an empty string (the
 // surrounding object is still meaningful and kept), while an array element matching one of
 // the IDs is dropped from the array entirely (a bare ID with nothing else attached to it has
 // nothing left worth keeping once removed). The second return value indicates whether
 // anything changed.
-func markReferencesDeleted(v any, ids map[string]struct{}) (any, bool) {
+func removeIDsFromConfigs(v any, ids map[string]struct{}) (any, bool) {
 	switch val := v.(type) {
 	case map[string]any:
 		result := make(map[string]any, len(val))
@@ -387,7 +387,7 @@ func markReferencesDeleted(v any, ids map[string]struct{}) (any, bool) {
 				}
 			}
 
-			marked, c := markReferencesDeleted(vv, ids)
+			marked, c := removeIDsFromConfigs(vv, ids)
 			result[k] = marked
 			changed = changed || c
 		}
@@ -404,7 +404,7 @@ func markReferencesDeleted(v any, ids map[string]struct{}) (any, bool) {
 				}
 			}
 
-			marked, c := markReferencesDeleted(vv, ids)
+			marked, c := removeIDsFromConfigs(vv, ids)
 			result = append(result, marked)
 			changed = changed || c
 		}

--- a/uiconfigs/service.go
+++ b/uiconfigs/service.go
@@ -14,11 +14,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 )
 
-const (
-	DeletedFlagKey = "deleted"
-	RawIDKey       = "id"
-)
-
 type Backup struct {
 	OrgsConfigs   []OrgConfig
 	ThingsConfigs []ThingConfig
@@ -39,8 +34,8 @@ type Service interface {
 	// RemoveOrgConfig removes the org config by org id.
 	RemoveOrgConfig(ctx context.Context, orgID string) error
 
-	// MarkReferencesDeleted flags references to the given Thing or Group IDs
-	// in the org's dashboard config.
+	// MarkReferencesDeleted replaces references to the given Thing or Group IDs with an
+	// empty string, in place, wherever they appear in the org's dashboard config.
 	MarkReferencesDeleted(ctx context.Context, orgID string, ids []string) error
 
 	// BackupOrgsConfigs retrieves all org configs.
@@ -370,31 +365,27 @@ func (svc *configService) isAdmin(ctx context.Context, token string) error {
 	return nil
 }
 
-// markReferencesDeleted marks objects containing the given IDs as deleted.
-// Legacy IDs directly in arrays are converted to flagged objects.
-// The second return value indicates whether anything changed.
+// markReferencesDeleted replaces any string value matching one of the given IDs - whether
+// it's a value inside a map or an element of an array - with an empty string in place. The
+// second return value indicates whether anything changed.
 func markReferencesDeleted(v any, ids map[string]struct{}) (any, bool) {
 	switch val := v.(type) {
 	case map[string]any:
 		result := make(map[string]any, len(val))
 		changed := false
-		matched := false
 
 		for k, vv := range val {
+			if s, ok := vv.(string); ok {
+				if _, found := ids[s]; found {
+					result[k] = ""
+					changed = true
+					continue
+				}
+			}
+
 			marked, c := markReferencesDeleted(vv, ids)
 			result[k] = marked
 			changed = changed || c
-
-			if s, ok := vv.(string); ok {
-				if _, found := ids[s]; found {
-					matched = true
-				}
-			}
-		}
-
-		if matched {
-			result[DeletedFlagKey] = true
-			changed = true
 		}
 
 		return result, changed
@@ -404,7 +395,7 @@ func markReferencesDeleted(v any, ids map[string]struct{}) (any, bool) {
 		for i, vv := range val {
 			if s, ok := vv.(string); ok {
 				if _, found := ids[s]; found {
-					result[i] = map[string]any{RawIDKey: s, DeletedFlagKey: true}
+					result[i] = ""
 					changed = true
 					continue
 				}

--- a/uiconfigs/service.go
+++ b/uiconfigs/service.go
@@ -13,6 +13,9 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 )
 
+const DeletedFlagKey = "deleted"
+const RawIDKey = "id"
+
 type Backup struct {
 	OrgsConfigs   []OrgConfig
 	ThingsConfigs []ThingConfig
@@ -32,6 +35,10 @@ type Service interface {
 
 	// RemoveOrgConfig removes the org config by org id.
 	RemoveOrgConfig(ctx context.Context, orgID string) error
+
+	// MarkReferencesDeleted flags references to the given Thing or Group IDs
+	// in the org's dashboard config.
+	MarkReferencesDeleted(ctx context.Context, orgID string, ids []string) error
 
 	// BackupOrgsConfigs retrieves all org configs.
 	BackupOrgsConfigs(ctx context.Context, token string) (OrgConfigBackup, error)
@@ -143,6 +150,42 @@ func (svc *configService) UpdateOrgConfig(ctx context.Context, token string, org
 
 func (svc *configService) RemoveOrgConfig(ctx context.Context, orgID string) error {
 	return svc.orgConfigs.Remove(ctx, orgID)
+}
+
+func (svc *configService) MarkReferencesDeleted(ctx context.Context, orgID string, ids []string) error {
+	if orgID == "" {
+		return nil
+	}
+
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		idSet[id] = struct{}{}
+	}
+
+	if len(idSet) == 0 {
+		return nil
+	}
+
+	cfg, err := svc.orgConfigs.RetrieveByOrg(ctx, orgID)
+	if err != nil {
+		return err
+	}
+
+	if len(cfg.Config) == 0 {
+		return nil
+	}
+
+	marked, changed := markReferencesDeleted(map[string]any(cfg.Config), idSet)
+	if !changed {
+		return nil
+	}
+	cfg.Config = Config(marked.(map[string]any))
+
+	_, err = svc.orgConfigs.Update(ctx, cfg)
+	return err
 }
 
 func (svc *configService) BackupOrgsConfigs(ctx context.Context, token string) (OrgConfigBackup, error) {
@@ -316,4 +359,54 @@ func (svc *configService) isAdmin(ctx context.Context, token string) error {
 	}
 
 	return nil
+}
+
+// markReferencesDeleted marks objects containing the given IDs as deleted.
+// Legacy IDs directly in arrays are converted to flagged objects.
+// The second return value indicates whether anything changed.
+func markReferencesDeleted(v any, ids map[string]struct{}) (any, bool) {
+	switch val := v.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(val))
+		changed := false
+		matched := false
+
+		for k, vv := range val {
+			marked, c := markReferencesDeleted(vv, ids)
+			result[k] = marked
+			changed = changed || c
+
+			if s, ok := vv.(string); ok {
+				if _, found := ids[s]; found {
+					matched = true
+				}
+			}
+		}
+
+		if matched {
+			result[DeletedFlagKey] = true
+			changed = true
+		}
+
+		return result, changed
+	case []any:
+		result := make([]any, len(val))
+		changed := false
+		for i, vv := range val {
+			if s, ok := vv.(string); ok {
+				if _, found := ids[s]; found {
+					result[i] = map[string]any{RawIDKey: s, DeletedFlagKey: true}
+					changed = true
+					continue
+				}
+			}
+
+			marked, c := markReferencesDeleted(vv, ids)
+			result[i] = marked
+			changed = changed || c
+		}
+		return result, changed
+	default:
+		return val, false
+	}
 }

--- a/uiconfigs/service.go
+++ b/uiconfigs/service.go
@@ -34,8 +34,9 @@ type Service interface {
 	// RemoveOrgConfig removes the org config by org id.
 	RemoveOrgConfig(ctx context.Context, orgID string) error
 
-	// MarkReferencesDeleted replaces references to the given Thing or Group IDs with an
-	// empty string, in place, wherever they appear in the org's dashboard config.
+	// MarkReferencesDeleted clears references to the given Thing or Group IDs wherever they
+	// appear in the org's dashboard config: a reference inside an object is blanked to an
+	// empty string in place, while a bare reference in an array is removed from it entirely.
 	MarkReferencesDeleted(ctx context.Context, orgID string, ids []string) error
 
 	// BackupOrgsConfigs retrieves all org configs.
@@ -365,9 +366,12 @@ func (svc *configService) isAdmin(ctx context.Context, token string) error {
 	return nil
 }
 
-// markReferencesDeleted replaces any string value matching one of the given IDs - whether
-// it's a value inside a map or an element of an array - with an empty string in place. The
-// second return value indicates whether anything changed.
+// markReferencesDeleted clears references to the given IDs wherever they appear in v: a
+// map value matching one of the IDs is replaced in place with an empty string (the
+// surrounding object is still meaningful and kept), while an array element matching one of
+// the IDs is dropped from the array entirely (a bare ID with nothing else attached to it has
+// nothing left worth keeping once removed). The second return value indicates whether
+// anything changed.
 func markReferencesDeleted(v any, ids map[string]struct{}) (any, bool) {
 	switch val := v.(type) {
 	case map[string]any:
@@ -390,19 +394,18 @@ func markReferencesDeleted(v any, ids map[string]struct{}) (any, bool) {
 
 		return result, changed
 	case []any:
-		result := make([]any, len(val))
+		result := make([]any, 0, len(val))
 		changed := false
-		for i, vv := range val {
+		for _, vv := range val {
 			if s, ok := vv.(string); ok {
 				if _, found := ids[s]; found {
-					result[i] = ""
 					changed = true
 					continue
 				}
 			}
 
 			marked, c := markReferencesDeleted(vv, ids)
-			result[i] = marked
+			result = append(result, marked)
 			changed = changed || c
 		}
 		return result, changed

--- a/uiconfigs/service.go
+++ b/uiconfigs/service.go
@@ -16,6 +16,7 @@ import (
 type Backup struct {
 	OrgsConfigs   []OrgConfig
 	ThingsConfigs []ThingConfig
+	GroupsConfigs []GroupConfig
 }
 
 // Service specifies an API that must be fullfiled by the domain service
@@ -54,16 +55,32 @@ type Service interface {
 	// BackupThingsConfigs retrieves all thing configs.
 	BackupThingsConfigs(ctx context.Context, token string) (ThingConfigBackup, error)
 
-	// Backup retrieves all org and thing configs.
+	// ViewGroupConfig retrieves the group config for the authenticated user and group.
+	ViewGroupConfig(ctx context.Context, token, groupID string) (GroupConfig, error)
+
+	// ListGroupsConfigs retrieves all group configs.
+	ListGroupsConfigs(ctx context.Context, token string, pm apiutil.PageMetadata) (GroupConfigPage, error)
+
+	// UpdateGroupConfig updates an existing group config for the authenticated user.
+	UpdateGroupConfig(ctx context.Context, token string, groupConfig GroupConfig) (GroupConfig, error)
+
+	// RemoveGroupConfig removes the group config by group id.
+	RemoveGroupConfig(ctx context.Context, groupID string) error
+
+	// BackupGroupsConfigs retrieves all group configs.
+	BackupGroupsConfigs(ctx context.Context, token string) (GroupConfigBackup, error)
+
+	// Backup retrieves all org, thing and group configs.
 	Backup(ctx context.Context, token string) (Backup, error)
 
-	// Restore adds all orgs and things configs from a backup.
+	// Restore adds all orgs, things and groups configs from a backup.
 	Restore(ctx context.Context, token string, backup Backup) error
 }
 
 type configService struct {
 	orgConfigs   OrgConfigRepository
 	thingConfigs ThingConfigRepository
+	groupConfigs GroupConfigRepository
 	things       domain.ThingsClient
 	auth         domain.AuthClient
 	idProvider   uuid.IDProvider
@@ -72,10 +89,11 @@ type configService struct {
 
 var _ Service = (*configService)(nil)
 
-func New(orgConfigs OrgConfigRepository, thingConfigs ThingConfigRepository, things domain.ThingsClient, auth domain.AuthClient, idp uuid.IDProvider, logger logger.Logger) Service {
+func New(orgConfigs OrgConfigRepository, thingConfigs ThingConfigRepository, groupConfigs GroupConfigRepository, things domain.ThingsClient, auth domain.AuthClient, idp uuid.IDProvider, logger logger.Logger) Service {
 	return &configService{
 		orgConfigs:   orgConfigs,
 		thingConfigs: thingConfigs,
+		groupConfigs: groupConfigs,
 		things:       things,
 		auth:         auth,
 		idProvider:   idp,
@@ -269,6 +287,94 @@ func (svc *configService) BackupThingsConfigs(ctx context.Context, token string)
 	}, nil
 }
 
+func (svc *configService) ViewGroupConfig(ctx context.Context, token, groupID string) (GroupConfig, error) {
+	_, err := svc.auth.Identify(ctx, token)
+	if err != nil {
+		return GroupConfig{}, err
+	}
+
+	if err := svc.things.CanUserAccessGroup(ctx, domain.UserAccessReq{Token: token, ID: groupID, Action: domain.GroupViewer}); err != nil {
+		return GroupConfig{}, errors.Wrap(errors.ErrAuthorization, err)
+	}
+
+	return svc.groupConfigs.RetrieveByGroup(ctx, groupID)
+}
+
+func (svc *configService) ListGroupsConfigs(ctx context.Context, token string, pm apiutil.PageMetadata) (GroupConfigPage, error) {
+	if err := svc.isAdmin(ctx, token); err == nil {
+		return svc.groupConfigs.RetrieveAll(ctx, pm)
+	}
+
+	if _, err := svc.auth.Identify(ctx, token); err != nil {
+		return GroupConfigPage{}, err
+	}
+
+	all, err := svc.groupConfigs.RetrieveAll(ctx, pm)
+	if err != nil {
+		return GroupConfigPage{}, err
+	}
+
+	groupsConfigs := make([]GroupConfig, 0, len(all.GroupsConfigs))
+	for _, g := range all.GroupsConfigs {
+		if err := svc.things.CanUserAccessGroup(ctx, domain.UserAccessReq{Token: token, ID: g.GroupID, Action: domain.GroupViewer}); err == nil {
+			groupsConfigs = append(groupsConfigs, g)
+		}
+	}
+
+	return GroupConfigPage{
+		Total:         uint64(len(groupsConfigs)),
+		GroupsConfigs: groupsConfigs,
+	}, nil
+}
+
+func (svc *configService) UpdateGroupConfig(ctx context.Context, token string, groupConfig GroupConfig) (GroupConfig, error) {
+	_, err := svc.auth.Identify(ctx, token)
+	if err != nil {
+		return GroupConfig{}, err
+	}
+
+	if err := svc.things.CanUserAccessGroup(ctx, domain.UserAccessReq{Token: token, ID: groupConfig.GroupID, Action: domain.GroupEditor}); err != nil {
+		return GroupConfig{}, errors.Wrap(errors.ErrAuthorization, err)
+	}
+
+	updated, err := svc.groupConfigs.Update(ctx, groupConfig)
+	if err != nil {
+		return GroupConfig{}, err
+	}
+
+	return updated, nil
+}
+
+func (svc *configService) RemoveGroupConfig(ctx context.Context, groupID string) error {
+	return svc.groupConfigs.Remove(ctx, groupID)
+}
+
+func (svc *configService) BackupGroupsConfigs(ctx context.Context, token string) (GroupConfigBackup, error) {
+	if err := svc.isAdmin(ctx, token); err == nil {
+		return svc.groupConfigs.BackupAll(ctx)
+	}
+
+	if _, err := svc.auth.Identify(ctx, token); err != nil {
+		return GroupConfigBackup{}, err
+	}
+
+	all, err := svc.groupConfigs.BackupAll(ctx)
+	if err != nil {
+		return GroupConfigBackup{}, err
+	}
+
+	groupsConfigs := make([]GroupConfig, 0, len(all.GroupsConfigs))
+	for _, g := range all.GroupsConfigs {
+		if err := svc.things.CanUserAccessGroup(ctx, domain.UserAccessReq{Token: token, ID: g.GroupID, Action: domain.GroupViewer}); err == nil {
+			groupsConfigs = append(groupsConfigs, g)
+		}
+	}
+
+	return GroupConfigBackup{
+		GroupsConfigs: groupsConfigs,
+	}, nil
+}
+
 func (svc *configService) Backup(ctx context.Context, token string) (Backup, error) {
 	orgs, err := svc.BackupOrgsConfigs(ctx, token)
 	if err != nil {
@@ -280,9 +386,15 @@ func (svc *configService) Backup(ctx context.Context, token string) (Backup, err
 		return Backup{}, err
 	}
 
+	groups, err := svc.BackupGroupsConfigs(ctx, token)
+	if err != nil {
+		return Backup{}, err
+	}
+
 	return Backup{
 		OrgsConfigs:   orgs.OrgsConfigs,
 		ThingsConfigs: things.ThingsConfigs,
+		GroupsConfigs: groups.GroupsConfigs,
 	}, nil
 }
 
@@ -295,6 +407,12 @@ func (svc *configService) Restore(ctx context.Context, token string, backup Back
 
 	for _, thingConfig := range backup.ThingsConfigs {
 		if _, err := svc.thingConfigs.Save(ctx, thingConfig); err != nil {
+			return err
+		}
+	}
+
+	for _, groupConfig := range backup.GroupsConfigs {
+		if _, err := svc.groupConfigs.Save(ctx, groupConfig); err != nil {
 			return err
 		}
 	}

--- a/uiconfigs/tracing/groups.go
+++ b/uiconfigs/tracing/groups.go
@@ -1,0 +1,84 @@
+package tracing
+
+import (
+	"context"
+
+	"github.com/MainfluxLabs/mainflux/pkg/apiutil"
+	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
+	"github.com/MainfluxLabs/mainflux/uiconfigs"
+	"github.com/opentracing/opentracing-go"
+)
+
+const (
+	saveGroupConfigs            = "save_group_configs"
+	retrieveGroupConfigsByGroup = "retrieve_group_configs_by_group"
+	retrieveAllGroupConfigs     = "retrieve_all_group_configs"
+	updateGroupConfig           = "update_group_configs"
+	removeGroupConfig           = "remove_group_config"
+	backupAllGroupConfigs       = "backup_all_group_configs"
+)
+
+var (
+	_ uiconfigs.GroupConfigRepository = (*groupConfigRepositoryMiddleware)(nil)
+)
+
+type groupConfigRepositoryMiddleware struct {
+	tracer opentracing.Tracer
+	repo   uiconfigs.GroupConfigRepository
+}
+
+// GroupConfigRepositoryMiddleware tracks request and their latency, and adds spans to context.
+func GroupConfigRepositoryMiddleware(tracer opentracing.Tracer, repo uiconfigs.GroupConfigRepository) uiconfigs.GroupConfigRepository {
+	return groupConfigRepositoryMiddleware{
+		tracer: tracer,
+		repo:   repo,
+	}
+}
+
+func (uirm groupConfigRepositoryMiddleware) Save(ctx context.Context, d uiconfigs.GroupConfig) (uiconfigs.GroupConfig, error) {
+	span := dbutil.CreateSpan(ctx, uirm.tracer, saveGroupConfigs)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return uirm.repo.Save(ctx, d)
+}
+
+func (uirm groupConfigRepositoryMiddleware) RetrieveByGroup(ctx context.Context, groupID string) (uiconfigs.GroupConfig, error) {
+	span := dbutil.CreateSpan(ctx, uirm.tracer, retrieveGroupConfigsByGroup)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return uirm.repo.RetrieveByGroup(ctx, groupID)
+}
+
+func (uirm groupConfigRepositoryMiddleware) RetrieveAll(ctx context.Context, pm apiutil.PageMetadata) (uiconfigs.GroupConfigPage, error) {
+	span := dbutil.CreateSpan(ctx, uirm.tracer, retrieveAllGroupConfigs)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return uirm.repo.RetrieveAll(ctx, pm)
+}
+
+func (uirm groupConfigRepositoryMiddleware) Update(ctx context.Context, d uiconfigs.GroupConfig) (uiconfigs.GroupConfig, error) {
+	span := dbutil.CreateSpan(ctx, uirm.tracer, updateGroupConfig)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return uirm.repo.Update(ctx, d)
+}
+
+func (uirm groupConfigRepositoryMiddleware) Remove(ctx context.Context, groupID string) error {
+	span := dbutil.CreateSpan(ctx, uirm.tracer, removeGroupConfig)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return uirm.repo.Remove(ctx, groupID)
+}
+
+func (uirm groupConfigRepositoryMiddleware) BackupAll(ctx context.Context) (uiconfigs.GroupConfigBackup, error) {
+	span := dbutil.CreateSpan(ctx, uirm.tracer, backupAllGroupConfigs)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return uirm.repo.BackupAll(ctx)
+}


### PR DESCRIPTION
Resolves #1173 

Adds per-group UI configuration support to the `uiconfigs` service, alongside the existing per-org and per-thing configs.

Introduces `GroupConfig` as an JSON blob keyed by `GroupID`, allowing the frontend to persist group-scoped UI state.

The implementation follows the existing patterns consistently across all layers.
