### PR TITLE
MF-1303 - Replace nats.Publisher/nats.PubSub with point-of-use interfaces

### DIFF
--- a/cmd/downlinks/main.go
+++ b/cmd/downlinks/main.go
@@ -272,7 +272,7 @@ func subscribeToThingsES(ctx context.Context, svc downlinks.Service, cfg config,
 	return subscriber.Subscribe(ctx, handler)
 }
 
-func newService(ts domain.ThingsClient, ac domain.AuthClient, pub nats.Publisher, dbTracer opentracing.Tracer, db *sqlx.DB, logger logger.Logger) downlinks.Service {
+func newService(ts domain.ThingsClient, ac domain.AuthClient, pub downlinks.Publisher, dbTracer opentracing.Tracer, db *sqlx.DB, logger logger.Logger) downlinks.Service {
 	database := dbutil.NewDatabase(db)
 	downlinksRepo := postgres.NewDownlinkRepository(database)
 	downlinksRepo = tracing.DownlinkRepositoryMiddleware(dbTracer, downlinksRepo)

--- a/cmd/modbus/main.go
+++ b/cmd/modbus/main.go
@@ -270,7 +270,7 @@ func subscribeToThingsES(ctx context.Context, svc modbus.Service, cfg config, lo
 	return subscriber.Subscribe(ctx, handler)
 }
 
-func newService(ts domain.ThingsClient, pub nats.Publisher, dbTracer opentracing.Tracer, db *sqlx.DB, logger logger.Logger) modbus.Service {
+func newService(ts domain.ThingsClient, pub modbus.Publisher, dbTracer opentracing.Tracer, db *sqlx.DB, logger logger.Logger) modbus.Service {
 	database := dbutil.NewDatabase(db)
 	clientsRepo := postgres.NewClientRepository(database)
 	clientsRepo = tracing.ClientRepositoryMiddleware(dbTracer, clientsRepo)

--- a/cmd/rules/main.go
+++ b/cmd/rules/main.go
@@ -303,7 +303,7 @@ func subscribeToThingsES(ctx context.Context, svc rules.Service, cfg config, log
 	return subscriber.Subscribe(ctx, handler)
 }
 
-func newService(dbTracer opentracing.Tracer, db *sqlx.DB, tc domain.ThingsClient, rc domain.ReadersClient, nps nats.Publisher, logger logger.Logger, scriptsEnabled bool) rules.Service {
+func newService(dbTracer opentracing.Tracer, db *sqlx.DB, tc domain.ThingsClient, rc domain.ReadersClient, nps rules.Publisher, logger logger.Logger, scriptsEnabled bool) rules.Service {
 	database := dbutil.NewDatabase(db)
 
 	rulesRepo := postgres.NewRuleRepository(database)

--- a/cmd/ws/main.go
+++ b/cmd/ws/main.go
@@ -134,7 +134,7 @@ func loadConfig() config {
 	}
 }
 
-func newService(tc domain.ThingsClient, nps nats.PubSub, logger logger.Logger) adapter.Service {
+func newService(tc domain.ThingsClient, nps adapter.PubSub, logger logger.Logger) adapter.Service {
 	svc := adapter.New(tc, nps)
 	svc = api.LoggingMiddleware(svc, logger)
 	svc = api.MetricsMiddleware(

--- a/coap/adapter.go
+++ b/coap/adapter.go
@@ -72,7 +72,7 @@ func (svc *adapterService) Publish(ctx context.Context, key domain.ThingKey, msg
 		return err
 	}
 
-	return svc.pubsub.PublishByFlags(msg, pc.ProfileConfig)
+	return svc.pubsub.Dispatch(msg, pc.ProfileConfig)
 }
 
 func (svc *adapterService) Subscribe(ctx context.Context, key domain.ThingKey, subtopic string, c Client) error {

--- a/coap/adapter.go
+++ b/coap/adapter.go
@@ -36,16 +36,23 @@ type Service interface {
 	SendCommandToGroup(ctx context.Context, key domain.ThingKey, groupID string, cmd protomfx.Command) error
 }
 
+// PubSub specifies the minimal publish/subscribe capability the CoAP adapter needs.
+type PubSub interface {
+	messaging.CommandPublisher
+	messaging.MessageDispatcher
+	messaging.Subscriber
+}
+
 var _ Service = (*adapterService)(nil)
 
 type adapterService struct {
 	things  domain.ThingsClient
-	pubsub  nats.PubSub
+	pubsub  PubSub
 	obsLock sync.Mutex
 }
 
 // New instantiates the CoAP adapter implementation.
-func New(things domain.ThingsClient, pubsub nats.PubSub) Service {
+func New(things domain.ThingsClient, pubsub PubSub) Service {
 	as := &adapterService{
 		things:  things,
 		pubsub:  pubsub,

--- a/converters/service.go
+++ b/converters/service.go
@@ -488,5 +488,5 @@ func (as *adapterService) publish(ctx context.Context, key string, msg protomfx.
 		return err
 	}
 
-	return as.publisher.PublishByFlags(msg, pc.ProfileConfig)
+	return as.publisher.Dispatch(msg, pc.ProfileConfig)
 }

--- a/converters/service.go
+++ b/converters/service.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
-	"github.com/MainfluxLabs/mainflux/pkg/messaging/nats"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	jsontransformer "github.com/MainfluxLabs/mainflux/pkg/transformers/json"
 )
@@ -43,15 +42,20 @@ type Service interface {
 	PublishJSONMessagesFromJSON(ctx context.Context, key string, records []map[string]any) error
 }
 
+// Publisher specifies the minimal publishing capability the converters service needs.
+type Publisher interface {
+	messaging.MessageDispatcher
+}
+
 var _ Service = (*adapterService)(nil)
 
 type adapterService struct {
-	publisher nats.Publisher
+	publisher Publisher
 	things    domain.ThingsClient
 }
 
 // New instantiates the HTTP adapter implementation.
-func New(pub nats.Publisher, things domain.ThingsClient) Service {
+func New(pub Publisher, things domain.ThingsClient) Service {
 	return &adapterService{
 		publisher: pub,
 		things:    things,

--- a/downlinks/service.go
+++ b/downlinks/service.go
@@ -442,7 +442,7 @@ func (ds *downlinksService) publish(config *domain.ProfileConfig, thingID string
 		return err
 	}
 
-	return ds.publisher.PublishByFlags(msg, config)
+	return ds.publisher.Dispatch(msg, config)
 }
 
 func (ds *downlinksService) getLimiter(baseURL string) *rate.Limiter {

--- a/downlinks/service.go
+++ b/downlinks/service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
-	"github.com/MainfluxLabs/mainflux/pkg/messaging/nats"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	"golang.org/x/time/rate"
@@ -81,12 +80,17 @@ type Service interface {
 	Restore(ctx context.Context, token string, downlinks []Downlink) error
 }
 
+// Publisher specifies the minimal publishing capability the downlinks service needs.
+type Publisher interface {
+	messaging.MessageDispatcher
+}
+
 type downlinksService struct {
 	things     domain.ThingsClient
 	auth       domain.AuthClient
 	downlinks  DownlinkRepository
 	idProvider uuid.IDProvider
-	publisher  nats.Publisher
+	publisher  Publisher
 	logger     logger.Logger
 	scheduler  *cron.ScheduleManager
 	limiters   map[string]*rate.Limiter
@@ -113,7 +117,7 @@ var (
 
 var _ Service = (*downlinksService)(nil)
 
-func New(things domain.ThingsClient, auth domain.AuthClient, pub nats.Publisher, downlinks DownlinkRepository, idp uuid.IDProvider, logger logger.Logger) Service {
+func New(things domain.ThingsClient, auth domain.AuthClient, pub Publisher, downlinks DownlinkRepository, idp uuid.IDProvider, logger logger.Logger) Service {
 	return &downlinksService{
 		things:     things,
 		auth:       auth,

--- a/http/adapter.go
+++ b/http/adapter.go
@@ -59,7 +59,7 @@ func (as *adapterService) Publish(ctx context.Context, key domain.ThingKey, msg 
 		return err
 	}
 
-	return as.publisher.PublishByFlags(msg, pc.ProfileConfig)
+	return as.publisher.Dispatch(msg, pc.ProfileConfig)
 }
 
 func (as *adapterService) SendCommandToThing(ctx context.Context, token, thingID string, cmd protomfx.Command) error {

--- a/http/adapter.go
+++ b/http/adapter.go
@@ -28,15 +28,21 @@ type Service interface {
 	SendCommandToGroupByKey(ctx context.Context, key domain.ThingKey, groupID string, cmd protomfx.Command) error
 }
 
+// Publisher specifies the minimal publishing capability the HTTP adapter needs.
+type Publisher interface {
+	messaging.CommandPublisher
+	messaging.MessageDispatcher
+}
+
 var _ Service = (*adapterService)(nil)
 
 type adapterService struct {
-	publisher nats.Publisher
+	publisher Publisher
 	things    domain.ThingsClient
 }
 
 // New instantiates the HTTP adapter implementation.
-func New(publisher nats.Publisher, things domain.ThingsClient) Service {
+func New(publisher Publisher, things domain.ThingsClient) Service {
 	return &adapterService{
 		publisher: publisher,
 		things:    things,

--- a/modbus/service.go
+++ b/modbus/service.go
@@ -16,7 +16,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
-	"github.com/MainfluxLabs/mainflux/pkg/messaging/nats"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 	gbmodbus "github.com/goburrow/modbus"
@@ -78,11 +77,16 @@ type Service interface {
 	LoadAndScheduleTasks(ctx context.Context) error
 }
 
+// Publisher specifies the minimal publishing capability the modbus service needs.
+type Publisher interface {
+	messaging.MessageDispatcher
+}
+
 type clientsService struct {
 	things     domain.ThingsClient
 	clients    ClientRepository
 	idProvider uuid.IDProvider
-	publisher  nats.Publisher
+	publisher  Publisher
 	logger     logger.Logger
 	scheduler  *cron.ScheduleManager
 	limiters   map[string]*rate.Limiter
@@ -117,7 +121,7 @@ type Block struct {
 	Length uint16
 }
 
-func New(things domain.ThingsClient, pub nats.Publisher, clients ClientRepository, idp uuid.IDProvider, logger logger.Logger) Service {
+func New(things domain.ThingsClient, pub Publisher, clients ClientRepository, idp uuid.IDProvider, logger logger.Logger) Service {
 	return &clientsService{
 		things:     things,
 		publisher:  pub,

--- a/modbus/service.go
+++ b/modbus/service.go
@@ -723,7 +723,7 @@ func (cs *clientsService) publish(config *domain.ProfileConfig, thingID string, 
 		return err
 	}
 
-	return cs.publisher.PublishByFlags(msg, pc.ProfileConfig)
+	return cs.publisher.Dispatch(msg, pc.ProfileConfig)
 }
 
 func (cs *clientsService) getLimiter(key string) *rate.Limiter {

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -253,7 +253,7 @@ func (h *handler) publishToBus(c *session.Client, topic string, payload []byte) 
 		return nil
 	}
 
-	return h.publisher.PublishByFlags(msg, pc.ProfileConfig)
+	return h.publisher.Dispatch(msg, pc.ProfileConfig)
 }
 
 func (h *handler) publishCommand(subject string, msg protomfx.Message) error {

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -47,9 +47,15 @@ var (
 	errFailedCacheDisconnection = errors.New("failed to remove connection from cache")
 )
 
+// Publisher specifies the minimal publishing capability the MQTT handler needs.
+type Publisher interface {
+	messaging.CommandPublisher
+	messaging.MessageDispatcher
+}
+
 // handler implements session.Handler interface
 type handler struct {
-	publisher nats.Publisher
+	publisher Publisher
 	things    domain.ThingsClient
 	service   Service
 	cache     cache.ConnectionCache
@@ -57,7 +63,7 @@ type handler struct {
 }
 
 // NewHandler creates new Handler entity
-func NewHandler(publisher nats.Publisher, things domain.ThingsClient,
+func NewHandler(publisher Publisher, things domain.ThingsClient,
 	svc Service, cache cache.ConnectionCache, logger logger.Logger) session.Handler {
 	return &handler{
 		publisher: publisher,

--- a/pkg/messaging/nats/publisher.go
+++ b/pkg/messaging/nats/publisher.go
@@ -99,8 +99,8 @@ func createSubject(entity, id, suffix, subtopic string) string {
 	return subject
 }
 
-// PublishByFlags publishes msg to every subject enabled by pc's dispatcher flags.
-func (pub *publisher) PublishByFlags(msg protomfx.Message, pc *domain.ProfileConfig) error {
+// Dispatch publishes msg to every subject enabled by pc's dispatcher flags.
+func (pub *publisher) Dispatch(msg protomfx.Message, pc *domain.ProfileConfig) error {
 	if pc == nil {
 		return nil
 	}

--- a/pkg/messaging/nats/publisher.go
+++ b/pkg/messaging/nats/publisher.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
-	"github.com/MainfluxLabs/mainflux/pkg/messaging"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/gogo/protobuf/proto"
 	broker "github.com/nats-io/nats.go"
@@ -25,27 +24,13 @@ const (
 	commandsSuffix = "commands"
 )
 
-// Publisher extends the base messaging.Publisher with alarm, command, notification and webhook publishing capabilities.
-type Publisher interface {
-	messaging.Publisher
-	messaging.AlarmPublisher
-	messaging.CommandPublisher
-	messaging.NotificationPublisher
-	messaging.WebhookPublisher
-
-	// PublishByFlags publishes msg to every subject enabled by the dispatcher flags in pc.
-	PublishByFlags(msg protomfx.Message, pc *domain.ProfileConfig) error
-}
-
-var _ Publisher = (*publisher)(nil)
-
 type publisher struct {
 	conn *broker.Conn
 	js   broker.JetStreamContext
 }
 
 // NewPublisher returns NATS message Publisher.
-func NewPublisher(url string) (Publisher, error) {
+func NewPublisher(url string) (*publisher, error) {
 	conn, js, err := connect(url)
 	if err != nil {
 		return nil, err
@@ -121,12 +106,12 @@ func (pub *publisher) PublishByFlags(msg protomfx.Message, pc *domain.ProfileCon
 	}
 
 	if pc.WriteEnabled {
-		if err := pub.Publish(GetMessagesSubject(msg.Publisher, msg.Subtopic), msg); err != nil {
+		if err := pub.publish(GetMessagesSubject(msg.Publisher, msg.Subtopic), &msg); err != nil {
 			return err
 		}
 	}
 	if pc.RuleEnabled {
-		if err := pub.Publish(SubjectRules, msg); err != nil {
+		if err := pub.publish(SubjectRules, &msg); err != nil {
 			return err
 		}
 	}

--- a/pkg/messaging/nats/pubsub.go
+++ b/pkg/messaging/nats/pubsub.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	log "github.com/MainfluxLabs/mainflux/logger"
-	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	broker "github.com/nats-io/nats.go"
@@ -45,24 +44,6 @@ const (
 	SubjectRules = "rules"
 )
 
-// PubSub extends messaging.PubSub with alarm/command/notification/webhook publishing and subscribing.
-type PubSub interface {
-	messaging.PubSub
-	messaging.AlarmPublisher
-	messaging.AlarmSubscriber
-	messaging.CommandPublisher
-	messaging.CommandSubscriber
-	messaging.NotificationPublisher
-	messaging.NotificationSubscriber
-	messaging.WebhookPublisher
-	messaging.WebhookSubscriber
-
-	// PublishByFlags publishes msg to every subject enabled by the dispatcher flags in pc.
-	PublishByFlags(msg protomfx.Message, pc *domain.ProfileConfig) error
-}
-
-var _ PubSub = (*pubsub)(nil)
-
 type subscription struct {
 	*broker.Subscription
 	cancel func() error
@@ -83,7 +64,7 @@ type pubsub struct {
 // from ordinary subscribe. For more information, please take a look
 // here: https://docs.nats.io/developing-with-nats/receiving/queues.
 // If the queue is empty, Subscribe will be used.
-func NewPubSub(url, queue string, logger log.Logger) (PubSub, error) {
+func NewPubSub(url, queue string, logger log.Logger) (*pubsub, error) {
 	conn, js, err := connect(url)
 	if err != nil {
 		return nil, err

--- a/pkg/messaging/pubsub.go
+++ b/pkg/messaging/pubsub.go
@@ -97,8 +97,8 @@ type PubSub interface {
 
 // MessageDispatcher routes a message to every subject enabled by a profile's dispatcher flags.
 type MessageDispatcher interface {
-	// PublishByFlags publishes msg to every subject enabled by the dispatcher flags in pc.
-	PublishByFlags(msg protomfx.Message, pc *domain.ProfileConfig) error
+	// Dispatch publishes msg to every subject enabled by the dispatcher flags in pc.
+	Dispatch(msg protomfx.Message, pc *domain.ProfileConfig) error
 }
 
 // AlarmPublisher specifies the alarm publishing API.

--- a/pkg/messaging/pubsub.go
+++ b/pkg/messaging/pubsub.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 )
 
@@ -94,16 +95,16 @@ type PubSub interface {
 	Subscriber
 }
 
+// MessageDispatcher routes a message to every subject enabled by a profile's dispatcher flags.
+type MessageDispatcher interface {
+	// PublishByFlags publishes msg to every subject enabled by the dispatcher flags in pc.
+	PublishByFlags(msg protomfx.Message, pc *domain.ProfileConfig) error
+}
+
 // AlarmPublisher specifies the alarm publishing API.
 type AlarmPublisher interface {
 	// PublishAlarm publishes an alarm to the message broker.
 	PublishAlarm(subject string, alarm protomfx.Alarm) error
-}
-
-// CommandPublisher specifies the command publishing API.
-type CommandPublisher interface {
-	// PublishCommand publishes a command to the message broker.
-	PublishCommand(subject string, cmd protomfx.Command) error
 }
 
 // AlarmHandler represents protomfx.Alarm handler for AlarmSubscriber.
@@ -122,6 +123,12 @@ type AlarmSubscriber interface {
 
 	// UnsubscribeAlarms unsubscribes from the alarm stream.
 	UnsubscribeAlarms(id string) error
+}
+
+// CommandPublisher specifies the command publishing API.
+type CommandPublisher interface {
+	// PublishCommand publishes a command to the message broker.
+	PublishCommand(subject string, cmd protomfx.Command) error
 }
 
 // CommandHandler represents protomfx.Command handler for CommandSubscriber.

--- a/pkg/mocks/publisher.go
+++ b/pkg/mocks/publisher.go
@@ -5,41 +5,28 @@ package mocks
 
 import (
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
-	"github.com/MainfluxLabs/mainflux/pkg/messaging/nats"
+	"github.com/MainfluxLabs/mainflux/pkg/messaging"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 )
+
+// Publisher covers the methods this mock's callers (http/mqtt/modbus/downlinks,
+// pkg/sdk tests) use.
+type Publisher interface {
+	messaging.CommandPublisher
+	messaging.MessageDispatcher
+}
 
 type mockPublisher struct{}
 
 // NewPublisher returns mock message publisher.
-func NewPublisher() nats.Publisher {
+func NewPublisher() Publisher {
 	return mockPublisher{}
-}
-
-func (pub mockPublisher) Publish(_ string, msg protomfx.Message) error {
-	return nil
-}
-
-func (pub mockPublisher) PublishAlarm(_ string, alarm protomfx.Alarm) error {
-	return nil
 }
 
 func (pub mockPublisher) PublishCommand(_ string, cmd protomfx.Command) error {
 	return nil
 }
 
-func (pub mockPublisher) PublishNotification(_ string, notification protomfx.Notification) error {
-	return nil
-}
-
-func (pub mockPublisher) PublishWebhook(_ string, webhook protomfx.Webhook) error {
-	return nil
-}
-
 func (pub mockPublisher) PublishByFlags(_ protomfx.Message, _ *domain.ProfileConfig) error {
-	return nil
-}
-
-func (pub mockPublisher) Close() error {
 	return nil
 }

--- a/pkg/mocks/publisher.go
+++ b/pkg/mocks/publisher.go
@@ -27,6 +27,6 @@ func (pub mockPublisher) PublishCommand(_ string, cmd protomfx.Command) error {
 	return nil
 }
 
-func (pub mockPublisher) PublishByFlags(_ protomfx.Message, _ *domain.ProfileConfig) error {
+func (pub mockPublisher) Dispatch(_ protomfx.Message, _ *domain.ProfileConfig) error {
 	return nil
 }

--- a/rules/mocks/pub.go
+++ b/rules/mocks/pub.go
@@ -4,43 +4,28 @@
 package mocks
 
 import (
-	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
-	"github.com/MainfluxLabs/mainflux/pkg/messaging/nats"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
+	"github.com/MainfluxLabs/mainflux/rules"
 )
 
-var _ nats.Publisher = (*mockPublisher)(nil)
+var _ rules.Publisher = (*mockPublisher)(nil)
 
 type mockPublisher struct {
 	fail bool
 }
 
 // NewPublisher returns a mock Publisher that succeeds by default.
-func NewPublisher() nats.Publisher {
+func NewPublisher() rules.Publisher {
 	return &mockPublisher{}
 }
 
 // NewFailingPublisher returns a mock Publisher whose Publish always fails.
-func NewFailingPublisher() nats.Publisher {
+func NewFailingPublisher() rules.Publisher {
 	return &mockPublisher{fail: true}
 }
 
-func (ps *mockPublisher) Publish(string, protomfx.Message) error {
-	if ps.fail {
-		return messaging.ErrPublishMessage
-	}
-	return nil
-}
-
 func (ps *mockPublisher) PublishAlarm(string, protomfx.Alarm) error {
-	if ps.fail {
-		return messaging.ErrPublishMessage
-	}
-	return nil
-}
-
-func (ps *mockPublisher) PublishCommand(string, protomfx.Command) error {
 	if ps.fail {
 		return messaging.ErrPublishMessage
 	}
@@ -58,16 +43,5 @@ func (ps *mockPublisher) PublishWebhook(string, protomfx.Webhook) error {
 	if ps.fail {
 		return messaging.ErrPublishMessage
 	}
-	return nil
-}
-
-func (ps *mockPublisher) PublishByFlags(protomfx.Message, *domain.ProfileConfig) error {
-	if ps.fail {
-		return messaging.ErrPublishMessage
-	}
-	return nil
-}
-
-func (ps *mockPublisher) Close() error {
 	return nil
 }

--- a/rules/service.go
+++ b/rules/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
-	"github.com/MainfluxLabs/mainflux/pkg/messaging/nats"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
 )
@@ -131,11 +130,18 @@ const (
 	subjectWebhooks = "webhooks"
 )
 
+// Publisher specifies the minimal publishing capability the rules service needs.
+type Publisher interface {
+	messaging.AlarmPublisher
+	messaging.NotificationPublisher
+	messaging.WebhookPublisher
+}
+
 type rulesService struct {
 	rules          Repository
 	things         domain.ThingsClient
 	readers        domain.ReadersClient
-	pub            nats.Publisher
+	pub            Publisher
 	idProvider     uuid.IDProvider
 	logger         logger.Logger
 	scriptsEnabled bool
@@ -144,7 +150,7 @@ type rulesService struct {
 var _ Service = (*rulesService)(nil)
 
 // New instantiates the rules service implementation.
-func New(rules Repository, things domain.ThingsClient, readers domain.ReadersClient, pub nats.Publisher, idp uuid.IDProvider, logger logger.Logger, scriptsEnabled bool) Service {
+func New(rules Repository, things domain.ThingsClient, readers domain.ReadersClient, pub Publisher, idp uuid.IDProvider, logger logger.Logger, scriptsEnabled bool) Service {
 	return &rulesService{
 		rules:          rules,
 		things:         things,

--- a/rules/service_test.go
+++ b/rules/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/MainfluxLabs/mainflux/logger"
 	"github.com/MainfluxLabs/mainflux/pkg/dbutil"
 	"github.com/MainfluxLabs/mainflux/pkg/errors"
-	"github.com/MainfluxLabs/mainflux/pkg/messaging/nats"
 	authmock "github.com/MainfluxLabs/mainflux/pkg/mocks"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
 	"github.com/MainfluxLabs/mainflux/pkg/uuid"
@@ -37,7 +36,7 @@ func newService() rules.Service {
 	return newServiceWithPub(mocks.NewPublisher())
 }
 
-func newServiceWithPub(pub nats.Publisher) rules.Service {
+func newServiceWithPub(pub rules.Publisher) rules.Service {
 	ths := authmock.NewThingsServiceClient(
 		nil,
 		map[string]things.Thing{

--- a/ws/adapter.go
+++ b/ws/adapter.go
@@ -75,7 +75,7 @@ func (svc *adapterService) Publish(ctx context.Context, key domain.ThingKey, msg
 		return err
 	}
 
-	return svc.pubsub.PublishByFlags(msg, pc.ProfileConfig)
+	return svc.pubsub.Dispatch(msg, pc.ProfileConfig)
 }
 
 func (svc *adapterService) Subscribe(ctx context.Context, key domain.ThingKey, subtopic string, c *Client) error {

--- a/ws/adapter.go
+++ b/ws/adapter.go
@@ -39,15 +39,22 @@ type Service interface {
 	SendCommandToGroupByKey(ctx context.Context, key domain.ThingKey, groupID string, cmd protomfx.Command) error
 }
 
+// PubSub specifies the minimal publish/subscribe capability the WS adapter needs.
+type PubSub interface {
+	messaging.CommandPublisher
+	messaging.MessageDispatcher
+	messaging.Subscriber
+}
+
 var _ Service = (*adapterService)(nil)
 
 type adapterService struct {
 	things domain.ThingsClient
-	pubsub nats.PubSub
+	pubsub PubSub
 }
 
 // New instantiates the WS adapter implementation
-func New(things domain.ThingsClient, pubsub nats.PubSub) Service {
+func New(things domain.ThingsClient, pubsub PubSub) Service {
 	return &adapterService{
 		things: things,
 		pubsub: pubsub,

--- a/ws/mocks/pubsub.go
+++ b/ws/mocks/pubsub.go
@@ -47,7 +47,7 @@ func (pubsub *mockPubSub) PublishCommand(string, protomfx.Command) error {
 	return nil
 }
 
-func (pubsub *mockPubSub) PublishByFlags(protomfx.Message, *domain.ProfileConfig) error {
+func (pubsub *mockPubSub) Dispatch(protomfx.Message, *domain.ProfileConfig) error {
 	if pubsub.fail {
 		return messaging.ErrPublishMessage
 	}

--- a/ws/mocks/pubsub.go
+++ b/ws/mocks/pubsub.go
@@ -4,62 +4,26 @@
 package mocks
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/MainfluxLabs/mainflux/pkg/domain"
 	"github.com/MainfluxLabs/mainflux/pkg/messaging"
-	"github.com/MainfluxLabs/mainflux/pkg/messaging/nats"
 	protomfx "github.com/MainfluxLabs/mainflux/pkg/proto"
-	"github.com/gorilla/websocket"
+	"github.com/MainfluxLabs/mainflux/ws"
 )
 
-var _ nats.PubSub = (*mockPubSub)(nil)
+var _ ws.PubSub = (*mockPubSub)(nil)
 
 type MockPubSub interface {
-	Publish(string, protomfx.Message) error
-	Subscribe(string, string, messaging.MessageHandler) error
-	Unsubscribe(string, string) error
-	PublishAlarm(string, protomfx.Alarm) error
-	SubscribeAlarms(string, messaging.AlarmHandler) error
-	UnsubscribeAlarms(string) error
-	PublishCommand(string, protomfx.Command) error
-	SubscribeCommands(string, string, messaging.CommandHandler) error
-	UnsubscribeCommands(string, string) error
-	PublishNotification(string, protomfx.Notification) error
-	SubscribeNotifications(string, string, messaging.NotificationHandler) error
-	UnsubscribeNotifications(string, string) error
-	PublishWebhook(string, protomfx.Webhook) error
-	SubscribeWebhooks(string, messaging.WebhookHandler) error
-	UnsubscribeWebhooks(string) error
-	PublishByFlags(protomfx.Message, *domain.ProfileConfig) error
+	ws.PubSub
 	SetFail(bool)
-	SetConn(*websocket.Conn)
-	Close() error
 }
 
 type mockPubSub struct {
 	fail bool
-	conn *websocket.Conn
 }
 
 // NewPubSub returns mock message publisher-subscriber
 func NewPubSub() MockPubSub {
-	return &mockPubSub{false, nil}
-}
-func (pubsub *mockPubSub) Publish(_ string, msg protomfx.Message) error {
-	if pubsub.conn != nil {
-		data, err := json.Marshal(msg)
-		if err != nil {
-			fmt.Println("can't marshall")
-			return messaging.ErrPublishMessage
-		}
-		return pubsub.conn.WriteMessage(websocket.BinaryMessage, data)
-	}
-	if pubsub.fail {
-		return messaging.ErrPublishMessage
-	}
-	return nil
+	return &mockPubSub{false}
 }
 
 func (pubsub *mockPubSub) Subscribe(string, string, messaging.MessageHandler) error {
@@ -76,86 +40,9 @@ func (pubsub *mockPubSub) Unsubscribe(string, string) error {
 	return nil
 }
 
-func (pubsub *mockPubSub) PublishAlarm(string, protomfx.Alarm) error {
-	if pubsub.fail {
-		return messaging.ErrPublishMessage
-	}
-	return nil
-}
-
-func (pubsub *mockPubSub) SubscribeAlarms(string, messaging.AlarmHandler) error {
-	if pubsub.fail {
-		return messaging.ErrFailedSubscribe
-	}
-	return nil
-}
-
-func (pubsub *mockPubSub) UnsubscribeAlarms(string) error {
-	if pubsub.fail {
-		return messaging.ErrFailedUnsubscribe
-	}
-	return nil
-}
-
 func (pubsub *mockPubSub) PublishCommand(string, protomfx.Command) error {
 	if pubsub.fail {
 		return messaging.ErrPublishMessage
-	}
-	return nil
-}
-
-func (pubsub *mockPubSub) SubscribeCommands(string, string, messaging.CommandHandler) error {
-	if pubsub.fail {
-		return messaging.ErrFailedSubscribe
-	}
-	return nil
-}
-
-func (pubsub *mockPubSub) UnsubscribeCommands(string, string) error {
-	if pubsub.fail {
-		return messaging.ErrFailedUnsubscribe
-	}
-	return nil
-}
-
-func (pubsub *mockPubSub) PublishNotification(string, protomfx.Notification) error {
-	if pubsub.fail {
-		return messaging.ErrPublishMessage
-	}
-	return nil
-}
-
-func (pubsub *mockPubSub) SubscribeNotifications(string, string, messaging.NotificationHandler) error {
-	if pubsub.fail {
-		return messaging.ErrFailedSubscribe
-	}
-	return nil
-}
-
-func (pubsub *mockPubSub) UnsubscribeNotifications(string, string) error {
-	if pubsub.fail {
-		return messaging.ErrFailedUnsubscribe
-	}
-	return nil
-}
-
-func (pubsub *mockPubSub) PublishWebhook(string, protomfx.Webhook) error {
-	if pubsub.fail {
-		return messaging.ErrPublishMessage
-	}
-	return nil
-}
-
-func (pubsub *mockPubSub) SubscribeWebhooks(string, messaging.WebhookHandler) error {
-	if pubsub.fail {
-		return messaging.ErrFailedSubscribe
-	}
-	return nil
-}
-
-func (pubsub *mockPubSub) UnsubscribeWebhooks(string) error {
-	if pubsub.fail {
-		return messaging.ErrFailedUnsubscribe
 	}
 	return nil
 }
@@ -169,10 +56,6 @@ func (pubsub *mockPubSub) PublishByFlags(protomfx.Message, *domain.ProfileConfig
 
 func (pubsub *mockPubSub) SetFail(fail bool) {
 	pubsub.fail = fail
-}
-
-func (pubsub *mockPubSub) SetConn(c *websocket.Conn) {
-	pubsub.conn = c
 }
 
 func (pubsub *mockPubSub) Close() error {


### PR DESCRIPTION
Each service now declares the minimal publish interface it actually needs, rather than depending on the full `nats.Publisher/nats.PubSub`. This decouples business logic from the NATS implementation and keeps each contract scoped to what's actually used - smaller, consumer-owned interfaces are easier to reason about and mock than one large shared one.

`downlinks.Publisher`, `modbus.Publisher`, and `converters.Publisher` are currently identical - kept separate since each may need different capabilities as it evolves.

Resolves #1303 